### PR TITLE
fix(storage): forward-compatible Job deserialization

### DIFF
--- a/src/whisper_ui/storage/database.py
+++ b/src/whisper_ui/storage/database.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import dataclasses
+import logging
 import sqlite3
 from pathlib import Path
 
 from whisper_ui.core.constants import DEFAULT_JOB_LIST_LIMIT, SQLITE_BUSY_TIMEOUT_MS
 from whisper_ui.core.models import Job, JobStatus
 from whisper_ui.storage.migrations import init_db
+
+logger = logging.getLogger(__name__)
 
 _JOB_COLUMNS = [
     "id",
@@ -28,8 +32,15 @@ _JOB_COLUMNS = [
 ]
 
 
+_JOB_FIELD_NAMES = {f.name for f in dataclasses.fields(Job)}
+
+
 def _row_to_job(row: sqlite3.Row) -> Job:
     d = dict(row)
+    unknown = d.keys() - _JOB_FIELD_NAMES
+    if unknown:
+        logger.warning("Job %s: ignoring unknown DB fields (version mismatch?): %s", d.get("id"), unknown)
+        d = {k: v for k, v in d.items() if k in _JOB_FIELD_NAMES}
     d["status"] = JobStatus(d["status"])
     d["enable_diarization"] = bool(d.get("enable_diarization", 1))
     d["convert_to_traditional"] = bool(d.get("convert_to_traditional", 1))

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -50,3 +50,32 @@ def test_list_jobs_with_limit(db: JobDatabase):
         db.insert_job(Job(filename=f"file{i}.mp3", filepath=f"/tmp/file{i}.mp3"))
     jobs = db.list_jobs(limit=2)
     assert len(jobs) == 2
+
+
+def test_row_to_job_ignores_unknown_db_fields(db: JobDatabase):
+    """Simulate a version mismatch where the DB has columns the Job dataclass doesn't know about."""
+    job = Job(filename="test.mp3", filepath="/tmp/test.mp3")
+    db.insert_job(job)
+
+    # Add an unknown column to the jobs table (simulates a newer frontend schema)
+    db._conn.execute("ALTER TABLE jobs ADD COLUMN future_field TEXT DEFAULT 'hello'")
+    db._conn.commit()
+
+    fetched = db.get_job(job.id)
+    assert fetched is not None
+    assert fetched.filename == "test.mp3"
+    assert fetched.status == JobStatus.PENDING
+    assert not hasattr(fetched, "future_field")
+
+
+def test_list_jobs_ignores_unknown_db_fields(db: JobDatabase):
+    """Ensure list_jobs also handles unknown DB columns gracefully."""
+    db.insert_job(Job(filename="a.mp3", filepath="/tmp/a.mp3"))
+    db.insert_job(Job(filename="b.mp3", filepath="/tmp/b.mp3"))
+
+    db._conn.execute("ALTER TABLE jobs ADD COLUMN future_field TEXT DEFAULT 'x'")
+    db._conn.commit()
+
+    jobs = db.list_jobs()
+    assert len(jobs) == 2
+    assert all(j.filename in ("a.mp3", "b.mp3") for j in jobs)


### PR DESCRIPTION
## Summary

- `_row_to_job()` now filters out DB columns not recognized by the `Job` dataclass before constructing the object, preventing `TypeError` crashes when frontend and worker images are at different versions
- Unknown fields are logged as warnings to help diagnose version mismatch issues
- Added unit tests verifying `get_job()` and `list_jobs()` handle unknown DB columns gracefully

## Context

When only the frontend image is rebuilt (e.g. after adding `batch_id`), the worker still runs old code. `SELECT *` returns the new column, but `Job(**d)` rejects unknown kwargs, causing all tasks to stay stuck in `queued`. This fix makes the deserialization forward-compatible: unknown fields are silently dropped (with a warning log), so the worker can still process jobs even when schema and dataclass are out of sync.

## Test plan

- [x] `test_row_to_job_ignores_unknown_db_fields` — verifies `get_job()` with extra DB column
- [x] `test_list_jobs_ignores_unknown_db_fields` — verifies `list_jobs()` with extra DB column
- [x] All 102 existing tests pass
- [x] `ruff check` and `ruff format --check` pass