### PR TITLE
docs: align README and version with v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,14 @@ and Docker deployment (GPU / CPU).
 ## Features
 
 - Upload audio/video files for transcription
+- Batch upload with automatic filtering of unsupported files
 - Speaker diarization with pyannote speaker-diarization-3.1 (optional)
 - Real-time progress tracking via Redis
 - Export to SRT, VTT, TXT, JSON, DOCX
+- Batch download of results as ZIP
 - Docker Compose deployment with GPU and CPU profiles
+
+**Supported formats:** `.mp3`, `.wav`, `.m4a`, `.flac`, `.ogg`, `.wma`, `.aac`, `.opus`, `.mp4`, `.webm`, `.mkv`
 
 ## Architecture
 
@@ -81,7 +85,7 @@ Pre-built Docker images are published to GHCR on each release.
 **Pin a specific version** by setting `WHISPER_UI_VERSION` in your `.env` file:
 
 ```bash
-WHISPER_UI_VERSION=0.1.0
+WHISPER_UI_VERSION=1.2.0
 ```
 
 **Build locally** instead of pulling (optional):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "0.1.0"
+version = "1.2.0"
 description = "Speech-to-text system using OpenAI Whisper with Streamlit UI, speaker diarization, and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

- Bump `pyproject.toml` version from `0.1.0` to `1.2.0` to match the latest git tag
- Add batch upload filtering and batch ZIP download to README Features section
- Add supported file formats list (`.mp3`, `.wav`, `.m4a`, `.flac`, `.ogg`, `.wma`, `.aac`, `.opus`, `.mp4`, `.webm`, `.mkv`)
- Update version pin example from `0.1.0` to `1.2.0`

## Test plan

- [x] All 114 tests pass
- [x] All pre-commit checks pass
- [ ] Verify README renders correctly on GitHub