### PR TITLE
chore(ci): upgrade all GitHub Actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,9 +8,9 @@ jobs:
   lint-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v4
       - name: Install dependencies
         run: pip install ".[dev]"
       - name: Lint

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -22,13 +22,13 @@ jobs:
           - image: whisper-ui-worker-cpu
             dockerfile: docker/Dockerfile.worker.cpu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -36,7 +36,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
           tags: |
@@ -46,7 +46,7 @@ jobs:
             type=edge,branch=main
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.dockerfile }}


### PR DESCRIPTION
## Summary

- Upgrade all 7 action references across `ci.yaml` and `docker-publish.yaml` to their latest major versions that use Node.js 24 runtime
- Resolves Node.js 20 deprecation warnings triggered after PR #8 merge (GitHub enforces Node.js 24 on 2026-06-02)

### Version Changes

| Action | Before | After | Workflow |
|--------|--------|-------|----------|
| `actions/checkout` | `v4` | `v6` | both |
| `jdx/mise-action` | `v2` | `v4` | ci.yaml |
| `docker/setup-buildx-action` | `v3` | `v4` | docker-publish.yaml |
| `docker/login-action` | `v3` | `v4` | docker-publish.yaml |
| `docker/metadata-action` | `v5` | `v6` | docker-publish.yaml |
| `docker/build-push-action` | `v5` | `v7` | docker-publish.yaml |

### Breaking Changes Analysis

All breaking changes in the new major versions are irrelevant to this project:
- **checkout v6**: credential storage changed to separate file — no impact (we use defaults)
- **mise-action v4**: Node.js 20 → 24 only — no impact
- **setup-buildx v4**: removed deprecated `config`/`config-inline`/`install` inputs — not used
- **login-action v4**: ESM migration, interface unchanged — no impact
- **metadata-action v6**: ESM migration, improved `#` comment handling — no impact
- **build-push-action v7**: removed deprecated env vars — not used

## Test plan

- [ ] CI workflow (lint-and-test) passes on this PR without Node.js 20 deprecation warnings
- [ ] After merge, Docker Publish workflow passes without deprecation warnings