### PR TITLE
fix: make alignment failure non-fatal with graceful degradation

### DIFF
--- a/src/whisper_ui/core/messages.py
+++ b/src/whisper_ui/core/messages.py
@@ -19,6 +19,7 @@ TRANSCRIBE_DONE = "轉錄完成。"
 ALIGN_LOADING = "正在載入對齊模型..."
 ALIGN_RUNNING = "正在對齊時間戳記..."
 ALIGN_DONE = "對齊完成。"
+ALIGN_SKIPPED = "對齊失敗，使用未對齊的時間戳記。"
 
 DIARIZE_LOADING = "正在載入說話者分離模型..."
 DIARIZE_RUNNING = "正在進行說話者分離..."

--- a/src/whisper_ui/pipeline/align.py
+++ b/src/whisper_ui/pipeline/align.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from whisper_ui.core.device import release_gpu_memory
 from whisper_ui.core.exceptions import AlignmentError
-from whisper_ui.core.messages import ALIGN_DONE, ALIGN_LOADING, ALIGN_RUNNING
+from whisper_ui.core.messages import ALIGN_DONE, ALIGN_LOADING, ALIGN_RUNNING, ALIGN_SKIPPED
 
 if TYPE_CHECKING:
     from whisper_ui.pipeline.base import ProgressCallback
@@ -61,7 +61,15 @@ class AlignStage:
         except ImportError as err:
             raise AlignmentError("whisperx is not installed.") from err
         except Exception as e:
-            raise AlignmentError(f"Alignment failed: {e}") from e
+            logger.warning(
+                "Alignment failed for language '%s', continuing without alignment: %s",
+                context.get("language", "unknown"),
+                e,
+                exc_info=True,
+            )
+            if on_progress:
+                on_progress(1.0, ALIGN_SKIPPED)
+            return context
 
     def cleanup(self) -> None:
         had_resources = self._model is not None or self._metadata is not None

--- a/src/whisper_ui/pipeline/align.py
+++ b/src/whisper_ui/pipeline/align.py
@@ -28,6 +28,7 @@ class AlignStage:
         if on_progress:
             on_progress(0.0, ALIGN_LOADING)
 
+        language = context.get("language", "unknown")
         try:
             import whisperx
 
@@ -63,7 +64,7 @@ class AlignStage:
         except Exception as e:
             logger.warning(
                 "Alignment failed for language '%s', continuing without alignment: %s",
-                context.get("language", "unknown"),
+                language,
                 e,
                 exc_info=True,
             )

--- a/tests/unit/test_pipeline_stages.py
+++ b/tests/unit/test_pipeline_stages.py
@@ -197,6 +197,26 @@ class TestAlignStage:
         assert "ja" in str(call_args)
         assert "model not found" in str(call_args)
 
+    def test_align_execution_failure_skips_without_partial_result(self):
+        stage = AlignStage(device="cpu")
+        mock_whisperx = MagicMock()
+        mock_whisperx.load_align_model.return_value = ("model", "metadata")
+        mock_whisperx.align.side_effect = RuntimeError("alignment crashed")
+        progress_calls = []
+
+        with patch.dict("sys.modules", {"whisperx": mock_whisperx}):
+            context = {
+                "transcription_result": {"segments": [{"text": "hello"}], "language": "ja"},
+                "whisperx_audio": "audio",
+                "language": "ja",
+            }
+            result = stage.execute(context, on_progress=lambda p, m: progress_calls.append((p, m)))
+
+        assert "aligned_result" not in result
+        assert progress_calls[-1] == (1.0, ALIGN_SKIPPED)
+        assert stage._model is not None
+        assert stage._metadata is not None
+
 
 class TestDiarizeStage:
     def test_disabled_skips(self):

--- a/tests/unit/test_pipeline_stages.py
+++ b/tests/unit/test_pipeline_stages.py
@@ -10,6 +10,7 @@ from whisper_ui.core.exceptions import AlignmentError, DiarizationError, Transcr
 from whisper_ui.core.messages import (
     ALIGN_DONE,
     ALIGN_LOADING,
+    ALIGN_SKIPPED,
     ASSIGN_DONE,
     ASSIGN_FAILED,
     ASSIGN_SKIPPED,
@@ -140,6 +141,61 @@ class TestAlignStage:
             pytest.raises(AlignmentError, match="not installed"),
         ):
             stage.execute({"transcription_result": {"segments": []}, "whisperx_audio": "audio"})
+
+    def test_alignment_failure_returns_context_without_aligned_result(self):
+        stage = AlignStage(device="cpu")
+        mock_whisperx = MagicMock()
+        mock_whisperx.load_align_model.side_effect = ValueError("model not found")
+
+        with patch.dict("sys.modules", {"whisperx": mock_whisperx}):
+            context = {
+                "transcription_result": {"segments": [], "language": "ja"},
+                "whisperx_audio": "audio",
+                "language": "ja",
+            }
+            result = stage.execute(context)
+
+        assert "aligned_result" not in result
+
+    def test_alignment_failure_reports_skipped_progress(self):
+        stage = AlignStage(device="cpu")
+        mock_whisperx = MagicMock()
+        mock_whisperx.load_align_model.side_effect = ValueError("model not found")
+        progress_calls = []
+
+        with patch.dict("sys.modules", {"whisperx": mock_whisperx}):
+            stage.execute(
+                {
+                    "transcription_result": {"segments": [], "language": "ja"},
+                    "whisperx_audio": "audio",
+                    "language": "ja",
+                },
+                on_progress=lambda p, m: progress_calls.append((p, m)),
+            )
+
+        assert progress_calls[-1] == (1.0, ALIGN_SKIPPED)
+
+    def test_alignment_failure_logs_warning(self):
+        stage = AlignStage(device="cpu")
+        mock_whisperx = MagicMock()
+        mock_whisperx.load_align_model.side_effect = ValueError("model not found")
+
+        with (
+            patch.dict("sys.modules", {"whisperx": mock_whisperx}),
+            patch("whisper_ui.pipeline.align.logger") as mock_logger,
+        ):
+            stage.execute(
+                {
+                    "transcription_result": {"segments": [], "language": "ja"},
+                    "whisperx_audio": "audio",
+                    "language": "ja",
+                },
+            )
+
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert "ja" in str(call_args)
+        assert "model not found" in str(call_args)
 
 
 class TestDiarizeStage:


### PR DESCRIPTION
## Summary

- 處理日文音檔時，AlignStage 因無法載入 HuggingFace 對齊模型而拋出 AlignmentError，導致整個 pipeline 中斷、使用者無法取得任何轉錄結果
- 下游的 AssignSpeakersStage 和 PostprocessStage 已內建處理 `aligned_result` 缺失的 fallback 邏輯，但 AlignStage 直接拋出例外，未給下游機會處理
- 將 AlignStage 的非關鍵性失敗改為 graceful degradation：記錄完整 traceback（含被 WhisperX 隱藏的真正底層錯誤）並繼續 pipeline，使用者取得轉錄文字 + segment 級時間戳，而非完全失敗
- `ImportError`（whisperx 未安裝）仍為硬性失敗

## Why

WhisperX 的 `load_align_model()` 在模型載入失敗時，用 bare `except Exception` 攔截真正的錯誤並拋出誤導性的 ValueError（說模型 "could not be found"，但模型實際存在於 HuggingFace）。這導致使用者無法理解錯誤原因，也無法取得任何結果。

## How

- 將 `AlignStage.execute()` 的 `except Exception` 從拋出 `AlignmentError` 改為記錄 warning（含 `exc_info=True` 完整 traceback）並回傳 context
- 新增 `ALIGN_SKIPPED` 訊息常數
- 新增 3 個對應測試

## Test plan

- [x] 241 tests passed（`python -m pytest --tb=short -q`）
- [x] pre-commit 全部通過
- [ ] 部署後以日文音檔測試：應產生轉錄結果而非 error
- [ ] 檢查 worker log：應包含 alignment 失敗的完整 traceback