### PR TITLE
refactor: parallelize pipeline via RQ DAG and per-resource worker queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,59 @@ All settings are configured via environment variables (`.env` file):
 > processing times. GPU deployment with `large-v3` and `int8_float16` gives the
 > best accuracy-to-speed ratio.
 
+### Worker topology and queues (advanced)
+
+Each upload is dispatched as an RQ **DAG of sub-jobs** (one per pipeline
+stage) rather than a single monolithic task. Sub-jobs are routed to
+resource-class queues so a long-running IO or network stage never blocks
+a GPU worker from picking up the next job:
+
+| Queue         | Stages                                     |
+| ------------- | ------------------------------------------ |
+| `whisper:gpu` | `transcribe_align`, `diarize`              |
+| `whisper:io`  | `download`, `preprocess`, `llm_correction` |
+| `whisper:cpu` | `assign_speakers`, `postprocess`           |
+
+**Single-container (default).** `docker compose --profile gpu up -d` keeps
+the existing behaviour: `worker-gpu` listens to every queue so one
+container drains the full pipeline end-to-end. You do not need to touch
+any queue variables for this layout.
+
+**Scaled topology.** To stop the GPU worker from picking up IO/LLM work,
+add the `io` profile and narrow the GPU worker's queue set:
+
+```bash
+# .env
+WORKER_GPU_QUEUES="whisper:gpu default"
+WORKER_IO_QUEUES="whisper:io whisper:cpu default"
+
+docker compose --profile gpu --profile io up -d
+```
+
+`worker-io` is a lightweight CPU container that drains `whisper:io`
+(download / preprocess / llm_correction) in parallel with `worker-gpu`
+running transcribe_align / diarize on the GPU. Two jobs enqueued back to
+back overlap: job B can be downloading while job A is on the GPU, and
+job A can be in llm_correction (hitting an external Ollama server) while
+job B is already transcribing.
+
+**Multi-GPU hosts.** When the DAG fans out transcribe_align and diarize
+as sibling branches they will automatically run in parallel once you
+provision more than one GPU worker. Example with two cards:
+
+```bash
+# Launch two GPU workers, each pinned to one card.
+docker compose --profile gpu up -d --scale worker-gpu=2
+# Or run named services and set WORKER_GPU_DEVICE_ID per container.
+```
+
+**Upgrading from the monolithic path.** Any jobs already enqueued under
+the legacy `process_transcription` entry point keep working — the
+default queue set on every worker still includes `default`, and the old
+monolithic function still exists in `whisper_ui.worker.tasks` for
+backwards compatibility. Drain in-flight jobs (or simply wait them out)
+before narrowing `WORKER_*_QUEUES` on a scaled topology.
+
 ### Queue / Timeout tuning (advanced)
 
 The RQ job timeout is derived from the probed audio duration

--- a/compose.yml
+++ b/compose.yml
@@ -57,6 +57,12 @@ services:
       args:
         PIP_INDEX_URL: ${PIP_INDEX_URL:-}
     environment:
+      # Queues this worker listens on. The default includes every queue so a
+      # single-profile `docker compose --profile gpu up` still runs the full
+      # pipeline end-to-end. For the scaled topology, set
+      # `WORKER_GPU_QUEUES=whisper:gpu default` and add the `io` profile so
+      # a dedicated worker-io handles download / preprocess / llm_correction.
+      - WORKER_QUEUES=${WORKER_GPU_QUEUES:-whisper:gpu whisper:io whisper:cpu default}
       - REDIS_URL=redis://:${REDIS_PASSWORD:-}@redis:6379/0
       - DATABASE_PATH=/app/data/db/whisper_ui.db
       - UPLOAD_DIR=/app/data/uploads
@@ -107,6 +113,10 @@ services:
       args:
         PIP_INDEX_URL: ${PIP_INDEX_URL:-}
     environment:
+      # Same broad default as worker-gpu: runs the whole pipeline in a
+      # single container when the CPU profile is used alone. Override with
+      # `WORKER_CPU_QUEUES=whisper:cpu default` to specialise.
+      - WORKER_QUEUES=${WORKER_CPU_QUEUES:-whisper:gpu whisper:io whisper:cpu default}
       - REDIS_URL=redis://:${REDIS_PASSWORD:-}@redis:6379/0
       - DATABASE_PATH=/app/data/db/whisper_ui.db
       - UPLOAD_DIR=/app/data/uploads
@@ -137,6 +147,56 @@ services:
     volumes:
       - app-data:/app/data
       - model-cache:/cache/huggingface
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+  # Optional IO-dedicated worker for multi-worker topologies. Use it when
+  # you want the GPU worker(s) to stay focused on whisper:gpu while a
+  # lightweight CPU container handles download / preprocess / llm_correction.
+  # Enable with: docker compose --profile gpu --profile io up -d
+  # Typically also set WORKER_GPU_QUEUES="whisper:gpu default" so the GPU
+  # worker stops picking up IO/CPU jobs itself.
+  #
+  # The image reuses Dockerfile.worker.cpu: stage_tasks.py imports every
+  # PipelineStage at module load time (RQ needs the symbols addressable
+  # even on workers that never execute them), so a slim Python-only image
+  # would still need torch / whisperx installed. Making the stage imports
+  # lazy is a follow-up; until then the IO worker just runs the CPU image
+  # with its queue narrowed to whisper:io.
+  worker-io:
+    profiles: [io]
+    image: ghcr.io/fdff87554/whisper-ui-worker-cpu:${WHISPER_UI_VERSION:-latest}
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.worker.cpu
+      args:
+        PIP_INDEX_URL: ${PIP_INDEX_URL:-}
+    environment:
+      - WORKER_QUEUES=${WORKER_IO_QUEUES:-whisper:io whisper:cpu default}
+      - REDIS_URL=redis://:${REDIS_PASSWORD:-}@redis:6379/0
+      - DATABASE_PATH=/app/data/db/whisper_ui.db
+      - UPLOAD_DIR=/app/data/uploads
+      - OUTPUT_DIR=/app/data/outputs
+      - DEVICE=cpu
+      - LANGUAGE=${LANGUAGE:-zh}
+      - YOUTUBE_MAX_DURATION=${YOUTUBE_MAX_DURATION:-14400}
+      - JOB_TIMEOUT_DEFAULT=${JOB_TIMEOUT_DEFAULT:-7200}
+      - JOB_TIMEOUT_FLOOR=${JOB_TIMEOUT_FLOOR:-1800}
+      - JOB_TIMEOUT_AUDIO_MULTIPLIER=${JOB_TIMEOUT_AUDIO_MULTIPLIER:-3.0}
+      - JOB_TIMEOUT_MAX=${JOB_TIMEOUT_MAX:-28800}
+      - STALE_JOB_BUFFER=${STALE_JOB_BUFFER:-1800}
+      - REDIS_PROCESSING_EXPIRY=${REDIS_PROCESSING_EXPIRY:-30600}
+      # LLM correction runs here when enabled — no GPU required.
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-}
+      - OLLAMA_MODEL=${OLLAMA_MODEL:-gemma4:e2b}
+      - OLLAMA_KEEP_ALIVE=${OLLAMA_KEEP_ALIVE:-30m}
+      - OLLAMA_REQUEST_TIMEOUT=${OLLAMA_REQUEST_TIMEOUT:-120}
+      - LLM_CHUNK_SIZE=${LLM_CHUNK_SIZE:-8}
+      - LLM_CHUNK_CONTEXT=${LLM_CHUNK_CONTEXT:-2}
+      - LLM_TEMPERATURE=${LLM_TEMPERATURE:-0.1}
+    volumes:
+      - app-data:/app/data
     depends_on:
       redis:
         condition: service_healthy

--- a/docker/entrypoint-worker.sh
+++ b/docker/entrypoint-worker.sh
@@ -17,9 +17,18 @@ echo "Device: ${DEVICE:-auto}, Compute type: ${COMPUTE_TYPE:-int8_float16}"
 MODEL_DIR="${HF_HOME:-/cache/huggingface}"
 echo "Model cache directory: ${MODEL_DIR}"
 
+# Queues to listen on. Defaults to the full set so a single container can
+# still run every pipeline stage, which is the common single-host layout.
+# The multi-worker docker-compose topology overrides this via WORKER_QUEUES
+# to specialise containers per resource class (io / gpu / cpu). "default" is
+# kept at the tail so any in-flight jobs from the legacy monolithic
+# process_transcription path still get picked up after an upgrade.
+WORKER_QUEUES="${WORKER_QUEUES:-whisper:gpu whisper:io whisper:cpu default}"
+
 # Start RQ worker
-echo "Starting RQ worker..."
+echo "Starting RQ worker on queues: ${WORKER_QUEUES}"
+# shellcheck disable=SC2086
 exec python -m rq.cli worker \
 	--url "${REDIS_URL:-redis://redis:6379/0}" \
 	--name "whisper-worker-$(hostname)" \
-	default
+	${WORKER_QUEUES}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,11 @@ dev = [
   "pytest>=9.0,<10",
   "pytest-cov>=7.0,<8",
   # In-process Redis stand-in for the end-to-end integration test. Avoids
-  # spinning up a real Redis or a Docker testcontainer in CI.
-  "fakeredis>=2.30,<3",
+  # spinning up a real Redis or a Docker testcontainer in CI. The ``lua``
+  # extra pulls in ``lupa`` so the RedisProgressReporter's EVAL-based
+  # atomic max-write script (see whisper_ui/worker/progress.py) can be
+  # exercised under fakeredis without a real Redis server.
+  "fakeredis[lua]>=2.30,<3",
 ]
 
 [build-system]

--- a/src/whisper_ui/core/constants.py
+++ b/src/whisper_ui/core/constants.py
@@ -49,3 +49,16 @@ YT_DLP_SOCKET_TIMEOUT = 30
 # REDIS_PROCESSING_EXPIRY now lives in Settings.redis_processing_expiry.
 REDIS_COMPLETED_EXPIRY = 86400  # 24 hours
 REDIS_FAILED_EXPIRY = 86400  # 24 hours
+
+# Worker queues. Stages are partitioned across these queues by the resource
+# they consume so a long-running IO or network stage (download, llm_correction)
+# never blocks a GPU worker from picking up the next job.
+#   whisper:io  -> network / disk IO (download, preprocess, llm_correction)
+#   whisper:gpu -> GPU inference (transcribe_align, diarize)
+#   whisper:cpu -> lightweight CPU finalisation (assign_speakers, postprocess)
+# The default queue is kept for backwards-compatibility with in-flight jobs
+# enqueued by the legacy process_transcription path before the upgrade.
+WORKER_QUEUE_IO = "whisper:io"
+WORKER_QUEUE_GPU = "whisper:gpu"
+WORKER_QUEUE_CPU = "whisper:cpu"
+WORKER_QUEUE_DEFAULT = "default"

--- a/src/whisper_ui/pipeline/orchestrator.py
+++ b/src/whisper_ui/pipeline/orchestrator.py
@@ -6,6 +6,12 @@ from typing import TYPE_CHECKING, Any
 from rq.timeouts import BaseTimeoutException
 
 from whisper_ui.core.exceptions import PipelineError
+from whisper_ui.pipeline.progress_bands import (
+    STAGE_WEIGHTS,
+    STAGE_WEIGHTS_WITH_DOWNLOAD,
+    STAGE_WEIGHTS_WITH_DOWNLOAD_AND_LLM,
+    STAGE_WEIGHTS_WITH_LLM,
+)
 
 if TYPE_CHECKING:
     from whisper_ui.core.models import TranscriptResult
@@ -13,49 +19,16 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-STAGE_WEIGHTS: dict[str, tuple[float, float]] = {
-    "preprocess": (0.00, 0.05),
-    "transcribe": (0.05, 0.55),
-    "align": (0.55, 0.65),
-    "diarize": (0.65, 0.90),
-    "assign_speakers": (0.90, 0.95),
-    "postprocess": (0.95, 1.00),
-}
-
-STAGE_WEIGHTS_WITH_DOWNLOAD: dict[str, tuple[float, float]] = {
-    "download": (0.00, 0.15),
-    "preprocess": (0.15, 0.20),
-    "transcribe": (0.20, 0.60),
-    "align": (0.60, 0.70),
-    "diarize": (0.70, 0.90),
-    "assign_speakers": (0.90, 0.95),
-    "postprocess": (0.95, 1.00),
-}
-
-# Weight bands used when LLMCorrectionStage is appended. Kept separate from
-# the default dicts so production jobs enqueued before an upgrade keep using
-# the layout they started with — changing the existing dicts would cause
-# their progress bars to jump when the worker is redeployed.
-STAGE_WEIGHTS_WITH_LLM: dict[str, tuple[float, float]] = {
-    "preprocess": (0.00, 0.05),
-    "transcribe": (0.05, 0.50),
-    "align": (0.50, 0.60),
-    "diarize": (0.60, 0.85),
-    "assign_speakers": (0.85, 0.90),
-    "postprocess": (0.90, 0.92),
-    "llm_correction": (0.92, 1.00),
-}
-
-STAGE_WEIGHTS_WITH_DOWNLOAD_AND_LLM: dict[str, tuple[float, float]] = {
-    "download": (0.00, 0.12),
-    "preprocess": (0.12, 0.17),
-    "transcribe": (0.17, 0.55),
-    "align": (0.55, 0.65),
-    "diarize": (0.65, 0.85),
-    "assign_speakers": (0.85, 0.90),
-    "postprocess": (0.90, 0.92),
-    "llm_correction": (0.92, 1.00),
-}
+# Re-exported so existing callers that import weight bands from the
+# orchestrator module continue to work. New code should import from
+# `whisper_ui.pipeline.progress_bands` directly.
+__all__ = [
+    "STAGE_WEIGHTS",
+    "STAGE_WEIGHTS_WITH_DOWNLOAD",
+    "STAGE_WEIGHTS_WITH_DOWNLOAD_AND_LLM",
+    "STAGE_WEIGHTS_WITH_LLM",
+    "PipelineOrchestrator",
+]
 
 
 class PipelineOrchestrator:

--- a/src/whisper_ui/pipeline/progress_bands.py
+++ b/src/whisper_ui/pipeline/progress_bands.py
@@ -1,0 +1,69 @@
+"""Stage progress weight bands used by the pipeline orchestrator and worker tasks.
+
+Each mapping declares the global-progress band `(start, end)` assigned to a
+stage name. Stage implementations report local progress in [0, 1] which is
+linearly mapped into its band, so the user-facing progress bar advances
+smoothly across stages without jumps.
+
+Four distinct layouts are kept instead of computing them dynamically because
+production jobs enqueued under an older layout must continue to report
+progress with the bands they started with — changing a shared dict would make
+their progress bar jump when the worker is redeployed.
+"""
+
+from __future__ import annotations
+
+StageWeights = dict[str, tuple[float, float]]
+
+
+STAGE_WEIGHTS: StageWeights = {
+    "preprocess": (0.00, 0.05),
+    "transcribe": (0.05, 0.55),
+    "align": (0.55, 0.65),
+    "diarize": (0.65, 0.90),
+    "assign_speakers": (0.90, 0.95),
+    "postprocess": (0.95, 1.00),
+}
+
+
+STAGE_WEIGHTS_WITH_DOWNLOAD: StageWeights = {
+    "download": (0.00, 0.15),
+    "preprocess": (0.15, 0.20),
+    "transcribe": (0.20, 0.60),
+    "align": (0.60, 0.70),
+    "diarize": (0.70, 0.90),
+    "assign_speakers": (0.90, 0.95),
+    "postprocess": (0.95, 1.00),
+}
+
+
+STAGE_WEIGHTS_WITH_LLM: StageWeights = {
+    "preprocess": (0.00, 0.05),
+    "transcribe": (0.05, 0.50),
+    "align": (0.50, 0.60),
+    "diarize": (0.60, 0.85),
+    "assign_speakers": (0.85, 0.90),
+    "postprocess": (0.90, 0.92),
+    "llm_correction": (0.92, 1.00),
+}
+
+
+STAGE_WEIGHTS_WITH_DOWNLOAD_AND_LLM: StageWeights = {
+    "download": (0.00, 0.12),
+    "preprocess": (0.12, 0.17),
+    "transcribe": (0.17, 0.55),
+    "align": (0.55, 0.65),
+    "diarize": (0.65, 0.85),
+    "assign_speakers": (0.85, 0.90),
+    "postprocess": (0.90, 0.92),
+    "llm_correction": (0.92, 1.00),
+}
+
+
+__all__ = [
+    "STAGE_WEIGHTS",
+    "STAGE_WEIGHTS_WITH_DOWNLOAD",
+    "STAGE_WEIGHTS_WITH_DOWNLOAD_AND_LLM",
+    "STAGE_WEIGHTS_WITH_LLM",
+    "StageWeights",
+]

--- a/src/whisper_ui/web/routes/jobs.py
+++ b/src/whisper_ui/web/routes/jobs.py
@@ -15,8 +15,8 @@ from whisper_ui.ui import labels as ui_labels
 from whisper_ui.web.batch_zip import create_batch_zip
 from whisper_ui.web.deps import DbDep, FileStoreDep, RedisDep, SettingsDep, make_content_disposition, templates
 from whisper_ui.web.validation import validate_hex_id
+from whisper_ui.worker.pipeline_dispatcher import enqueue_pipeline
 from whisper_ui.worker.progress import RedisProgressReporter
-from whisper_ui.worker.timeout import calculate_job_timeout
 
 if TYPE_CHECKING:
     from whisper_ui.storage.database import JobDatabase
@@ -123,15 +123,19 @@ def _probe_retry_duration(job: Job) -> float | None:
 
 
 @router.post("/jobs/{job_id}/retry")
-async def retry_job(job_id: str, db: DbDep, redis: RedisDep, settings: SettingsDep):
+async def retry_job(
+    job_id: str,
+    db: DbDep,
+    redis: RedisDep,
+    settings: SettingsDep,
+    filestore: FileStoreDep,
+):
     validate_hex_id(job_id, "job_id")
     job = db.get_job(job_id)
     if job is None or job.status != JobStatus.FAILED:
         return Response(status_code=404)
 
     try:
-        from rq import Queue
-
         retry_duration = _probe_retry_duration(job)
         job.status = JobStatus.QUEUED
         job.error = None
@@ -142,12 +146,7 @@ async def retry_job(job_id: str, db: DbDep, redis: RedisDep, settings: SettingsD
         db.update_job(job)
         redis.delete(f"job:{job.id}")
 
-        q = Queue(connection=redis)
-        q.enqueue(
-            "whisper_ui.worker.tasks.process_transcription",
-            job.id,
-            job_timeout=calculate_job_timeout(retry_duration, settings),
-        )
+        enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
     except Exception:
         logger.exception("Failed to enqueue retry for job %s", job.id)
         job.status = JobStatus.FAILED
@@ -173,15 +172,18 @@ async def delete_job(job_id: str, db: DbDep, filestore: FileStoreDep, redis: Red
 
 
 @router.post("/jobs/batch/{batch_id}/retry")
-async def retry_batch(batch_id: str, db: DbDep, redis: RedisDep, settings: SettingsDep):
+async def retry_batch(
+    batch_id: str,
+    db: DbDep,
+    redis: RedisDep,
+    settings: SettingsDep,
+    filestore: FileStoreDep,
+):
     validate_hex_id(batch_id, "batch_id")
     all_jobs = db.list_jobs_by_batch(batch_id)
     if not all_jobs:
         return Response(status_code=404)
 
-    from rq import Queue
-
-    q = Queue(connection=redis)
     for job in all_jobs:
         if job.status != JobStatus.FAILED:
             continue
@@ -195,11 +197,7 @@ async def retry_batch(batch_id: str, db: DbDep, redis: RedisDep, settings: Setti
             job.duration = retry_duration
             db.update_job(job)
             redis.delete(f"job:{job.id}")
-            q.enqueue(
-                "whisper_ui.worker.tasks.process_transcription",
-                job.id,
-                job_timeout=calculate_job_timeout(retry_duration, settings),
-            )
+            enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
         except Exception:
             logger.exception("Failed to retry job %s", job.id)
             job.status = JobStatus.FAILED

--- a/src/whisper_ui/web/routes/upload.py
+++ b/src/whisper_ui/web/routes/upload.py
@@ -19,7 +19,7 @@ from whisper_ui.pipeline.preprocess import SUPPORTED_EXTENSIONS
 from whisper_ui.ui import labels as ui_labels
 from whisper_ui.web.deps import DbDep, FileStoreDep, RedisDep, SettingsDep, templates
 from whisper_ui.web.url_validation import PlaylistURLError, YouTubeURLError, validate_youtube_url
-from whisper_ui.worker.timeout import calculate_job_timeout
+from whisper_ui.worker.pipeline_dispatcher import enqueue_pipeline
 
 _READ_CHUNK_SIZE = 1024 * 1024  # 1 MB
 
@@ -128,14 +128,6 @@ async def upload_submit(
     submitted_count = 0
     failed_count = 0
 
-    try:
-        from rq import Queue
-
-        q = Queue(connection=redis)
-    except Exception:
-        logger.exception("Failed to construct RQ queue from Redis connection")
-        return _error_redirect_or_fragment(request, "/upload?error=queue", ui_labels.UPLOAD_QUEUE_ERROR)
-
     max_size = settings.max_upload_size
     for uploaded_file in valid_files:
         display_name = PurePosixPath(uploaded_file.filename or "unknown").name
@@ -169,11 +161,7 @@ async def upload_submit(
         db.insert_job(job)
 
         try:
-            q.enqueue(
-                "whisper_ui.worker.tasks.process_transcription",
-                job.id,
-                job_timeout=calculate_job_timeout(job.duration, settings),
-            )
+            enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
             submitted_count += 1
         except Exception:
             logger.exception("Failed to enqueue job %s", job.id)
@@ -254,14 +242,6 @@ async def upload_url_submit(
     # Batch ID only when multiple URLs
     batch_id = uuid.uuid4().hex if len(unique_urls) > 1 else None
 
-    try:
-        from rq import Queue
-
-        q = Queue(connection=redis)
-    except Exception:
-        logger.exception("Failed to construct RQ queue from Redis connection")
-        return _error_redirect_or_fragment(request, "/upload?error=queue", ui_labels.UPLOAD_QUEUE_ERROR)
-
     submitted_count = 0
     failed_count = 0
     for clean_url in unique_urls:
@@ -283,11 +263,7 @@ async def upload_url_submit(
         db.insert_job(job)
 
         try:
-            q.enqueue(
-                "whisper_ui.worker.tasks.process_transcription",
-                job.id,
-                job_timeout=calculate_job_timeout(None, settings),
-            )
+            enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
             submitted_count += 1
         except Exception:
             logger.exception("Failed to enqueue URL job %s", job.id)

--- a/src/whisper_ui/worker/context_store.py
+++ b/src/whisper_ui/worker/context_store.py
@@ -1,0 +1,87 @@
+"""Shared pipeline context storage backed by a Redis hash.
+
+Each parent job owns one context hash at `whisper:ctx:{parent_job_id}`. Stage
+tasks read the full context at the start of their execution, run their stage,
+and write back only the keys that stage is declared to produce. Storing fields
+in a hash (one Redis field per context key) means two stages that write
+disjoint keys can commit concurrently without racing — this is what makes
+fan-in at assign_speakers safe.
+
+Values are pickled individually per field so every supported Python object a
+stage stores in the context (dataclasses, dicts, lists, primitives) survives
+the round trip. Large arrays such as ``whisperx_audio`` are deliberately *not*
+persisted here; they only live in the process that produced them.
+"""
+
+from __future__ import annotations
+
+import pickle
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from redis import Redis
+
+
+# One-day expiry is a safety net for abandoned contexts (worker killed before
+# the finalizer ran). Any successful pipeline will delete its own context.
+_CONTEXT_TTL_SECONDS = 86_400
+
+
+class PipelineContextStore:
+    """Redis-hash backed view of a parent job's pipeline context."""
+
+    def __init__(self, redis: Redis, parent_job_id: str) -> None:
+        self._redis = redis
+        self._key = f"whisper:ctx:{parent_job_id}"
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def initialize(self, context: dict[str, Any]) -> None:
+        """Replace the context with ``context``.
+
+        Used by the dispatcher when a new pipeline is enqueued so that any
+        stale hash left over from a previous run is cleared before the first
+        stage runs.
+        """
+        self._redis.delete(self._key)
+        if context:
+            mapping = {k: pickle.dumps(v) for k, v in context.items()}
+            self._redis.hset(self._key, mapping=mapping)
+        self._redis.expire(self._key, _CONTEXT_TTL_SECONDS)
+
+    def load(self) -> dict[str, Any]:
+        """Load the full context as a Python dict.
+
+        Returns an empty dict when no context has been initialized yet, which
+        mirrors the legacy in-process behaviour where a stage receives an
+        empty dict before the pipeline has started seeding it.
+        """
+        raw = self._redis.hgetall(self._key)
+        return {self._decode(k): pickle.loads(v) for k, v in raw.items()}
+
+    def update(self, updates: dict[str, Any]) -> None:
+        """Write ``updates`` to the hash, replacing any existing fields.
+
+        Empty updates are a no-op so a stage that produces nothing can call
+        ``update({})`` unconditionally.
+        """
+        if not updates:
+            return
+        mapping = {k: pickle.dumps(v) for k, v in updates.items()}
+        self._redis.hset(self._key, mapping=mapping)
+        self._redis.expire(self._key, _CONTEXT_TTL_SECONDS)
+
+    def delete(self) -> None:
+        """Drop the context hash. Called by the pipeline finalizer."""
+        self._redis.delete(self._key)
+
+    @staticmethod
+    def _decode(field: bytes | str) -> str:
+        if isinstance(field, bytes):
+            return field.decode()
+        return field
+
+
+__all__ = ["PipelineContextStore"]

--- a/src/whisper_ui/worker/context_store.py
+++ b/src/whisper_ui/worker/context_store.py
@@ -12,6 +12,44 @@ stage stores in the context (dataclasses, dicts, lists, primitives) survives
 the round trip. Large arrays such as ``whisperx_audio`` are deliberately *not*
 persisted here; they only live in the process that produced them.
 
+Serialization choice and threat model
+-------------------------------------
+
+Using ``pickle`` for values is an explicit, documented trade-off against
+switching to JSON or msgpack. The reasoning is layered:
+
+1. **Deployment target is internal network only.** Whisper-UI is shipped as
+   a docker-compose stack intended to run on a trusted internal host; the
+   README explicitly does not claim support for public / multi-tenant
+   deployment. The compose file configures ``REDIS_PASSWORD`` and binds
+   Redis to the internal network only, so an attacker reaching the Redis
+   hash at all already implies a prior compromise inside that network.
+   At that point a pickle RCE gadget only promotes attacker-on-Redis to
+   attacker-on-worker — the attack surface is not novel, merely wider by
+   one hop.
+
+2. **Context payloads contain whisperx internals.** The rich fields
+   (``transcription_result``, ``aligned_result``, ``diarize_result``,
+   ``final_result``) are nested Python dicts with numpy arrays and pandas
+   frames in the middle. JSON does not round-trip numpy cleanly; msgpack
+   round-trips only with a numpy extension, and either choice would force
+   every stage to maintain a custom ``to_dict`` / ``from_dict`` layer. The
+   audit cost of that migration is large, and every new stage would have
+   to stay in sync with it.
+
+3. **No alternative is strictly safer in the current threat model.** The
+   only meaningful threat model shift would be exposing Redis to an
+   untrusted network. If that ever happens, the right response is a
+   deployment hardening pass (Redis auth, TLS, network segmentation),
+   alongside a serializer migration — not a serializer migration alone.
+
+**Upgrade path.** When/if the deployment story opens up to public
+networks, replace ``pickle.dumps`` / ``pickle.loads`` with
+``msgpack-numpy`` and audit every ``output_keys`` tuple in
+``worker/stage_tasks.py`` to make sure the payloads round-trip
+losslessly. Generation-gated writes are orthogonal and will continue to
+work unchanged because the Lua script only sees opaque bytes.
+
 Generation-gated writes
 -----------------------
 
@@ -31,6 +69,12 @@ closes that window server-side via a Lua compare-and-write script.
 
 from __future__ import annotations
 
+# ``pickle`` is deliberate — see "Serialization choice and threat model" in
+# the module docstring for the full rationale. The internal-network-only
+# deployment story plus authenticated Redis means the pickle attack surface
+# already requires a prior internal compromise, and the context payloads
+# (whisperx nested dicts with numpy arrays) do not round-trip cleanly
+# through safer serializers without a large per-stage audit.
 import pickle
 from typing import TYPE_CHECKING, Any
 
@@ -121,6 +165,9 @@ class PipelineContextStore:
         empty dict before the pipeline has started seeding it.
         """
         raw = self._redis.hgetall(self._key)
+        # pickle.loads is safe in this codebase only under the threat model
+        # documented at the top of this module. Do not change this call
+        # site without also updating that docstring.
         return {self._decode(k): pickle.loads(v) for k, v in raw.items()}
 
     def update(self, updates: dict[str, Any]) -> None:

--- a/src/whisper_ui/worker/context_store.py
+++ b/src/whisper_ui/worker/context_store.py
@@ -11,6 +11,22 @@ Values are pickled individually per field so every supported Python object a
 stage stores in the context (dataclasses, dicts, lists, primitives) survives
 the round trip. Large arrays such as ``whisperx_audio`` are deliberately *not*
 persisted here; they only live in the process that produced them.
+
+Generation-gated writes
+-----------------------
+
+A separate per-parent-job counter (``whisper:pipeline:{parent}:generation``)
+is bumped on every ``enqueue_pipeline`` call. Each sub-job is enqueued with
+the current generation embedded in its RQ meta, and
+``update_if_generation_matches`` refuses to write when the caller's
+generation no longer matches the one stored in Redis.
+
+This exists to isolate retries: if a user retries a failed job while a
+lingering stage from the previous attempt (e.g. a diarize call deep inside
+a pyannote C++ inference that did not yet honour ``send_stop_job_command``)
+is still running, that stale stage must not be able to write its stale
+output into the fresh context hash the retry just seeded. Generation gating
+closes that window server-side via a Lua compare-and-write script.
 """
 
 from __future__ import annotations
@@ -27,23 +43,69 @@ if TYPE_CHECKING:
 _CONTEXT_TTL_SECONDS = 86_400
 
 
+# Atomic generation-gated HSET: write the pickled fields only if the stored
+# generation counter matches the caller's expected generation. Returns 1 on
+# success, 0 if the write was rejected because the caller's generation was
+# stale (the parent job has been retried under a new generation).
+#
+# KEYS[1] = context hash key (whisper:ctx:<parent>)
+# KEYS[2] = generation counter key (whisper:pipeline:<parent>:generation)
+# ARGV[1] = expected generation (int as string)
+# ARGV[2] = TTL in seconds
+# ARGV[3..] = alternating field/value pairs for the HSET
+_GENERATION_GATED_HSET_LUA = """
+local ctx_key = KEYS[1]
+local gen_key = KEYS[2]
+local expected = ARGV[1]
+local ttl = tonumber(ARGV[2])
+local current = redis.call('GET', gen_key)
+if current and current ~= expected then
+  return 0
+end
+local pairs_count = #ARGV - 2
+if pairs_count >= 2 then
+  local args = {}
+  for i = 3, #ARGV do
+    args[#args + 1] = ARGV[i]
+  end
+  redis.call('HSET', ctx_key, unpack(args))
+end
+redis.call('EXPIRE', ctx_key, ttl)
+return 1
+"""
+
+
 class PipelineContextStore:
-    """Redis-hash backed view of a parent job's pipeline context."""
+    """Redis-hash backed view of a parent job's pipeline context.
+
+    The store does **not** own the generation counter lifecycle — the
+    dispatcher INCRs it when a pipeline is enqueued and the store only
+    reads it. This separation keeps the context store a plain data layer
+    while the dispatcher remains the single place that decides when a
+    retry starts a new attempt.
+    """
 
     def __init__(self, redis: Redis, parent_job_id: str) -> None:
         self._redis = redis
         self._key = f"whisper:ctx:{parent_job_id}"
+        self._generation_key = f"whisper:pipeline:{parent_job_id}:generation"
+        self._gated_hset_script = redis.register_script(_GENERATION_GATED_HSET_LUA)
 
     @property
     def key(self) -> str:
         return self._key
+
+    @property
+    def generation_key(self) -> str:
+        return self._generation_key
 
     def initialize(self, context: dict[str, Any]) -> None:
         """Replace the context with ``context``.
 
         Used by the dispatcher when a new pipeline is enqueued so that any
         stale hash left over from a previous run is cleared before the first
-        stage runs.
+        stage runs. Does **not** touch the generation counter — that is the
+        dispatcher's responsibility.
         """
         self._redis.delete(self._key)
         if context:
@@ -62,7 +124,12 @@ class PipelineContextStore:
         return {self._decode(k): pickle.loads(v) for k, v in raw.items()}
 
     def update(self, updates: dict[str, Any]) -> None:
-        """Write ``updates`` to the hash, replacing any existing fields.
+        """Write ``updates`` to the hash unconditionally.
+
+        Used only for seeding keys from the dispatcher / pre-context hooks
+        that run before any sub-job meta exists. Stage tasks must prefer
+        :meth:`update_if_generation_matches` so their writes can be rejected
+        when the parent job has been retried under a new generation.
 
         Empty updates are a no-op so a stage that produces nothing can call
         ``update({})`` unconditionally.
@@ -73,8 +140,49 @@ class PipelineContextStore:
         self._redis.hset(self._key, mapping=mapping)
         self._redis.expire(self._key, _CONTEXT_TTL_SECONDS)
 
+    def update_if_generation_matches(
+        self,
+        updates: dict[str, Any],
+        expected_generation: int,
+    ) -> bool:
+        """Write ``updates`` only if the parent generation still matches.
+
+        Returns True when the write committed, False when it was rejected
+        because another enqueue_pipeline call has since bumped the
+        generation. Callers should treat a False return as "this attempt
+        has been superseded" and stop mutating shared state; the stage
+        itself has already run and its work is simply discarded.
+
+        Empty updates still go through the Lua script so the TTL is
+        refreshed and the generation check runs — this keeps the
+        invariant that any successful stage execution either commits its
+        output or discovers the retry, with no silent middle ground.
+        """
+        serialized_pairs: list[str | bytes] = []
+        for field, value in updates.items():
+            serialized_pairs.append(field)
+            serialized_pairs.append(pickle.dumps(value))
+        result = self._gated_hset_script(
+            keys=[self._key, self._generation_key],
+            args=[str(expected_generation), _CONTEXT_TTL_SECONDS, *serialized_pairs],
+        )
+        return int(result) == 1
+
+    def get_generation(self) -> int | None:
+        """Return the current generation, or None if none has been set yet."""
+        raw = self._redis.get(self._generation_key)
+        if raw is None:
+            return None
+        return int(raw)
+
     def delete(self) -> None:
-        """Drop the context hash. Called by the pipeline finalizer."""
+        """Drop the context hash. Called by the pipeline finalizer.
+
+        Intentionally does *not* delete the generation counter: if a late
+        retry comes in while a stale stage is mid-execution, we want the
+        counter to still be visible so the stale stage's
+        update_if_generation_matches call can see the new value.
+        """
         self._redis.delete(self._key)
 
     @staticmethod

--- a/src/whisper_ui/worker/pipeline_dispatcher.py
+++ b/src/whisper_ui/worker/pipeline_dispatcher.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from rq import Callback, Queue
+from rq.timeouts import BaseTimeoutException
 
 from whisper_ui.core.constants import (
     ERROR_DISPLAY_LENGTH,
@@ -35,8 +36,9 @@ from whisper_ui.core.constants import (
 )
 from whisper_ui.core.messages import PIPELINE_COMPLETE
 from whisper_ui.core.models import JobStatus
+from whisper_ui.ui.labels import JOBS_TIMEOUT_ERROR
 from whisper_ui.worker.context_store import PipelineContextStore
-from whisper_ui.worker.runtime import build_worker_runtime
+from whisper_ui.worker.runtime import build_worker_runtime, extract_rq_timeout_seconds
 from whisper_ui.worker.stage_tasks import (
     run_assign_speakers,
     run_diarize,
@@ -270,6 +272,29 @@ def finalize_success(rq_job, connection, _result) -> None:
             _clear_subjob_set(runtime.redis, parent_job_id)
 
 
+def _format_failure_message(exc_type, exc_value) -> str:
+    """Turn an RQ ``on_failure`` exception triple into the user-facing error.
+
+    RQ timeouts get routed through the same ``JOBS_TIMEOUT_ERROR`` label the
+    legacy monolithic worker used (see ``worker/tasks.py``) so the UI shows
+    the Chinese "任務總執行時間超出上限" message regardless of whether the
+    pipeline ran in the DAG or legacy path. Any other exception falls back
+    to ``str(exc_value)``, matching the pre-DAG behaviour for non-timeout
+    failures.
+
+    RQ passes the exception *class* as ``exc_type`` (not an instance), so the
+    type check must use ``issubclass``. ``exc_value`` is still the instance
+    and is passed through to ``extract_rq_timeout_seconds`` for message-regex
+    parsing when the current-job lookup is unavailable.
+    """
+    if exc_type is not None and isinstance(exc_type, type) and issubclass(exc_type, BaseTimeoutException):
+        seconds = extract_rq_timeout_seconds(exc_value) if exc_value is not None else "?"
+        return JOBS_TIMEOUT_ERROR.format(seconds=seconds)
+    if exc_value is not None:
+        return str(exc_value)
+    return "unknown pipeline failure"
+
+
 def finalize_failure(rq_job, connection, _exc_type, exc_value, _traceback) -> None:
     """RQ ``on_failure`` callback attached to every sub-job.
 
@@ -282,7 +307,7 @@ def finalize_failure(rq_job, connection, _exc_type, exc_value, _traceback) -> No
         logger.error("finalize_failure invoked without parent_job_id in meta")
         return
 
-    error_msg = str(exc_value) if exc_value is not None else "unknown pipeline failure"
+    error_msg = _format_failure_message(_exc_type, exc_value)
 
     with build_worker_runtime(parent_job_id) as runtime:
         job = runtime.db.get_job(parent_job_id)

--- a/src/whisper_ui/worker/pipeline_dispatcher.py
+++ b/src/whisper_ui/worker/pipeline_dispatcher.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from rq import Callback, Queue
+from rq.command import send_stop_job_command
 from rq.timeouts import BaseTimeoutException
 
 from whisper_ui.core.constants import (
@@ -348,20 +349,52 @@ def _mark_failed(
 
 
 def _cancel_remaining_subjobs(redis: Redis, parent_job_id: str, *, exclude: str) -> None:
-    """Cancel every sub-job that has not yet started, except the one that
+    """Stop every sub-job belonging to the same parent, except the one that
     just failed (``exclude``).
 
-    RQ's default behaviour for a failed dependency is to move the dependent
-    job to the ``deferred`` registry and never execute it; from the user's
-    perspective that looks like a hang. Explicitly cancelling them here means
-    the queue drains cleanly and monitoring dashboards show a clear terminal
-    state for every sub-job.
+    This has to handle two distinct states for each sibling:
+
+    1. **Already running.** ``RQJob.cancel()`` alone does *not* stop a
+       running job — it only removes pending / deferred ones from the
+       queue. For running jobs we fire ``send_stop_job_command`` first,
+       which RQ delivers via a Redis pub/sub channel to the owning
+       worker; the worker then raises a stop exception inside the job
+       process at the next safe point. (See PR #39 review R3: without
+       this, the diarize branch could keep running after transcribe
+       failed and eventually write its result into the Redis context
+       store, polluting a subsequent retry.)
+    2. **Still queued / deferred.** ``send_stop_job_command`` is a no-op
+       for jobs that have not started, so we follow it with ``cancel()``
+       to evict them from the queue registry. Downstream dependent jobs
+       (e.g. assign_speakers waiting on transcribe_align + diarize)
+       would otherwise sit in the deferred registry forever.
+
+    Both calls are best-effort: any failure only debug-logs and the
+    loop keeps going so one stuck sibling cannot block the others.
+
+    Note that even after ``send_stop_job_command`` lands, a worker
+    already inside a native extension call (pyannote / whisperx C++
+    inference) can take a bounded amount of time to actually exit. That
+    residual window is closed by the generation-id gating in the next
+    commit — this layer is the fast-path that minimizes wasted GPU time.
     """
     from rq.job import Job as RQJob
 
     for sub_id in _load_subjob_ids(redis, parent_job_id):
         if sub_id == exclude:
             continue
+        # Layer 1a: stop if currently running. Fire-and-forget — the stop
+        # command is delivered over Redis pub/sub, so we cannot
+        # synchronously confirm it took effect.
+        try:
+            send_stop_job_command(redis, sub_id)
+        except Exception:
+            logger.debug(
+                "send_stop_job_command for %s failed (likely not currently running)",
+                sub_id,
+                exc_info=True,
+            )
+        # Layer 1b: cancel queued / deferred siblings so the queue drains.
         try:
             sub = RQJob.fetch(sub_id, connection=redis)
         except Exception:

--- a/src/whisper_ui/worker/pipeline_dispatcher.py
+++ b/src/whisper_ui/worker/pipeline_dispatcher.py
@@ -179,6 +179,24 @@ def enqueue_pipeline(
     # its write the next time it calls update_if_generation_matches.
     generation = _bump_generation(redis, job.id)
 
+    # Seed the progress hash with the new generation immediately so a stale
+    # writer that arrives after the retry route deleted ``job:{id}`` (wiping
+    # the hash-embedded generation field) sees the fresh generation=N via
+    # both the central counter (checked in Lua KEYS[2]) AND the hash field.
+    # This is the hash-level belt on top of the central-counter suspenders
+    # added in Commit 21, and also gives the UI a clean ``progress=0,
+    # status=queued`` read right after retry instead of an empty hash.
+    progress_key = f"job:{job.id}"
+    redis.hset(
+        progress_key,
+        mapping={
+            "progress": "0",
+            "status": "queued",
+            "generation": str(generation),
+        },
+    )
+    redis.expire(progress_key, settings.redis_processing_expiry)
+
     ctx_store = PipelineContextStore(redis, job.id)
     ctx_store.initialize(initial_context)
     # The subjobs set is now per-generation, so we do NOT clear previous

--- a/src/whisper_ui/worker/pipeline_dispatcher.py
+++ b/src/whisper_ui/worker/pipeline_dispatcher.py
@@ -1,0 +1,335 @@
+"""Dispatcher that assembles a per-pipeline DAG of RQ sub-jobs.
+
+``enqueue_pipeline`` replaces the legacy single-task ``process_transcription``
+path. Instead of running every pipeline stage inside one monolithic worker
+task, it seeds the shared context in Redis and fans out one RQ sub-job per
+logical stage (or stage group). The sub-jobs are wired together via
+``depends_on`` so that:
+
+* download (if any) runs before preprocess
+* transcribe_align and diarize start in parallel after preprocess
+* assign_speakers fans them back in
+* postprocess (and the optional llm_correction) finish the chain
+
+The final job carries an ``on_success`` callback that saves the transcript
+result, marks the parent job COMPLETED, and clears the context store. Every
+sub-job also carries an ``on_failure`` callback that marks the parent FAILED,
+cancels any dependent jobs that have not yet run, and cleans up the
+intermediate 16 kHz WAV.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rq import Callback, Queue
+
+from whisper_ui.core.constants import (
+    ERROR_DISPLAY_LENGTH,
+    ERROR_MAX_LENGTH,
+)
+from whisper_ui.core.messages import PIPELINE_COMPLETE
+from whisper_ui.core.models import JobStatus
+from whisper_ui.worker.context_store import PipelineContextStore
+from whisper_ui.worker.runtime import build_worker_runtime
+from whisper_ui.worker.stage_tasks import (
+    run_assign_speakers,
+    run_diarize,
+    run_download,
+    run_llm_correction,
+    run_postprocess,
+    run_preprocess,
+    run_transcribe_align,
+)
+from whisper_ui.worker.timeout import calculate_job_timeout
+
+if TYPE_CHECKING:
+    from redis import Redis
+    from rq.job import Job as RQJob
+
+    from whisper_ui.core.config import Settings
+    from whisper_ui.core.models import Job
+    from whisper_ui.storage.database import JobDatabase
+    from whisper_ui.storage.filestore import FileStore
+    from whisper_ui.worker.progress import RedisProgressReporter
+
+logger = logging.getLogger(__name__)
+
+
+# Redis set key used to track the RQ ids of sub-jobs belonging to one parent.
+# The failure callback reads this set so it can cancel any dependents that
+# have not yet started.
+def _subjobs_key(parent_job_id: str) -> str:
+    return f"whisper:pipeline:{parent_job_id}:subjobs"
+
+
+def _record_subjob(redis: Redis, parent_job_id: str, sub_job_id: str) -> None:
+    redis.sadd(_subjobs_key(parent_job_id), sub_job_id)
+    redis.expire(_subjobs_key(parent_job_id), 86_400)
+
+
+def _load_subjob_ids(redis: Redis, parent_job_id: str) -> list[str]:
+    raw = redis.smembers(_subjobs_key(parent_job_id))
+    return [item.decode() if isinstance(item, bytes) else item for item in raw]
+
+
+def _clear_subjob_set(redis: Redis, parent_job_id: str) -> None:
+    redis.delete(_subjobs_key(parent_job_id))
+
+
+def enqueue_pipeline(
+    job: Job,
+    *,
+    redis: Redis,
+    settings: Settings,
+    filestore: FileStore,
+) -> str:
+    """Build and enqueue the RQ DAG for ``job``.
+
+    The DAG shape depends on three flags that come from the Job record and
+    the deployment settings:
+
+    * ``job.source_url`` → prepend a download sub-job
+    * ``job.enable_diarization`` → add a diarize branch parallel to transcribe
+    * ``job.llm_correction_enabled`` (AND ``settings.ollama_base_url``) → add
+      an llm_correction sub-job after postprocess
+
+    Returns the id of the last sub-job in the chain, so callers can attach
+    monitoring to the tail of the pipeline if they want to.
+    """
+    q = Queue(connection=redis)
+
+    initial_context: dict = {
+        "language": job.language,
+        "batch_size": settings.batch_size,
+        "num_speakers": job.num_speakers,
+    }
+    if job.source_url:
+        initial_context["source_url"] = job.source_url
+        initial_context["download_dir"] = str(filestore.prepare_upload_path(job.id, "_").parent)
+        initial_context["input_path"] = ""
+    else:
+        initial_context["input_path"] = job.filepath or ""
+
+    ctx_store = PipelineContextStore(redis, job.id)
+    ctx_store.initialize(initial_context)
+    _clear_subjob_set(redis, job.id)
+
+    timeout = calculate_job_timeout(job.duration, settings)
+    success_cb = Callback("whisper_ui.worker.pipeline_dispatcher.finalize_success")
+    failure_cb = Callback("whisper_ui.worker.pipeline_dispatcher.finalize_failure")
+    meta = {"parent_job_id": job.id}
+
+    llm_active = bool(job.llm_correction_enabled) and bool(settings.ollama_base_url)
+
+    enqueued: list[RQJob] = []
+
+    def _enqueue(func, *, depends_on=None, is_final: bool) -> RQJob:
+        kwargs = {
+            "job_timeout": timeout,
+            "meta": dict(meta),
+            "on_failure": failure_cb,
+        }
+        if depends_on is not None:
+            kwargs["depends_on"] = depends_on
+        if is_final:
+            kwargs["on_success"] = success_cb
+        sub = q.enqueue(func, job.id, **kwargs)
+        enqueued.append(sub)
+        _record_subjob(redis, job.id, sub.id)
+        return sub
+
+    # Build the DAG. Note the "is_final" flag is only true on the very last
+    # sub-job of the chosen branch, so finalize_success runs exactly once.
+    if job.source_url:
+        download_job = _enqueue(run_download, is_final=False)
+        preprocess_job = _enqueue(run_preprocess, depends_on=download_job, is_final=False)
+    else:
+        preprocess_job = _enqueue(run_preprocess, is_final=False)
+
+    transcribe_job = _enqueue(
+        run_transcribe_align,
+        depends_on=preprocess_job,
+        is_final=False,
+    )
+
+    if job.enable_diarization:
+        diarize_job = _enqueue(run_diarize, depends_on=preprocess_job, is_final=False)
+        assign_deps: list[RQJob] = [transcribe_job, diarize_job]
+    else:
+        assign_deps = [transcribe_job]
+
+    assign_job = _enqueue(run_assign_speakers, depends_on=assign_deps, is_final=False)
+    postprocess_final = not llm_active
+    postprocess_job = _enqueue(
+        run_postprocess,
+        depends_on=assign_job,
+        is_final=postprocess_final,
+    )
+
+    if llm_active:
+        llm_job = _enqueue(run_llm_correction, depends_on=postprocess_job, is_final=True)
+        tail_id = llm_job.id
+    else:
+        tail_id = postprocess_job.id
+
+    logger.info(
+        "Enqueued pipeline DAG for job %s with %d sub-jobs",
+        job.id,
+        len(enqueued),
+    )
+    return tail_id
+
+
+def _apply_filename_from_video_title(job: Job, context: dict) -> None:
+    """If the pipeline downloaded a YouTube video, surface its title as the
+    user-facing filename. Mirrors the legacy behaviour in
+    ``worker.tasks.process_transcription``.
+    """
+    if job.source_url and context.get("video_title"):
+        job.filename = context["video_title"]
+
+
+def _cleanup_preprocessed_audio(context: dict) -> None:
+    audio_path = context.get("audio_path")
+    if not audio_path:
+        return
+    try:
+        Path(audio_path).unlink(missing_ok=True)
+    except OSError:
+        logger.warning("Failed to clean up preprocessed file: %s", audio_path)
+
+
+def finalize_success(rq_job, connection, _result) -> None:
+    """RQ ``on_success`` callback for the final sub-job.
+
+    Converts the accumulated context into a persisted transcript file,
+    updates the parent Job row to COMPLETED, and clears the Redis context
+    hash + sub-job tracking set.
+    """
+    parent_job_id = rq_job.meta.get("parent_job_id") if rq_job.meta else None
+    if not parent_job_id:
+        logger.error("finalize_success invoked without parent_job_id in meta")
+        return
+
+    with build_worker_runtime(parent_job_id) as runtime:
+        job = runtime.db.get_job(parent_job_id)
+        if job is None:
+            logger.error("finalize_success could not find parent job %s", parent_job_id)
+            return
+
+        ctx_store = PipelineContextStore(runtime.redis, parent_job_id)
+        context = ctx_store.load()
+
+        transcript_result = context.get("transcript_result")
+        if transcript_result is None:
+            logger.error("finalize_success for job %s: no transcript_result in context", parent_job_id)
+            _mark_failed(job, runtime.db, runtime.reporter, "transcript_result missing")
+            ctx_store.delete()
+            _clear_subjob_set(runtime.redis, parent_job_id)
+            return
+
+        try:
+            _apply_filename_from_video_title(job, context)
+            result_path = runtime.filestore.save_result(parent_job_id, transcript_result)
+
+            job.status = JobStatus.COMPLETED
+            job.progress = 1.0
+            job.progress_message = PIPELINE_COMPLETE
+            job.result_path = str(result_path)
+            job.duration = transcript_result.duration
+            runtime.db.update_job(job)
+            runtime.reporter.complete(str(result_path))
+
+            logger.info("Job %s completed successfully via DAG pipeline", parent_job_id)
+        finally:
+            _cleanup_preprocessed_audio(context)
+            ctx_store.delete()
+            _clear_subjob_set(runtime.redis, parent_job_id)
+
+
+def finalize_failure(rq_job, connection, _exc_type, exc_value, _traceback) -> None:
+    """RQ ``on_failure`` callback attached to every sub-job.
+
+    Called once per failing sub-job. The first invocation marks the parent
+    FAILED and cancels the other sub-jobs; subsequent invocations become
+    no-ops because the parent is already in a terminal state.
+    """
+    parent_job_id = rq_job.meta.get("parent_job_id") if rq_job.meta else None
+    if not parent_job_id:
+        logger.error("finalize_failure invoked without parent_job_id in meta")
+        return
+
+    error_msg = str(exc_value) if exc_value is not None else "unknown pipeline failure"
+
+    with build_worker_runtime(parent_job_id) as runtime:
+        job = runtime.db.get_job(parent_job_id)
+        if job is None:
+            logger.error("finalize_failure could not find parent job %s", parent_job_id)
+            return
+
+        if job.status == JobStatus.FAILED:
+            logger.debug(
+                "finalize_failure: job %s already FAILED, skipping duplicate cleanup",
+                parent_job_id,
+            )
+            return
+
+        ctx_store = PipelineContextStore(runtime.redis, parent_job_id)
+        context = ctx_store.load()
+
+        try:
+            _cancel_remaining_subjobs(runtime.redis, parent_job_id, exclude=rq_job.id)
+            _mark_failed(job, runtime.db, runtime.reporter, error_msg)
+        finally:
+            _cleanup_preprocessed_audio(context)
+            ctx_store.delete()
+            _clear_subjob_set(runtime.redis, parent_job_id)
+
+
+def _mark_failed(
+    job: Job,
+    db: JobDatabase,
+    reporter: RedisProgressReporter,
+    error_msg: str,
+) -> None:
+    job.status = JobStatus.FAILED
+    job.error = error_msg[:ERROR_MAX_LENGTH]
+    job.progress_message = f"Failed: {error_msg[:ERROR_DISPLAY_LENGTH]}"
+    db.update_job(job)
+    reporter.fail(error_msg)
+
+
+def _cancel_remaining_subjobs(redis: Redis, parent_job_id: str, *, exclude: str) -> None:
+    """Cancel every sub-job that has not yet started, except the one that
+    just failed (``exclude``).
+
+    RQ's default behaviour for a failed dependency is to move the dependent
+    job to the ``deferred`` registry and never execute it; from the user's
+    perspective that looks like a hang. Explicitly cancelling them here means
+    the queue drains cleanly and monitoring dashboards show a clear terminal
+    state for every sub-job.
+    """
+    from rq.job import Job as RQJob
+
+    for sub_id in _load_subjob_ids(redis, parent_job_id):
+        if sub_id == exclude:
+            continue
+        try:
+            sub = RQJob.fetch(sub_id, connection=redis)
+        except Exception:
+            logger.debug("sub-job %s no longer exists, skipping cancel", sub_id)
+            continue
+        try:
+            sub.cancel()
+        except Exception:
+            logger.warning("failed to cancel sub-job %s", sub_id, exc_info=True)
+
+
+__all__ = [
+    "enqueue_pipeline",
+    "finalize_failure",
+    "finalize_success",
+]

--- a/src/whisper_ui/worker/pipeline_dispatcher.py
+++ b/src/whisper_ui/worker/pipeline_dispatcher.py
@@ -85,6 +85,29 @@ def _subjobs_key(parent_job_id: str) -> str:
     return f"whisper:pipeline:{parent_job_id}:subjobs"
 
 
+def _generation_key(parent_job_id: str) -> str:
+    return f"whisper:pipeline:{parent_job_id}:generation"
+
+
+# TTL applied to the generation counter so an abandoned job eventually
+# frees the key. Must outlive the longest plausible stage execution so a
+# late writer can still see the bumped value and drop its update.
+_GENERATION_TTL_SECONDS = 86_400
+
+
+def _bump_generation(redis: Redis, parent_job_id: str) -> int:
+    """Atomically advance the generation counter for ``parent_job_id``.
+
+    Returns the new generation. Every enqueue_pipeline call (including
+    retries) goes through this, so sibling sub-jobs from a previous attempt
+    that somehow kept running will see a newer generation when they try
+    to commit their output and silently drop the write.
+    """
+    new_gen = redis.incr(_generation_key(parent_job_id))
+    redis.expire(_generation_key(parent_job_id), _GENERATION_TTL_SECONDS)
+    return int(new_gen)
+
+
 def _record_subjob(redis: Redis, parent_job_id: str, sub_job_id: str) -> None:
     redis.sadd(_subjobs_key(parent_job_id), sub_job_id)
     redis.expire(_subjobs_key(parent_job_id), 86_400)
@@ -135,6 +158,11 @@ def enqueue_pipeline(
     else:
         initial_context["input_path"] = job.filepath or ""
 
+    # Bump the generation counter *before* initializing the context so any
+    # stale writer from the previous attempt sees the new value and drops
+    # its write the next time it calls update_if_generation_matches.
+    generation = _bump_generation(redis, job.id)
+
     ctx_store = PipelineContextStore(redis, job.id)
     ctx_store.initialize(initial_context)
     _clear_subjob_set(redis, job.id)
@@ -142,7 +170,10 @@ def enqueue_pipeline(
     timeout = calculate_job_timeout(job.duration, settings)
     success_cb = Callback("whisper_ui.worker.pipeline_dispatcher.finalize_success")
     failure_cb = Callback("whisper_ui.worker.pipeline_dispatcher.finalize_failure")
-    meta = {"parent_job_id": job.id}
+    # Sub-job meta carries both the parent_job_id (for callbacks that need
+    # to route to the right Job row) and the generation (so stage tasks
+    # can gate their writes against stale retries).
+    meta = {"parent_job_id": job.id, "generation": generation}
 
     llm_active = bool(job.llm_correction_enabled) and bool(settings.ollama_base_url)
 

--- a/src/whisper_ui/worker/pipeline_dispatcher.py
+++ b/src/whisper_ui/worker/pipeline_dispatcher.py
@@ -29,6 +29,9 @@ from rq import Callback, Queue
 from whisper_ui.core.constants import (
     ERROR_DISPLAY_LENGTH,
     ERROR_MAX_LENGTH,
+    WORKER_QUEUE_CPU,
+    WORKER_QUEUE_GPU,
+    WORKER_QUEUE_IO,
 )
 from whisper_ui.core.messages import PIPELINE_COMPLETE
 from whisper_ui.core.models import JobStatus
@@ -44,6 +47,20 @@ from whisper_ui.worker.stage_tasks import (
     run_transcribe_align,
 )
 from whisper_ui.worker.timeout import calculate_job_timeout
+
+# Stage function → queue name. IO stages (download, preprocess, llm_correction)
+# go to a queue serviced by workers that do not hold a CUDA context, GPU
+# stages go to the GPU queue, and lightweight CPU finalisation stages go to
+# the CPU queue. See whisper_ui.core.constants for the rationale.
+_STAGE_QUEUES = {
+    run_download.__name__: WORKER_QUEUE_IO,
+    run_preprocess.__name__: WORKER_QUEUE_IO,
+    run_llm_correction.__name__: WORKER_QUEUE_IO,
+    run_transcribe_align.__name__: WORKER_QUEUE_GPU,
+    run_diarize.__name__: WORKER_QUEUE_GPU,
+    run_assign_speakers.__name__: WORKER_QUEUE_CPU,
+    run_postprocess.__name__: WORKER_QUEUE_CPU,
+}
 
 if TYPE_CHECKING:
     from redis import Redis
@@ -99,7 +116,9 @@ def enqueue_pipeline(
     Returns the id of the last sub-job in the chain, so callers can attach
     monitoring to the tail of the pipeline if they want to.
     """
-    q = Queue(connection=redis)
+    queues = {
+        name: Queue(name=name, connection=redis) for name in (WORKER_QUEUE_IO, WORKER_QUEUE_GPU, WORKER_QUEUE_CPU)
+    }
 
     initial_context: dict = {
         "language": job.language,
@@ -127,6 +146,7 @@ def enqueue_pipeline(
     enqueued: list[RQJob] = []
 
     def _enqueue(func, *, depends_on=None, is_final: bool) -> RQJob:
+        queue_name = _STAGE_QUEUES[func.__name__]
         kwargs = {
             "job_timeout": timeout,
             "meta": dict(meta),
@@ -136,7 +156,7 @@ def enqueue_pipeline(
             kwargs["depends_on"] = depends_on
         if is_final:
             kwargs["on_success"] = success_cb
-        sub = q.enqueue(func, job.id, **kwargs)
+        sub = queues[queue_name].enqueue(func, job.id, **kwargs)
         enqueued.append(sub)
         _record_subjob(redis, job.id, sub.id)
         return sub

--- a/src/whisper_ui/worker/pipeline_dispatcher.py
+++ b/src/whisper_ui/worker/pipeline_dispatcher.py
@@ -78,20 +78,25 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# Redis set key used to track the RQ ids of sub-jobs belonging to one parent.
-# The failure callback reads this set so it can cancel any dependents that
-# have not yet started.
-def _subjobs_key(parent_job_id: str) -> str:
-    return f"whisper:pipeline:{parent_job_id}:subjobs"
+# Redis keys for tracking sub-jobs and the generation counter. The
+# subjobs set is scoped per-generation so a stale callback from a
+# superseded attempt cannot accidentally enumerate the new attempt's
+# sub-jobs. See Commit 18 / PR #39 Round 2 review for the full rationale:
+# an earlier version of this module stored all sub-jobs under a single
+# parent-scoped key and cleared it on retry, which made attempt 2's ids
+# visible to attempt 1's late finalize callback.
+def _subjobs_key(parent_job_id: str, generation: int) -> str:
+    return f"whisper:pipeline:{parent_job_id}:subjobs:{generation}"
 
 
 def _generation_key(parent_job_id: str) -> str:
     return f"whisper:pipeline:{parent_job_id}:generation"
 
 
-# TTL applied to the generation counter so an abandoned job eventually
-# frees the key. Must outlive the longest plausible stage execution so a
-# late writer can still see the bumped value and drop its update.
+# TTL applied to the generation counter and subjobs sets so an abandoned
+# job eventually frees its keys. Must outlive the longest plausible stage
+# execution so a late writer can still see the bumped generation value
+# (and drop its update) after the finalizer has cleaned up the context.
 _GENERATION_TTL_SECONDS = 86_400
 
 
@@ -108,18 +113,29 @@ def _bump_generation(redis: Redis, parent_job_id: str) -> int:
     return int(new_gen)
 
 
-def _record_subjob(redis: Redis, parent_job_id: str, sub_job_id: str) -> None:
-    redis.sadd(_subjobs_key(parent_job_id), sub_job_id)
-    redis.expire(_subjobs_key(parent_job_id), 86_400)
+def _current_generation(redis: Redis, parent_job_id: str) -> int | None:
+    """Return the generation counter for ``parent_job_id``, or None when
+    no attempt has ever been enqueued (or the counter has expired).
+    """
+    raw = redis.get(_generation_key(parent_job_id))
+    if raw is None:
+        return None
+    return int(raw)
 
 
-def _load_subjob_ids(redis: Redis, parent_job_id: str) -> list[str]:
-    raw = redis.smembers(_subjobs_key(parent_job_id))
+def _record_subjob(redis: Redis, parent_job_id: str, generation: int, sub_job_id: str) -> None:
+    key = _subjobs_key(parent_job_id, generation)
+    redis.sadd(key, sub_job_id)
+    redis.expire(key, _GENERATION_TTL_SECONDS)
+
+
+def _load_subjob_ids(redis: Redis, parent_job_id: str, generation: int) -> list[str]:
+    raw = redis.smembers(_subjobs_key(parent_job_id, generation))
     return [item.decode() if isinstance(item, bytes) else item for item in raw]
 
 
-def _clear_subjob_set(redis: Redis, parent_job_id: str) -> None:
-    redis.delete(_subjobs_key(parent_job_id))
+def _clear_subjob_set(redis: Redis, parent_job_id: str, generation: int) -> None:
+    redis.delete(_subjobs_key(parent_job_id, generation))
 
 
 def enqueue_pipeline(
@@ -165,7 +181,12 @@ def enqueue_pipeline(
 
     ctx_store = PipelineContextStore(redis, job.id)
     ctx_store.initialize(initial_context)
-    _clear_subjob_set(redis, job.id)
+    # The subjobs set is now per-generation, so we do NOT clear previous
+    # attempts' sets here. An attempt 1 sub-job set will be cleaned up by
+    # its own finalize callback (or expire naturally via _GENERATION_TTL_SECONDS),
+    # and attempt 2's callback only ever looks at its own generation's set.
+    # This is what keeps a stale attempt 1 callback from cancelling attempt
+    # 2's live sub-jobs — the mechanism that broke in Round 2 review.
 
     timeout = calculate_job_timeout(job.duration, settings)
     success_cb = Callback("whisper_ui.worker.pipeline_dispatcher.finalize_success")
@@ -192,7 +213,7 @@ def enqueue_pipeline(
             kwargs["on_success"] = success_cb
         sub = queues[queue_name].enqueue(func, job.id, **kwargs)
         enqueued.append(sub)
-        _record_subjob(redis, job.id, sub.id)
+        _record_subjob(redis, job.id, generation, sub.id)
         return sub
 
     # Build the DAG. Note the "is_final" flag is only true on the very last
@@ -261,14 +282,32 @@ def finalize_success(rq_job, connection, _result) -> None:
 
     Converts the accumulated context into a persisted transcript file,
     updates the parent Job row to COMPLETED, and clears the Redis context
-    hash + sub-job tracking set.
+    hash + sub-job tracking set for this attempt's generation.
+
+    Callback staleness: if the parent's generation counter has moved on
+    since this sub-job was enqueued (e.g. the user retried mid-pipeline),
+    the callback short-circuits without touching any state. Without this
+    guard, a stale attempt-1 success callback could mark an in-progress
+    attempt 2 as COMPLETED with attempt 1's transcript file — see PR #39
+    Round 2 review R2-1.
     """
     parent_job_id = rq_job.meta.get("parent_job_id") if rq_job.meta else None
     if not parent_job_id:
         logger.error("finalize_success invoked without parent_job_id in meta")
         return
 
+    meta_generation = _extract_meta_generation(rq_job)
+
     with build_worker_runtime(parent_job_id) as runtime:
+        if _is_stale_callback(runtime.redis, parent_job_id, meta_generation):
+            logger.warning(
+                "finalize_success dropped for job %s: stale callback from generation %s "
+                "(current generation has moved on)",
+                parent_job_id,
+                meta_generation,
+            )
+            return
+
         job = runtime.db.get_job(parent_job_id)
         if job is None:
             logger.error("finalize_success could not find parent job %s", parent_job_id)
@@ -282,7 +321,8 @@ def finalize_success(rq_job, connection, _result) -> None:
             logger.error("finalize_success for job %s: no transcript_result in context", parent_job_id)
             _mark_failed(job, runtime.db, runtime.reporter, "transcript_result missing")
             ctx_store.delete()
-            _clear_subjob_set(runtime.redis, parent_job_id)
+            if meta_generation is not None:
+                _clear_subjob_set(runtime.redis, parent_job_id, meta_generation)
             return
 
         try:
@@ -301,7 +341,46 @@ def finalize_success(rq_job, connection, _result) -> None:
         finally:
             _cleanup_preprocessed_audio(context)
             ctx_store.delete()
-            _clear_subjob_set(runtime.redis, parent_job_id)
+            if meta_generation is not None:
+                _clear_subjob_set(runtime.redis, parent_job_id, meta_generation)
+
+
+def _extract_meta_generation(rq_job) -> int | None:
+    """Pull the generation id a sub-job was enqueued under out of its RQ meta.
+
+    Sub-jobs from the legacy monolithic path (or tests that fabricate a
+    MagicMock RQ job) may not carry this field at all — treat that as
+    "no generation tracked" so the finalize callbacks fall through to
+    their original behaviour and we do not regress the legacy path.
+    """
+    if rq_job is None or not getattr(rq_job, "meta", None):
+        return None
+    raw = rq_job.meta.get("generation")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_stale_callback(redis: Redis, parent_job_id: str, meta_generation: int | None) -> bool:
+    """Return True when a finalize callback's meta generation has been
+    superseded by a retry that bumped the parent generation counter.
+
+    Degrades gracefully when either generation is unknown: if the meta
+    has no generation (legacy / fabricated job) or the Redis counter is
+    missing, we treat the callback as still valid so legacy code paths
+    and tests that don't set up the full retry machinery keep working.
+    Only a strictly-older meta generation than the current counter
+    triggers the stale short-circuit.
+    """
+    if meta_generation is None:
+        return False
+    current = _current_generation(redis, parent_job_id)
+    if current is None:
+        return False
+    return meta_generation < current
 
 
 def _format_failure_message(exc_type, exc_value) -> str:
@@ -330,18 +409,37 @@ def _format_failure_message(exc_type, exc_value) -> str:
 def finalize_failure(rq_job, connection, _exc_type, exc_value, _traceback) -> None:
     """RQ ``on_failure`` callback attached to every sub-job.
 
-    Called once per failing sub-job. The first invocation marks the parent
-    FAILED and cancels the other sub-jobs; subsequent invocations become
-    no-ops because the parent is already in a terminal state.
+    Called once per failing sub-job. The first invocation (for the
+    current generation) marks the parent FAILED and cancels the other
+    sub-jobs in the same generation; subsequent invocations from the
+    same generation are no-ops because the parent is already terminal.
+
+    Callback staleness: when the parent's generation counter has moved
+    on since this sub-job was enqueued (e.g. the user retried mid-run),
+    the callback short-circuits without cancelling or marking anything.
+    Without this guard an attempt 1 failure could mark an in-flight
+    attempt 2 as FAILED and cancel all of attempt 2's sub-jobs — the
+    exact bug from PR #39 Round 2 review R2-1 that the reproduction
+    test below covers.
     """
     parent_job_id = rq_job.meta.get("parent_job_id") if rq_job.meta else None
     if not parent_job_id:
         logger.error("finalize_failure invoked without parent_job_id in meta")
         return
 
+    meta_generation = _extract_meta_generation(rq_job)
     error_msg = _format_failure_message(_exc_type, exc_value)
 
     with build_worker_runtime(parent_job_id) as runtime:
+        if _is_stale_callback(runtime.redis, parent_job_id, meta_generation):
+            logger.warning(
+                "finalize_failure dropped for job %s: stale callback from generation %s "
+                "(current generation has moved on)",
+                parent_job_id,
+                meta_generation,
+            )
+            return
+
         job = runtime.db.get_job(parent_job_id)
         if job is None:
             logger.error("finalize_failure could not find parent job %s", parent_job_id)
@@ -358,12 +456,19 @@ def finalize_failure(rq_job, connection, _exc_type, exc_value, _traceback) -> No
         context = ctx_store.load()
 
         try:
-            _cancel_remaining_subjobs(runtime.redis, parent_job_id, exclude=rq_job.id)
+            if meta_generation is not None:
+                _cancel_remaining_subjobs(
+                    runtime.redis,
+                    parent_job_id,
+                    generation=meta_generation,
+                    exclude=rq_job.id,
+                )
             _mark_failed(job, runtime.db, runtime.reporter, error_msg)
         finally:
             _cleanup_preprocessed_audio(context)
             ctx_store.delete()
-            _clear_subjob_set(runtime.redis, parent_job_id)
+            if meta_generation is not None:
+                _clear_subjob_set(runtime.redis, parent_job_id, meta_generation)
 
 
 def _mark_failed(
@@ -379,9 +484,21 @@ def _mark_failed(
     reporter.fail(error_msg)
 
 
-def _cancel_remaining_subjobs(redis: Redis, parent_job_id: str, *, exclude: str) -> None:
-    """Stop every sub-job belonging to the same parent, except the one that
-    just failed (``exclude``).
+def _cancel_remaining_subjobs(
+    redis: Redis,
+    parent_job_id: str,
+    *,
+    generation: int,
+    exclude: str,
+) -> None:
+    """Stop every sub-job belonging to the same parent *and same
+    generation*, except the one that just failed (``exclude``).
+
+    Scoping by generation is what prevents a stale attempt-1 callback
+    from cancelling attempt 2's live sub-jobs. ``_load_subjob_ids`` only
+    returns sub-jobs that were enqueued under this exact generation; a
+    retry opens a fresh set under a new generation that stale callbacks
+    cannot see.
 
     This has to handle two distinct states for each sibling:
 
@@ -411,7 +528,7 @@ def _cancel_remaining_subjobs(redis: Redis, parent_job_id: str, *, exclude: str)
     """
     from rq.job import Job as RQJob
 
-    for sub_id in _load_subjob_ids(redis, parent_job_id):
+    for sub_id in _load_subjob_ids(redis, parent_job_id, generation):
         if sub_id == exclude:
             continue
         # Layer 1a: stop if currently running. Fire-and-forget — the stop

--- a/src/whisper_ui/worker/pipeline_dispatcher.py
+++ b/src/whisper_ui/worker/pipeline_dispatcher.py
@@ -39,6 +39,7 @@ from whisper_ui.core.messages import PIPELINE_COMPLETE
 from whisper_ui.core.models import JobStatus
 from whisper_ui.ui.labels import JOBS_TIMEOUT_ERROR
 from whisper_ui.worker.context_store import PipelineContextStore
+from whisper_ui.worker.progress import RedisProgressReporter
 from whisper_ui.worker.runtime import build_worker_runtime, extract_rq_timeout_seconds
 from whisper_ui.worker.stage_tasks import (
     run_assign_speakers,
@@ -73,7 +74,6 @@ if TYPE_CHECKING:
     from whisper_ui.core.models import Job
     from whisper_ui.storage.database import JobDatabase
     from whisper_ui.storage.filestore import FileStore
-    from whisper_ui.worker.progress import RedisProgressReporter
 
 logger = logging.getLogger(__name__)
 
@@ -316,10 +316,15 @@ def finalize_success(rq_job, connection, _result) -> None:
         ctx_store = PipelineContextStore(runtime.redis, parent_job_id)
         context = ctx_store.load()
 
+        # Build a generation-aware reporter so terminal writes (complete /
+        # fail) are gated by the Lua scripts even if the Python short-
+        # circuit above is somehow bypassed — defense in depth.
+        reporter = _build_generation_aware_reporter(runtime, parent_job_id, meta_generation)
+
         transcript_result = context.get("transcript_result")
         if transcript_result is None:
             logger.error("finalize_success for job %s: no transcript_result in context", parent_job_id)
-            _mark_failed(job, runtime.db, runtime.reporter, "transcript_result missing")
+            _mark_failed(job, runtime.db, reporter, "transcript_result missing")
             ctx_store.delete()
             if meta_generation is not None:
                 _clear_subjob_set(runtime.redis, parent_job_id, meta_generation)
@@ -335,7 +340,7 @@ def finalize_success(rq_job, connection, _result) -> None:
             job.result_path = str(result_path)
             job.duration = transcript_result.duration
             runtime.db.update_job(job)
-            runtime.reporter.complete(str(result_path))
+            reporter.complete(str(result_path))
 
             logger.info("Job %s completed successfully via DAG pipeline", parent_job_id)
         finally:
@@ -343,6 +348,25 @@ def finalize_success(rq_job, connection, _result) -> None:
             ctx_store.delete()
             if meta_generation is not None:
                 _clear_subjob_set(runtime.redis, parent_job_id, meta_generation)
+
+
+def _build_generation_aware_reporter(runtime, parent_job_id: str, generation: int | None) -> RedisProgressReporter:
+    """Build a reporter that stamps its terminal writes with ``generation``.
+
+    The finalize callbacks use this to make sure a stale attempt-1
+    ``reporter.complete()`` or ``reporter.fail()`` — which would otherwise
+    race past the Python short-circuit via a partial corruption of the
+    progress hash — is dropped by the Lua scripts server-side. When the
+    caller has no generation (legacy path, fabricated MagicMock RQ
+    job), the reporter falls back to legacy semantics so existing tests
+    and the monolithic worker path stay bit-for-bit compatible.
+    """
+    return RedisProgressReporter(
+        runtime.redis,
+        parent_job_id,
+        processing_ttl=runtime.settings.redis_processing_expiry,
+        generation=generation,
+    )
 
 
 def _extract_meta_generation(rq_job) -> int | None:
@@ -455,6 +479,12 @@ def finalize_failure(rq_job, connection, _exc_type, exc_value, _traceback) -> No
         ctx_store = PipelineContextStore(runtime.redis, parent_job_id)
         context = ctx_store.load()
 
+        # Build a generation-aware reporter for the same defense-in-depth
+        # reason as finalize_success: even if the Python short-circuit
+        # above is bypassed by a pathological call, the Lua fail script
+        # still refuses to overwrite a newer attempt's hash.
+        reporter = _build_generation_aware_reporter(runtime, parent_job_id, meta_generation)
+
         try:
             if meta_generation is not None:
                 _cancel_remaining_subjobs(
@@ -463,7 +493,7 @@ def finalize_failure(rq_job, connection, _exc_type, exc_value, _traceback) -> No
                     generation=meta_generation,
                     exclude=rq_job.id,
                 )
-            _mark_failed(job, runtime.db, runtime.reporter, error_msg)
+            _mark_failed(job, runtime.db, reporter, error_msg)
         finally:
             _cleanup_preprocessed_audio(context)
             ctx_store.delete()

--- a/src/whisper_ui/worker/progress.py
+++ b/src/whisper_ui/worker/progress.py
@@ -24,30 +24,83 @@ logger = logging.getLogger(__name__)
 # not leave orphaned progress keys around for the whole completed-job window.
 _DEFAULT_PROCESSING_TTL = 7200
 
+# Sentinel meaning "no generation check" in the Lua scripts. Callers that
+# did not attach a generation (legacy monolithic path, tests that predate
+# the generation machinery) pass this as caller_gen and the scripts skip
+# every generation-related branch, falling back to their pre-Round-2
+# max-write / unconditional-replace semantics.
+_NO_GENERATION = -1
 
-# Atomic "max-write" script for parallel-branch progress reporting.
+
+# Atomic generation-aware max-write for progress reports.
 #
-# Background: in the DAG pipeline, ``transcribe_align`` and ``diarize`` run
-# as sibling sub-jobs in separate worker processes. Both hold a progress
-# reporter bound to the same parent job_id and both can ``HSET`` the
-# ``progress`` field concurrently. A straight ``HSET`` would let whichever
-# write lands last win, which means the user's progress bar can visibly
-# jump backwards (e.g. diarize at 0.72 → transcribe interleaves with 0.40 →
-# bar rewinds to 0.40). The in-process throttled guard inside
-# ``make_throttled_progress_reporter`` only protects a single closure, not
-# two sibling workers.
+# Three branches, in priority order:
 #
-# This Lua script runs server-side so the HGET / compare / HSET are one
-# atomic operation. Progress only advances when the new value is >= the
-# current one; ``message`` and ``status`` always update (message transitions
-# between stages are information the user wants even if progress happens to
-# stay the same, and ``status`` can only monotonically stay on "processing"
-# until ``complete``/``fail`` is called).
+# 1. ``caller_gen < 0`` (sentinel) → legacy mode. No generation tracking.
+#    Max-write by progress value; message and status always update.
+#    Existing Phase 2 semantics, preserved so the legacy ``tasks.py``
+#    path and any reporter built via ``build_worker_runtime`` without a
+#    generation stays bit-for-bit compatible.
+#
+# 2. ``caller_gen > stored_gen`` (including stored_gen missing) → reset.
+#    A fresh attempt is taking over the progress hash. Unconditionally
+#    overwrite progress / message / status and stamp the new generation.
+#    This is the path that unblocks "attempt 2 wants to start from 0.05
+#    after attempt 1 was pinned at 0.85" — the Round 2 R2-2 scenario
+#    the reproducer in the plan exercises end-to-end.
+#
+# 3. ``caller_gen == stored_gen`` → max-write within the attempt. Same
+#    semantics as the Phase 2 script: progress only advances, message
+#    still updates even when progress holds so the UI can switch stage
+#    labels mid-attempt.
+#
+# 4. ``caller_gen < stored_gen`` → drop. A late writer from a superseded
+#    attempt is trying to touch a hash that already belongs to a newer
+#    attempt. Silently ignore it and return 0 so Python-level metrics
+#    can count if desired.
 _PROGRESS_MAX_WRITE_LUA = """
 local key = KEYS[1]
 local new_progress = tonumber(ARGV[1])
 local message = ARGV[2]
 local ttl = tonumber(ARGV[3])
+local caller_gen = tonumber(ARGV[4])
+
+if caller_gen < 0 then
+  -- Legacy mode: no generation tracking at all. Max-write.
+  local current = redis.call('HGET', key, 'progress')
+  if (not current) or (new_progress >= tonumber(current)) then
+    redis.call('HSET', key, 'progress', tostring(new_progress),
+               'message', message, 'status', 'processing')
+  else
+    redis.call('HSET', key, 'message', message, 'status', 'processing')
+  end
+  redis.call('EXPIRE', key, ttl)
+  return 1
+end
+
+local stored_gen_raw = redis.call('HGET', key, 'generation')
+local stored_gen = nil
+if stored_gen_raw then
+  stored_gen = tonumber(stored_gen_raw)
+end
+
+if (not stored_gen) or caller_gen > stored_gen then
+  -- New attempt takes over: reset the hash unconditionally.
+  redis.call('HSET', key,
+    'progress', tostring(new_progress),
+    'message', message,
+    'status', 'processing',
+    'generation', tostring(caller_gen))
+  redis.call('EXPIRE', key, ttl)
+  return 1
+end
+
+if caller_gen < stored_gen then
+  -- Stale writer from a superseded attempt. Drop silently.
+  return 0
+end
+
+-- Same generation as the hash: normal max-write semantics.
 local current = redis.call('HGET', key, 'progress')
 if (not current) or (new_progress >= tonumber(current)) then
   redis.call('HSET', key, 'progress', tostring(new_progress),
@@ -60,22 +113,120 @@ return 1
 """
 
 
+# Atomic generation-aware terminal write for complete().
+#
+# Mirrors the max-write script's generation logic but writes the
+# terminal "completed" hash contents when the generation check passes.
+# Terminal writes are unconditional within the caller's generation: a
+# stage that believes the pipeline is done owns the hash regardless of
+# what progress value was previously stored.
+_PROGRESS_COMPLETE_LUA = """
+local key = KEYS[1]
+local result_path = ARGV[1]
+local pipeline_complete_msg = ARGV[2]
+local ttl = tonumber(ARGV[3])
+local caller_gen = tonumber(ARGV[4])
+
+if caller_gen >= 0 then
+  local stored_gen_raw = redis.call('HGET', key, 'generation')
+  if stored_gen_raw then
+    local stored_gen = tonumber(stored_gen_raw)
+    if stored_gen and caller_gen < stored_gen then
+      return 0
+    end
+  end
+end
+
+redis.call('HSET', key,
+  'progress', '1.0',
+  'message', pipeline_complete_msg,
+  'status', 'completed',
+  'result_path', result_path)
+if caller_gen >= 0 then
+  redis.call('HSET', key, 'generation', tostring(caller_gen))
+end
+redis.call('EXPIRE', key, ttl)
+return 1
+"""
+
+
+# Atomic generation-aware terminal write for fail().
+_PROGRESS_FAIL_LUA = """
+local key = KEYS[1]
+local message = ARGV[1]
+local error_text = ARGV[2]
+local ttl = tonumber(ARGV[3])
+local caller_gen = tonumber(ARGV[4])
+
+if caller_gen >= 0 then
+  local stored_gen_raw = redis.call('HGET', key, 'generation')
+  if stored_gen_raw then
+    local stored_gen = tonumber(stored_gen_raw)
+    if stored_gen and caller_gen < stored_gen then
+      return 0
+    end
+  end
+end
+
+redis.call('HSET', key,
+  'progress', '0.0',
+  'message', message,
+  'status', 'failed',
+  'error', error_text)
+if caller_gen >= 0 then
+  redis.call('HSET', key, 'generation', tostring(caller_gen))
+end
+redis.call('EXPIRE', key, ttl)
+return 1
+"""
+
+
 class RedisProgressReporter:
+    """Best-effort progress / terminal-state writer for a single job.
+
+    ``generation`` scopes every write to an attempt. When provided the
+    reporter's report/complete/fail calls go through the generation-aware
+    Lua scripts above, so a stale writer from a superseded attempt has
+    its writes dropped server-side and cannot corrupt the new attempt's
+    progress hash. When left as ``None`` the scripts fall back to legacy
+    semantics (max-write for report, unconditional replace for
+    complete/fail) — this keeps the pre-Round-2 behaviour for the
+    legacy ``worker.tasks.process_transcription`` path and for any
+    caller that does not yet know which attempt it belongs to.
+    """
+
     def __init__(
         self,
         redis: Redis,
         job_id: str,
         *,
         processing_ttl: int = _DEFAULT_PROCESSING_TTL,
+        generation: int | None = None,
     ) -> None:
         self._redis = redis
         self._job_id = job_id
         self._key = f"job:{job_id}"
         self._processing_ttl = processing_ttl
-        # register_script loads the script lazily; the first call goes
+        self._generation = generation
+        # register_script loads each script lazily; the first call goes
         # through EVAL and subsequent calls reuse the cached SHA via
         # EVALSHA, which is cheap on the network path.
         self._max_write_script = redis.register_script(_PROGRESS_MAX_WRITE_LUA)
+        self._complete_script = redis.register_script(_PROGRESS_COMPLETE_LUA)
+        self._fail_script = redis.register_script(_PROGRESS_FAIL_LUA)
+
+    @property
+    def generation(self) -> int | None:
+        return self._generation
+
+    def _caller_gen_arg(self) -> int:
+        """Translate the optional generation into the Lua sentinel encoding.
+
+        ``None`` in Python becomes ``-1`` in the script, which short-
+        circuits every generation branch and falls back to legacy
+        semantics. Any non-negative integer is passed through as-is.
+        """
+        return _NO_GENERATION if self._generation is None else int(self._generation)
 
     def report(self, progress: float, message: str) -> None:
         # Progress reports are best-effort: SQLite remains the source of
@@ -85,38 +236,31 @@ class RedisProgressReporter:
         try:
             self._max_write_script(
                 keys=[self._key],
-                args=[progress, message, self._processing_ttl],
+                args=[progress, message, self._processing_ttl, self._caller_gen_arg()],
             )
         except RedisError:
             logger.warning("Redis progress write failed for %s", self._job_id, exc_info=True)
 
     def complete(self, result_path: str) -> None:
         try:
-            self._redis.hset(
-                self._key,
-                mapping={
-                    "progress": "1.0",
-                    "message": PIPELINE_COMPLETE,
-                    "status": "completed",
-                    "result_path": result_path,
-                },
+            self._complete_script(
+                keys=[self._key],
+                args=[result_path, PIPELINE_COMPLETE, REDIS_COMPLETED_EXPIRY, self._caller_gen_arg()],
             )
-            self._redis.expire(self._key, REDIS_COMPLETED_EXPIRY)
         except RedisError:
             logger.warning("Redis complete write failed for %s", self._job_id, exc_info=True)
 
     def fail(self, error: str) -> None:
         try:
-            self._redis.hset(
-                self._key,
-                mapping={
-                    "progress": "0.0",
-                    "message": error[:MESSAGE_MAX_LENGTH],
-                    "status": "failed",
-                    "error": error[:ERROR_MAX_LENGTH],
-                },
+            self._fail_script(
+                keys=[self._key],
+                args=[
+                    error[:MESSAGE_MAX_LENGTH],
+                    error[:ERROR_MAX_LENGTH],
+                    REDIS_FAILED_EXPIRY,
+                    self._caller_gen_arg(),
+                ],
             )
-            self._redis.expire(self._key, REDIS_FAILED_EXPIRY)
         except RedisError:
             logger.warning("Redis fail write failed for %s", self._job_id, exc_info=True)
 

--- a/src/whisper_ui/worker/progress.py
+++ b/src/whisper_ui/worker/progress.py
@@ -228,31 +228,53 @@ class RedisProgressReporter:
         """
         return _NO_GENERATION if self._generation is None else int(self._generation)
 
-    def report(self, progress: float, message: str) -> None:
-        # Progress reports are best-effort: SQLite remains the source of
-        # truth for job state. A transient Redis outage mid-job must not
-        # take down the worker — log and swallow so the pipeline keeps
-        # running and the user only loses live progress updates.
+    def report(self, progress: float, message: str) -> bool:
+        """Attempt a generation-gated max-write.
+
+        Returns ``True`` when the Lua script accepted the write (or when
+        ``generation`` is None, meaning legacy max-write semantics always
+        accept), ``False`` when the script explicitly rejected a stale
+        write (``caller_gen < stored_gen``).
+
+        Transient Redis outages are swallowed and reported as accepted so
+        the legacy throttler path keeps writing to SQLite — SQLite is the
+        source of truth when Redis is unavailable. Only an explicit "Lua
+        returned 0" is surfaced to the caller as a rejection signal, and
+        that only happens in exactly one branch of the script: a stage
+        attempting to write under a superseded generation. ``runtime.
+        make_throttled_progress_reporter`` uses this signal to skip its
+        DB mirror so a stale Job snapshot cannot overwrite the current
+        attempt's row via the full-column ``update_job`` UPDATE path.
+        """
         try:
-            self._max_write_script(
+            result = self._max_write_script(
                 keys=[self._key],
                 args=[progress, message, self._processing_ttl, self._caller_gen_arg()],
             )
         except RedisError:
             logger.warning("Redis progress write failed for %s", self._job_id, exc_info=True)
+            # SQLite is the source of truth during transient Redis outages;
+            # treating the write as accepted lets the throttler keep the DB
+            # mirror fresh even when Redis is down.
+            return True
+        return int(result) != 0
 
-    def complete(self, result_path: str) -> None:
+    def complete(self, result_path: str) -> bool:
+        """Terminal-state write. See :meth:`report` for the bool contract."""
         try:
-            self._complete_script(
+            result = self._complete_script(
                 keys=[self._key],
                 args=[result_path, PIPELINE_COMPLETE, REDIS_COMPLETED_EXPIRY, self._caller_gen_arg()],
             )
         except RedisError:
             logger.warning("Redis complete write failed for %s", self._job_id, exc_info=True)
+            return True
+        return int(result) != 0
 
-    def fail(self, error: str) -> None:
+    def fail(self, error: str) -> bool:
+        """Terminal-state write. See :meth:`report` for the bool contract."""
         try:
-            self._fail_script(
+            result = self._fail_script(
                 keys=[self._key],
                 args=[
                     error[:MESSAGE_MAX_LENGTH],
@@ -263,6 +285,8 @@ class RedisProgressReporter:
             )
         except RedisError:
             logger.warning("Redis fail write failed for %s", self._job_id, exc_info=True)
+            return True
+        return int(result) != 0
 
     @staticmethod
     def get_progress(redis: Redis, job_id: str) -> dict[str, str]:

--- a/src/whisper_ui/worker/progress.py
+++ b/src/whisper_ui/worker/progress.py
@@ -25,6 +25,41 @@ logger = logging.getLogger(__name__)
 _DEFAULT_PROCESSING_TTL = 7200
 
 
+# Atomic "max-write" script for parallel-branch progress reporting.
+#
+# Background: in the DAG pipeline, ``transcribe_align`` and ``diarize`` run
+# as sibling sub-jobs in separate worker processes. Both hold a progress
+# reporter bound to the same parent job_id and both can ``HSET`` the
+# ``progress`` field concurrently. A straight ``HSET`` would let whichever
+# write lands last win, which means the user's progress bar can visibly
+# jump backwards (e.g. diarize at 0.72 → transcribe interleaves with 0.40 →
+# bar rewinds to 0.40). The in-process throttled guard inside
+# ``make_throttled_progress_reporter`` only protects a single closure, not
+# two sibling workers.
+#
+# This Lua script runs server-side so the HGET / compare / HSET are one
+# atomic operation. Progress only advances when the new value is >= the
+# current one; ``message`` and ``status`` always update (message transitions
+# between stages are information the user wants even if progress happens to
+# stay the same, and ``status`` can only monotonically stay on "processing"
+# until ``complete``/``fail`` is called).
+_PROGRESS_MAX_WRITE_LUA = """
+local key = KEYS[1]
+local new_progress = tonumber(ARGV[1])
+local message = ARGV[2]
+local ttl = tonumber(ARGV[3])
+local current = redis.call('HGET', key, 'progress')
+if (not current) or (new_progress >= tonumber(current)) then
+  redis.call('HSET', key, 'progress', tostring(new_progress),
+             'message', message, 'status', 'processing')
+else
+  redis.call('HSET', key, 'message', message, 'status', 'processing')
+end
+redis.call('EXPIRE', key, ttl)
+return 1
+"""
+
+
 class RedisProgressReporter:
     def __init__(
         self,
@@ -37,6 +72,10 @@ class RedisProgressReporter:
         self._job_id = job_id
         self._key = f"job:{job_id}"
         self._processing_ttl = processing_ttl
+        # register_script loads the script lazily; the first call goes
+        # through EVAL and subsequent calls reuse the cached SHA via
+        # EVALSHA, which is cheap on the network path.
+        self._max_write_script = redis.register_script(_PROGRESS_MAX_WRITE_LUA)
 
     def report(self, progress: float, message: str) -> None:
         # Progress reports are best-effort: SQLite remains the source of
@@ -44,15 +83,10 @@ class RedisProgressReporter:
         # take down the worker — log and swallow so the pipeline keeps
         # running and the user only loses live progress updates.
         try:
-            self._redis.hset(
-                self._key,
-                mapping={
-                    "progress": str(progress),
-                    "message": message,
-                    "status": "processing",
-                },
+            self._max_write_script(
+                keys=[self._key],
+                args=[progress, message, self._processing_ttl],
             )
-            self._redis.expire(self._key, self._processing_ttl)
         except RedisError:
             logger.warning("Redis progress write failed for %s", self._job_id, exc_info=True)
 

--- a/src/whisper_ui/worker/progress.py
+++ b/src/whisper_ui/worker/progress.py
@@ -78,6 +78,23 @@ if caller_gen < 0 then
   return 1
 end
 
+-- Authoritative check: the central generation counter at KEYS[2] is the
+-- source of truth for which attempt currently owns the pipeline. The
+-- hash-embedded generation (checked further down) is an optimisation
+-- that avoids the extra GET when the hash is already stamped, but after
+-- the retry route deletes the progress hash the embedded field vanishes.
+-- Without this central-counter check, a stale gen=1 writer arriving
+-- after the delete would walk into the "(not stored_gen)" reset branch
+-- and be accepted — the exact Round-4 review race window.
+local central_gen_key = KEYS[2]
+local central_gen_raw = redis.call('GET', central_gen_key)
+if central_gen_raw then
+  local central_gen = tonumber(central_gen_raw)
+  if central_gen and caller_gen < central_gen then
+    return 0
+  end
+end
+
 local stored_gen_raw = redis.call('HGET', key, 'generation')
 local stored_gen = nil
 if stored_gen_raw then
@@ -128,6 +145,13 @@ local ttl = tonumber(ARGV[3])
 local caller_gen = tonumber(ARGV[4])
 
 if caller_gen >= 0 then
+  local central_gen_raw = redis.call('GET', KEYS[2])
+  if central_gen_raw then
+    local central_gen = tonumber(central_gen_raw)
+    if central_gen and caller_gen < central_gen then
+      return 0
+    end
+  end
   local stored_gen_raw = redis.call('HGET', key, 'generation')
   if stored_gen_raw then
     local stored_gen = tonumber(stored_gen_raw)
@@ -159,6 +183,13 @@ local ttl = tonumber(ARGV[3])
 local caller_gen = tonumber(ARGV[4])
 
 if caller_gen >= 0 then
+  local central_gen_raw = redis.call('GET', KEYS[2])
+  if central_gen_raw then
+    local central_gen = tonumber(central_gen_raw)
+    if central_gen and caller_gen < central_gen then
+      return 0
+    end
+  end
   local stored_gen_raw = redis.call('HGET', key, 'generation')
   if stored_gen_raw then
     local stored_gen = tonumber(stored_gen_raw)
@@ -206,6 +237,13 @@ class RedisProgressReporter:
         self._redis = redis
         self._job_id = job_id
         self._key = f"job:{job_id}"
+        # Central generation counter — the authoritative source for which
+        # attempt currently owns the pipeline. Lua scripts read this via
+        # KEYS[2] as a belt-and-suspenders check on top of the hash-level
+        # generation field. Closing the Round-4 window where the retry
+        # route deletes the hash (wiping the embedded generation) but the
+        # central counter has already been bumped.
+        self._generation_key = f"whisper:pipeline:{job_id}:generation"
         self._processing_ttl = processing_ttl
         self._generation = generation
         # register_script loads each script lazily; the first call goes
@@ -248,7 +286,7 @@ class RedisProgressReporter:
         """
         try:
             result = self._max_write_script(
-                keys=[self._key],
+                keys=[self._key, self._generation_key],
                 args=[progress, message, self._processing_ttl, self._caller_gen_arg()],
             )
         except RedisError:
@@ -263,7 +301,7 @@ class RedisProgressReporter:
         """Terminal-state write. See :meth:`report` for the bool contract."""
         try:
             result = self._complete_script(
-                keys=[self._key],
+                keys=[self._key, self._generation_key],
                 args=[result_path, PIPELINE_COMPLETE, REDIS_COMPLETED_EXPIRY, self._caller_gen_arg()],
             )
         except RedisError:
@@ -275,7 +313,7 @@ class RedisProgressReporter:
         """Terminal-state write. See :meth:`report` for the bool contract."""
         try:
             result = self._fail_script(
-                keys=[self._key],
+                keys=[self._key, self._generation_key],
                 args=[
                     error[:MESSAGE_MAX_LENGTH],
                     error[:ERROR_MAX_LENGTH],

--- a/src/whisper_ui/worker/runtime.py
+++ b/src/whisper_ui/worker/runtime.py
@@ -135,7 +135,26 @@ def make_throttled_progress_reporter(
                 if delta < min_delta and (now - last_written_at) < min_interval_sec:
                     return
 
-            reporter.report(progress, message)
+            # The reporter returns False exactly when its Lua script
+            # determined the caller's generation is strictly older than
+            # the stored one (i.e. the parent job has been retried under
+            # a newer attempt). In that case we must NOT touch the Job
+            # object or the SQLite row: db.update_job performs a
+            # full-column UPDATE from the in-memory snapshot, so a stale
+            # Job captured by this closure would overwrite the current
+            # attempt's status / result_path / error fields. Silently
+            # drop the DB mirror and leave the closure's monotonic /
+            # throttle state untouched so a subsequent (equally stale)
+            # call takes the same fast path instead of slipping through.
+            accepted = reporter.report(progress, message)
+            if not accepted:
+                logger.debug(
+                    "progress write for %s dropped server-side (stale generation); "
+                    "skipping DB mirror to avoid overwriting the current attempt",
+                    job.id,
+                )
+                return
+
             job.progress = progress
             job.progress_message = message
             db.update_job(job)

--- a/src/whisper_ui/worker/runtime.py
+++ b/src/whisper_ui/worker/runtime.py
@@ -1,0 +1,153 @@
+"""Shared worker runtime helpers used by both the legacy monolithic task and
+the per-stage DAG entrypoints.
+
+``build_worker_runtime`` centralises the boilerplate of loading settings,
+opening Redis / SQLite connections, and wiring up a progress reporter, so
+every worker task can access those shared resources the same way. A context
+manager is used so the caller gets deterministic cleanup (database close)
+regardless of whether the task completes, raises, or is killed.
+
+``make_throttled_progress_reporter`` is re-exported from here so it lives
+alongside the other runtime helpers.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from redis import Redis
+
+from whisper_ui.core.config import get_settings
+from whisper_ui.core.constants import (
+    PROGRESS_WRITE_MIN_DELTA,
+    PROGRESS_WRITE_MIN_INTERVAL_SEC,
+)
+from whisper_ui.storage.database import JobDatabase
+from whisper_ui.storage.filestore import FileStore
+from whisper_ui.worker.progress import RedisProgressReporter
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from whisper_ui.core.config import Settings
+    from whisper_ui.core.models import Job
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class WorkerRuntime:
+    """Bundle of shared resources a worker task needs for one invocation.
+
+    Acquired via :func:`build_worker_runtime`. The ``db`` handle is closed
+    automatically when the context manager exits.
+    """
+
+    settings: Settings
+    redis: Redis
+    reporter: RedisProgressReporter
+    db: JobDatabase
+    filestore: FileStore
+
+
+@contextmanager
+def build_worker_runtime(job_id: str) -> Iterator[WorkerRuntime]:
+    """Open the shared worker resources tied to a single job execution.
+
+    The same ``job_id`` is used as the Redis progress key so all sub-tasks
+    belonging to the same parent job converge onto a single progress hash.
+    """
+    settings = get_settings()
+    redis = Redis.from_url(settings.redis_url)
+    reporter = RedisProgressReporter(
+        redis,
+        job_id,
+        processing_ttl=settings.redis_processing_expiry,
+    )
+    db = JobDatabase(settings.database_path)
+    filestore = FileStore(settings.upload_dir, settings.output_dir)
+    try:
+        yield WorkerRuntime(
+            settings=settings,
+            redis=redis,
+            reporter=reporter,
+            db=db,
+            filestore=filestore,
+        )
+    finally:
+        db.close()
+
+
+def make_throttled_progress_reporter(
+    reporter: RedisProgressReporter,
+    db: JobDatabase,
+    job: Job,
+    *,
+    min_delta: float = PROGRESS_WRITE_MIN_DELTA,
+    min_interval_sec: float = PROGRESS_WRITE_MIN_INTERVAL_SEC,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> Callable[[float, str], None]:
+    """Wrap progress callbacks so high-frequency sub-stage updates do not
+    thrash SQLite and Redis.
+
+    The throttle drops a report when both of these hold:
+    - progress moved less than ``min_delta`` from the last written value,
+    - less than ``min_interval_sec`` has elapsed since the last write.
+
+    It always flushes when the message changes (stage transition, state
+    flip), on the very first call, and whenever progress reaches 1.0, so
+    no user-visible milestone is ever swallowed.
+    """
+    last_progress = -1.0
+    last_written_at = 0.0
+    last_message = ""
+    # The diarize heartbeat invokes ``report`` from a background thread while
+    # the main thread is blocked inside the C++ inference call, so in normal
+    # operation only one thread mutates the closure state at a time. The lock
+    # is cheap defence-in-depth: it guarantees the read-decide-write sequence
+    # below is atomic even if some future stage spawns a worker thread that
+    # also calls on_progress.
+    lock = threading.Lock()
+
+    def report(progress: float, message: str) -> None:
+        nonlocal last_progress, last_written_at, last_message
+
+        with lock:
+            # Monotonicity guard: drop any in-closure regression unconditionally,
+            # even if the message changed. The only realistic source of one is a
+            # late diarize heartbeat racing the main thread's DIARIZE_DONE flush;
+            # letting it through would visibly rewind the bar from 100% back to
+            # ~94%. Worker retries always spin up a fresh closure, so legitimate
+            # rewinds never reach this point.
+            if last_progress >= 0 and progress < last_progress:
+                return
+
+            now = monotonic()
+            force = last_progress < 0 or message != last_message or progress >= 1.0
+            if not force:
+                delta = progress - last_progress
+                if delta < min_delta and (now - last_written_at) < min_interval_sec:
+                    return
+
+            reporter.report(progress, message)
+            job.progress = progress
+            job.progress_message = message
+            db.update_job(job)
+
+            last_progress = progress
+            last_written_at = now
+            last_message = message
+
+    return report
+
+
+__all__ = [
+    "WorkerRuntime",
+    "build_worker_runtime",
+    "make_throttled_progress_reporter",
+]

--- a/src/whisper_ui/worker/runtime.py
+++ b/src/whisper_ui/worker/runtime.py
@@ -14,6 +14,7 @@ alongside the other runtime helpers.
 from __future__ import annotations
 
 import logging
+import re
 import threading
 import time
 from contextlib import contextmanager
@@ -146,8 +147,47 @@ def make_throttled_progress_reporter(
     return report
 
 
+_RQ_TIMEOUT_MESSAGE_PATTERN = re.compile(r"\((\d+)\s*seconds?\)")
+
+
+def extract_rq_timeout_seconds(exc: BaseException) -> int | str:
+    """Return the configured RQ ``job_timeout`` for the running job.
+
+    RQ's death-penalty handler formats the timeout into the exception
+    *message* but does not attach it as an attribute on the exception
+    instance (see ``rq.timeouts.UnixSignalDeathPenalty.handle_death_penalty``
+    in RQ 2.7.0). So:
+
+    1. In a real worker context, ``rq.get_current_job().timeout`` holds the
+       actual configured value from enqueue time.
+    2. Outside a worker context (unit tests that call the worker entrypoints
+       directly, or the DAG failure callback which runs outside the timing-
+       out job itself), fall back to parsing the formatted message.
+    3. If both fail, return ``"?"`` so the error label still renders.
+
+    Lives in ``runtime`` rather than ``tasks`` because both the legacy
+    monolithic worker and the DAG ``finalize_failure`` callback need to
+    produce the same Chinese timeout label when surfacing the error back
+    to the user — sharing the extractor keeps the two paths in lockstep.
+    """
+    try:
+        from rq import get_current_job
+
+        current = get_current_job()
+        if current is not None and current.timeout:
+            return current.timeout
+    except Exception:
+        logger.debug("rq.get_current_job() unavailable while extracting timeout", exc_info=True)
+
+    match = _RQ_TIMEOUT_MESSAGE_PATTERN.search(str(exc))
+    if match:
+        return int(match.group(1))
+    return "?"
+
+
 __all__ = [
     "WorkerRuntime",
     "build_worker_runtime",
+    "extract_rq_timeout_seconds",
     "make_throttled_progress_reporter",
 ]

--- a/src/whisper_ui/worker/stage_tasks.py
+++ b/src/whisper_ui/worker/stage_tasks.py
@@ -1,0 +1,336 @@
+"""Per-stage RQ task entrypoints for the parallel pipeline DAG.
+
+Each ``run_*`` function is a single RQ job. The dispatcher assembles these
+into a DAG per pipeline run, passing the parent job id only — the actual
+pipeline context lives in Redis and is read/written through
+:class:`PipelineContextStore` so that fan-out branches can run in different
+worker processes.
+
+The ``transcribe`` and ``align`` stages are merged into
+``run_transcribe_align`` because they share an in-memory audio buffer that is
+expensive to serialize across processes and always run back-to-back on the
+same GPU worker anyway. Diarize stays separate so it can fan out to a second
+GPU worker when multiple cards are available.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from rq.timeouts import BaseTimeoutException
+
+from whisper_ui.core.exceptions import PipelineError
+from whisper_ui.pipeline.align import AlignStage
+from whisper_ui.pipeline.assign_speakers import AssignSpeakersStage
+from whisper_ui.pipeline.diarize import DiarizeStage
+from whisper_ui.pipeline.download import DownloadStage
+from whisper_ui.pipeline.postprocess import PostprocessStage
+from whisper_ui.pipeline.preprocess import PreprocessStage
+from whisper_ui.pipeline.progress_bands import (
+    STAGE_WEIGHTS,
+    STAGE_WEIGHTS_WITH_DOWNLOAD,
+    STAGE_WEIGHTS_WITH_DOWNLOAD_AND_LLM,
+    STAGE_WEIGHTS_WITH_LLM,
+    StageWeights,
+)
+from whisper_ui.pipeline.transcribe import TranscribeStage
+from whisper_ui.worker.context_store import PipelineContextStore
+from whisper_ui.worker.runtime import (
+    WorkerRuntime,
+    build_worker_runtime,
+    make_throttled_progress_reporter,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from whisper_ui.core.models import Job
+    from whisper_ui.pipeline.base import PipelineStage, ProgressCallback
+
+logger = logging.getLogger(__name__)
+
+
+def _llm_is_active(job: Job, runtime: WorkerRuntime) -> bool:
+    """Return whether LLM correction should be part of this job's pipeline.
+
+    Mirrors the trigger in :mod:`whisper_ui.worker.tasks`: the user must have
+    opted in *and* the deployment must expose an Ollama endpoint. The pair is
+    used both to select the right progress weight table and to decide whether
+    to enqueue a ``run_llm_correction`` sub-job.
+    """
+    return bool(job.llm_correction_enabled) and bool(runtime.settings.ollama_base_url)
+
+
+def pick_stage_weights(job: Job, runtime: WorkerRuntime) -> StageWeights:
+    """Select the stage weight table that matches this job's pipeline shape."""
+    has_download = bool(job.source_url)
+    llm_active = _llm_is_active(job, runtime)
+    if has_download and llm_active:
+        return STAGE_WEIGHTS_WITH_DOWNLOAD_AND_LLM
+    if has_download:
+        return STAGE_WEIGHTS_WITH_DOWNLOAD
+    if llm_active:
+        return STAGE_WEIGHTS_WITH_LLM
+    return STAGE_WEIGHTS
+
+
+def _load_job(runtime: WorkerRuntime, parent_job_id: str) -> Job:
+    job = runtime.db.get_job(parent_job_id)
+    if job is None:
+        raise PipelineError(f"Job {parent_job_id} not found while running stage task")
+    return job
+
+
+def _banded_progress(
+    throttled: Callable[[float, str], None],
+    band: tuple[float, float],
+) -> ProgressCallback:
+    """Wrap a throttled reporter so stages can emit local [0, 1] progress.
+
+    Each stage's local progress is linearly mapped into its global band using
+    the same formula the legacy orchestrator applied.
+    """
+    start, end = band
+    span = end - start
+
+    def on_progress(local: float, message: str) -> None:
+        global_progress = start + local * span
+        throttled(global_progress, message)
+
+    return on_progress
+
+
+def _execute_stage(
+    stage: PipelineStage,
+    context: dict[str, Any],
+    on_progress: ProgressCallback,
+    *,
+    stage_name: str,
+) -> dict[str, Any]:
+    """Run a stage and convert non-timeout failures into ``PipelineError``.
+
+    This mirrors the legacy orchestrator's contract so stage tasks emit the
+    same error shape the worker-tasks layer already knows how to classify.
+    """
+    try:
+        updated = stage.execute(context, on_progress=on_progress)
+    except BaseTimeoutException:
+        raise
+    except PipelineError:
+        raise
+    except Exception as e:
+        raise PipelineError(f"Stage '{stage_name}' failed: {e}") from e
+    finally:
+        stage.cleanup()
+    return updated
+
+
+def _persist_outputs(
+    ctx_store: PipelineContextStore,
+    updated: dict[str, Any],
+    output_keys: tuple[str, ...],
+) -> None:
+    """Write only the declared outputs back to the context store.
+
+    Declaring outputs explicitly (instead of diffing the whole dict) keeps
+    fan-in safe: two concurrent branches writing to disjoint keys never stomp
+    each other, and large intermediates that should not leave the producing
+    process (e.g. ``whisperx_audio``) are automatically excluded.
+    """
+    updates = {key: updated[key] for key in output_keys if key in updated}
+    ctx_store.update(updates)
+
+
+def _run_single_stage(
+    parent_job_id: str,
+    *,
+    stage_name: str,
+    build_stage: Callable[[Job, WorkerRuntime], PipelineStage],
+    output_keys: tuple[str, ...],
+    pre_context_update: Callable[[Job, WorkerRuntime, dict[str, Any]], None] | None = None,
+) -> str:
+    """Shared driver used by every ``run_*`` entry below.
+
+    ``pre_context_update`` lets stages that need to seed context fields from
+    the live ``Job`` record (e.g. download preparing ``download_dir``) do so
+    without duplicating the runtime setup.
+    """
+    with build_worker_runtime(parent_job_id) as runtime:
+        job = _load_job(runtime, parent_job_id)
+        ctx_store = PipelineContextStore(runtime.redis, parent_job_id)
+        context = ctx_store.load()
+
+        if pre_context_update is not None:
+            pre_context_update(job, runtime, context)
+
+        stage = build_stage(job, runtime)
+        throttled = make_throttled_progress_reporter(runtime.reporter, runtime.db, job)
+        weights = pick_stage_weights(job, runtime)
+        band = weights.get(stage_name, (0.0, 1.0))
+        on_progress = _banded_progress(throttled, band)
+
+        updated = _execute_stage(stage, context.copy(), on_progress, stage_name=stage_name)
+        _persist_outputs(ctx_store, updated, output_keys)
+
+        logger.info("Stage %s finished for job %s", stage_name, parent_job_id)
+        return f"{stage_name}:{parent_job_id}"
+
+
+def _seed_download_context(job: Job, runtime: WorkerRuntime, context: dict[str, Any]) -> None:
+    """Ensure download-specific context keys exist when the pipeline starts
+    from a URL source.
+    """
+    context.setdefault("source_url", job.source_url or "")
+    download_dir = str(runtime.filestore.prepare_upload_path(job.id, "_").parent)
+    context["download_dir"] = download_dir
+    context["input_path"] = context.get("input_path", "")
+    # Persist the seeded keys so DownloadStage running in this same task
+    # sees them after it reloads via its own context argument.
+    ctx_store = PipelineContextStore(runtime.redis, job.id)
+    ctx_store.update(
+        {
+            "source_url": context["source_url"],
+            "download_dir": context["download_dir"],
+            "input_path": context["input_path"],
+        }
+    )
+
+
+def run_download(parent_job_id: str) -> str:
+    return _run_single_stage(
+        parent_job_id,
+        stage_name="download",
+        build_stage=lambda job, runtime: DownloadStage(
+            max_duration=runtime.settings.youtube_max_duration,
+        ),
+        output_keys=("input_path", "video_title"),
+        pre_context_update=_seed_download_context,
+    )
+
+
+def run_preprocess(parent_job_id: str) -> str:
+    def _seed_file_input(job: Job, runtime: WorkerRuntime, context: dict[str, Any]) -> None:
+        # For direct-file uploads the input_path is on the Job record and
+        # may not yet be in the Redis context (this is the first stage).
+        if not context.get("input_path") and job.filepath:
+            context["input_path"] = job.filepath
+            PipelineContextStore(runtime.redis, job.id).update({"input_path": job.filepath})
+
+    return _run_single_stage(
+        parent_job_id,
+        stage_name="preprocess",
+        build_stage=lambda job, runtime: PreprocessStage(),
+        output_keys=("audio_path", "duration"),
+        pre_context_update=_seed_file_input,
+    )
+
+
+def run_transcribe_align(parent_job_id: str) -> str:
+    """Run transcribe and align back-to-back in a single worker process.
+
+    They share ``whisperx_audio`` (a large numpy buffer) through the local
+    context dict, which avoids pickling it through Redis between two separate
+    RQ tasks. The global progress bar still advances through the ``transcribe``
+    and ``align`` bands independently.
+    """
+    with build_worker_runtime(parent_job_id) as runtime:
+        job = _load_job(runtime, parent_job_id)
+        ctx_store = PipelineContextStore(runtime.redis, parent_job_id)
+        context = ctx_store.load()
+
+        throttled = make_throttled_progress_reporter(runtime.reporter, runtime.db, job)
+        weights = pick_stage_weights(job, runtime)
+
+        transcribe = TranscribeStage(
+            model_name=job.model_name,
+            compute_type=runtime.settings.compute_type,
+            device=runtime.settings.device,
+        )
+        align = AlignStage(device=runtime.settings.device)
+
+        transcribe_progress = _banded_progress(throttled, weights.get("transcribe", (0.0, 1.0)))
+        align_progress = _banded_progress(throttled, weights.get("align", (0.0, 1.0)))
+
+        after_transcribe = _execute_stage(transcribe, context.copy(), transcribe_progress, stage_name="transcribe")
+        after_align = _execute_stage(align, after_transcribe, align_progress, stage_name="align")
+
+        _persist_outputs(
+            ctx_store,
+            after_align,
+            output_keys=("transcription_result", "aligned_result"),
+        )
+
+        logger.info("Stage transcribe_align finished for job %s", parent_job_id)
+        return f"transcribe_align:{parent_job_id}"
+
+
+def run_diarize(parent_job_id: str) -> str:
+    return _run_single_stage(
+        parent_job_id,
+        stage_name="diarize",
+        build_stage=lambda job, runtime: DiarizeStage(
+            hf_token=runtime.settings.hf_token,
+            device=runtime.settings.device,
+            enabled=job.enable_diarization,
+            heartbeat_interval=runtime.settings.diarize_heartbeat_interval,
+        ),
+        output_keys=("diarize_result",),
+    )
+
+
+def run_assign_speakers(parent_job_id: str) -> str:
+    return _run_single_stage(
+        parent_job_id,
+        stage_name="assign_speakers",
+        build_stage=lambda job, runtime: AssignSpeakersStage(),
+        output_keys=("final_result",),
+    )
+
+
+def run_postprocess(parent_job_id: str) -> str:
+    return _run_single_stage(
+        parent_job_id,
+        stage_name="postprocess",
+        build_stage=lambda job, runtime: PostprocessStage(
+            convert_to_traditional=job.convert_to_traditional,
+        ),
+        output_keys=("transcript_result",),
+    )
+
+
+def run_llm_correction(parent_job_id: str) -> str:
+    def _build(job: Job, runtime: WorkerRuntime) -> PipelineStage:
+        # Lazy import so workers built without the worker-llm extras (httpx)
+        # can still boot and process non-LLM jobs.
+        from whisper_ui.pipeline.llm_correction import LLMCorrectionStage
+
+        settings = runtime.settings
+        return LLMCorrectionStage(
+            base_url=settings.ollama_base_url,
+            model=settings.ollama_model,
+            keep_alive=settings.ollama_keep_alive,
+            chunk_size=settings.llm_chunk_size,
+            chunk_context=settings.llm_chunk_context,
+            temperature=settings.llm_temperature,
+            request_timeout=float(settings.ollama_request_timeout),
+        )
+
+    return _run_single_stage(
+        parent_job_id,
+        stage_name="llm_correction",
+        build_stage=_build,
+        output_keys=("transcript_result",),
+    )
+
+
+__all__ = [
+    "pick_stage_weights",
+    "run_assign_speakers",
+    "run_diarize",
+    "run_download",
+    "run_llm_correction",
+    "run_postprocess",
+    "run_preprocess",
+    "run_transcribe_align",
+]

--- a/src/whisper_ui/worker/stage_tasks.py
+++ b/src/whisper_ui/worker/stage_tasks.py
@@ -152,10 +152,34 @@ def _execute_stage(
     return updated
 
 
+def _current_generation() -> int | None:
+    """Return the generation id the currently-running RQ job was enqueued
+    under, or None outside an RQ worker context (e.g. unit tests that
+    invoke stage tasks directly).
+
+    Stage tasks use this to tell the context store which attempt they
+    belong to, so a stale write from a previous retry attempt can be
+    rejected even after ``send_stop_job_command`` has fired.
+    """
+    try:
+        from rq import get_current_job
+
+        current = get_current_job()
+        if current is None or not current.meta:
+            return None
+        gen = current.meta.get("generation")
+        return int(gen) if gen is not None else None
+    except Exception:
+        logger.debug("rq.get_current_job() unavailable while reading generation", exc_info=True)
+        return None
+
+
 def _persist_outputs(
     ctx_store: PipelineContextStore,
     updated: dict[str, Any],
     output_keys: tuple[str, ...],
+    *,
+    stage_name: str,
 ) -> None:
     """Write only the declared outputs back to the context store.
 
@@ -163,9 +187,25 @@ def _persist_outputs(
     fan-in safe: two concurrent branches writing to disjoint keys never stomp
     each other, and large intermediates that should not leave the producing
     process (e.g. ``whisperx_audio``) are automatically excluded.
+
+    When the current RQ job meta carries a ``generation``, the write goes
+    through the context store's generation-gated path so a retry that has
+    already incremented the generation counter causes this stale stage's
+    output to be silently dropped. If the generation cannot be determined
+    (e.g. running outside a worker in unit tests), fall back to the
+    unconditional update so tests keep working.
     """
     updates = {key: updated[key] for key in output_keys if key in updated}
-    ctx_store.update(updates)
+    generation = _current_generation()
+    if generation is None:
+        ctx_store.update(updates)
+        return
+    committed = ctx_store.update_if_generation_matches(updates, generation)
+    if not committed:
+        logger.warning(
+            "Stage %s output dropped: parent job was retried under a new generation",
+            stage_name,
+        )
 
 
 def _run_single_stage(
@@ -198,7 +238,7 @@ def _run_single_stage(
         on_progress = _banded_progress(throttled, band)
 
         updated = _execute_stage(stage, context.copy(), on_progress, stage_name=stage_name)
-        _persist_outputs(ctx_store, updated, output_keys)
+        _persist_outputs(ctx_store, updated, output_keys, stage_name=stage_name)
 
         logger.info("Stage %s finished for job %s", stage_name, parent_job_id)
         return f"{stage_name}:{parent_job_id}"
@@ -287,6 +327,7 @@ def run_transcribe_align(parent_job_id: str) -> str:
             ctx_store,
             after_align,
             output_keys=("transcription_result", "aligned_result"),
+            stage_name="transcribe_align",
         )
 
         logger.info("Stage transcribe_align finished for job %s", parent_job_id)

--- a/src/whisper_ui/worker/stage_tasks.py
+++ b/src/whisper_ui/worker/stage_tasks.py
@@ -37,6 +37,7 @@ from whisper_ui.pipeline.progress_bands import (
 )
 from whisper_ui.pipeline.transcribe import TranscribeStage
 from whisper_ui.worker.context_store import PipelineContextStore
+from whisper_ui.worker.progress import RedisProgressReporter
 from whisper_ui.worker.runtime import (
     WorkerRuntime,
     build_worker_runtime,
@@ -174,6 +175,28 @@ def _current_generation() -> int | None:
         return None
 
 
+def _build_generation_aware_reporter(runtime: WorkerRuntime, parent_job_id: str) -> RedisProgressReporter:
+    """Build a ``RedisProgressReporter`` that stamps its writes with the
+    current RQ job's generation.
+
+    This closes the Round 2 R2-2 race where a stale attempt-1 writer
+    could pin the progress hash at its old high-water mark after the
+    user retried: a fresh reporter for attempt 2 carries a higher
+    generation, and the Lua script's reset branch unconditionally
+    overwrites the hash on its first call. The runtime's default
+    ``runtime.reporter`` stays generation-less so the legacy
+    ``worker.tasks.process_transcription`` path keeps its original
+    semantics — only the DAG stage task path is upgraded.
+    """
+    generation = _current_generation()
+    return RedisProgressReporter(
+        runtime.redis,
+        parent_job_id,
+        processing_ttl=runtime.settings.redis_processing_expiry,
+        generation=generation,
+    )
+
+
 def _persist_outputs(
     ctx_store: PipelineContextStore,
     updated: dict[str, Any],
@@ -232,7 +255,8 @@ def _run_single_stage(
             pre_context_update(job, runtime, context)
 
         stage = build_stage(job, runtime)
-        throttled = make_throttled_progress_reporter(runtime.reporter, runtime.db, job)
+        reporter = _build_generation_aware_reporter(runtime, parent_job_id)
+        throttled = make_throttled_progress_reporter(reporter, runtime.db, job)
         weights = pick_stage_weights(job, runtime)
         band = weights.get(stage_name, (0.0, 1.0))
         on_progress = _banded_progress(throttled, band)
@@ -307,7 +331,8 @@ def run_transcribe_align(parent_job_id: str) -> str:
         ctx_store = PipelineContextStore(runtime.redis, parent_job_id)
         context = ctx_store.load()
 
-        throttled = make_throttled_progress_reporter(runtime.reporter, runtime.db, job)
+        reporter = _build_generation_aware_reporter(runtime, parent_job_id)
+        throttled = make_throttled_progress_reporter(reporter, runtime.db, job)
         weights = pick_stage_weights(job, runtime)
 
         transcribe = TranscribeStage(

--- a/src/whisper_ui/worker/stage_tasks.py
+++ b/src/whisper_ui/worker/stage_tasks.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 from rq.timeouts import BaseTimeoutException
 
 from whisper_ui.core.exceptions import PipelineError
+from whisper_ui.core.models import JobStatus
 from whisper_ui.pipeline.align import AlignStage
 from whisper_ui.pipeline.assign_speakers import AssignSpeakersStage
 from whisper_ui.pipeline.diarize import DiarizeStage
@@ -80,6 +81,31 @@ def _load_job(runtime: WorkerRuntime, parent_job_id: str) -> Job:
     if job is None:
         raise PipelineError(f"Job {parent_job_id} not found while running stage task")
     return job
+
+
+def _mark_processing_if_queued(runtime: WorkerRuntime, job: Job) -> None:
+    """Flip the parent job from QUEUED to PROCESSING on first stage entry.
+
+    The legacy monolithic worker task set PROCESSING at the very top of
+    ``process_transcription``. In the DAG path, multiple sub-jobs can be the
+    "first" one to actually run (e.g. transcribe_align and diarize start in
+    parallel after preprocess), so every stage task idempotently promotes
+    the job when it observes QUEUED. The SQLite write path serialises
+    concurrent writers via WAL mode + busy_timeout, so two parallel branches
+    flipping simultaneously converge on the same PROCESSING state without
+    corrupting the row.
+
+    This guards three downstream behaviours that depend on the
+    QUEUED → PROCESSING transition:
+
+    - ``recover_stale_jobs`` only scans status = 'processing'; without this
+      flip a crashed DAG leaves the parent stuck in QUEUED forever.
+    - Dashboard polling speed and status badges branch on PROCESSING.
+    - Legacy tests asserting a running job's status expect PROCESSING.
+    """
+    if job.status == JobStatus.QUEUED:
+        job.status = JobStatus.PROCESSING
+        runtime.db.update_job(job)
 
 
 def _banded_progress(
@@ -158,6 +184,7 @@ def _run_single_stage(
     """
     with build_worker_runtime(parent_job_id) as runtime:
         job = _load_job(runtime, parent_job_id)
+        _mark_processing_if_queued(runtime, job)
         ctx_store = PipelineContextStore(runtime.redis, parent_job_id)
         context = ctx_store.load()
 
@@ -236,6 +263,7 @@ def run_transcribe_align(parent_job_id: str) -> str:
     """
     with build_worker_runtime(parent_job_id) as runtime:
         job = _load_job(runtime, parent_job_id)
+        _mark_processing_if_queued(runtime, job)
         ctx_store = PipelineContextStore(runtime.redis, parent_job_id)
         context = ctx_store.load()
 

--- a/src/whisper_ui/worker/tasks.py
+++ b/src/whisper_ui/worker/tasks.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from pathlib import Path
 
 from whisper_ui.core.constants import (
@@ -26,47 +25,16 @@ from whisper_ui.pipeline.transcribe import TranscribeStage
 from whisper_ui.ui.labels import JOBS_TIMEOUT_ERROR
 from whisper_ui.worker.runtime import (
     build_worker_runtime,
+    extract_rq_timeout_seconds,
     make_throttled_progress_reporter,
 )
 
 logger = logging.getLogger(__name__)
 
-_RQ_TIMEOUT_MESSAGE_PATTERN = re.compile(r"\((\d+)\s*seconds?\)")
-
-
-def _extract_rq_timeout_seconds(exc: BaseException) -> int | str:
-    """Return the configured RQ ``job_timeout`` for the running job.
-
-    RQ's death-penalty handler formats the timeout into the exception
-    *message* but does not attach it as an attribute on the exception
-    instance (see ``rq.timeouts.UnixSignalDeathPenalty.handle_death_penalty``
-    in RQ 2.7.0). So:
-
-    1. In a real worker context, ``rq.get_current_job().timeout`` holds the
-       actual configured value from enqueue time.
-    2. Outside a worker context (unit tests that call
-       ``process_transcription`` directly), fall back to parsing the
-       formatted message.
-    3. If both fail, return ``"?"`` so the error label still renders.
-    """
-    try:
-        from rq import get_current_job
-
-        current = get_current_job()
-        if current is not None and current.timeout:
-            return current.timeout
-    except Exception:
-        logger.debug("rq.get_current_job() unavailable while extracting timeout", exc_info=True)
-
-    match = _RQ_TIMEOUT_MESSAGE_PATTERN.search(str(exc))
-    if match:
-        return int(match.group(1))
-    return "?"
-
-
-# Backwards-compatible alias kept for tests and downstream callers that
-# imported the private helper directly. New code should import from
-# ``whisper_ui.worker.runtime``.
+# Backwards-compatible aliases kept for tests and downstream callers that
+# imported these private helpers directly before they moved to
+# ``whisper_ui.worker.runtime``. New code should import from runtime.
+_extract_rq_timeout_seconds = extract_rq_timeout_seconds
 _make_throttled_progress_reporter = make_throttled_progress_reporter
 
 

--- a/src/whisper_ui/worker/tasks.py
+++ b/src/whisper_ui/worker/tasks.py
@@ -2,19 +2,11 @@ from __future__ import annotations
 
 import logging
 import re
-import threading
-import time
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-from redis import Redis
-
-from whisper_ui.core.config import get_settings
 from whisper_ui.core.constants import (
     ERROR_DISPLAY_LENGTH,
     ERROR_MAX_LENGTH,
-    PROGRESS_WRITE_MIN_DELTA,
-    PROGRESS_WRITE_MIN_INTERVAL_SEC,
 )
 from whisper_ui.core.messages import PIPELINE_COMPLETE
 from whisper_ui.core.models import Job, JobStatus
@@ -31,13 +23,11 @@ from whisper_ui.pipeline.progress_bands import (
     STAGE_WEIGHTS_WITH_LLM,
 )
 from whisper_ui.pipeline.transcribe import TranscribeStage
-from whisper_ui.storage.database import JobDatabase
-from whisper_ui.storage.filestore import FileStore
 from whisper_ui.ui.labels import JOBS_TIMEOUT_ERROR
-from whisper_ui.worker.progress import RedisProgressReporter
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
+from whisper_ui.worker.runtime import (
+    build_worker_runtime,
+    make_throttled_progress_reporter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -74,67 +64,10 @@ def _extract_rq_timeout_seconds(exc: BaseException) -> int | str:
     return "?"
 
 
-def _make_throttled_progress_reporter(
-    reporter: RedisProgressReporter,
-    db: JobDatabase,
-    job: Job,
-    *,
-    min_delta: float = PROGRESS_WRITE_MIN_DELTA,
-    min_interval_sec: float = PROGRESS_WRITE_MIN_INTERVAL_SEC,
-    monotonic: Callable[[], float] = time.monotonic,
-) -> Callable[[float, str], None]:
-    """Wrap progress callbacks so high-frequency sub-stage updates do not
-    thrash SQLite and Redis.
-
-    The throttle drops a report when both of these hold:
-    - progress moved less than ``min_delta`` from the last written value,
-    - less than ``min_interval_sec`` has elapsed since the last write.
-
-    It always flushes when the message changes (stage transition, state
-    flip), on the very first call, and whenever progress reaches 1.0, so
-    no user-visible milestone is ever swallowed.
-    """
-    last_progress = -1.0
-    last_written_at = 0.0
-    last_message = ""
-    # The diarize heartbeat invokes ``report`` from a background thread while
-    # the main thread is blocked inside the C++ inference call, so in normal
-    # operation only one thread mutates the closure state at a time. The lock
-    # is cheap defence-in-depth: it guarantees the read-decide-write sequence
-    # below is atomic even if some future stage spawns a worker thread that
-    # also calls on_progress.
-    lock = threading.Lock()
-
-    def report(progress: float, message: str) -> None:
-        nonlocal last_progress, last_written_at, last_message
-
-        with lock:
-            # Monotonicity guard: drop any in-closure regression unconditionally,
-            # even if the message changed. The only realistic source of one is a
-            # late diarize heartbeat racing the main thread's DIARIZE_DONE flush;
-            # letting it through would visibly rewind the bar from 100% back to
-            # ~94%. Worker retries always spin up a fresh closure, so legitimate
-            # rewinds never reach this point.
-            if last_progress >= 0 and progress < last_progress:
-                return
-
-            now = monotonic()
-            force = last_progress < 0 or message != last_message or progress >= 1.0
-            if not force:
-                delta = progress - last_progress
-                if delta < min_delta and (now - last_written_at) < min_interval_sec:
-                    return
-
-            reporter.report(progress, message)
-            job.progress = progress
-            job.progress_message = message
-            db.update_job(job)
-
-            last_progress = progress
-            last_written_at = now
-            last_message = message
-
-    return report
+# Backwards-compatible alias kept for tests and downstream callers that
+# imported the private helper directly. New code should import from
+# ``whisper_ui.worker.runtime``.
+_make_throttled_progress_reporter = make_throttled_progress_reporter
 
 
 def _cleanup_preprocessed(context: dict) -> None:
@@ -151,128 +84,125 @@ def _cleanup_preprocessed(context: dict) -> None:
 def process_transcription(job_id: str) -> str:
     from rq.timeouts import BaseTimeoutException
 
-    settings = get_settings()
-    redis = Redis.from_url(settings.redis_url)
-    reporter = RedisProgressReporter(redis, job_id, processing_ttl=settings.redis_processing_expiry)
-    db = JobDatabase(settings.database_path)
-    filestore = FileStore(settings.upload_dir, settings.output_dir)
+    with build_worker_runtime(job_id) as runtime:
+        settings = runtime.settings
+        reporter = runtime.reporter
+        db = runtime.db
+        filestore = runtime.filestore
 
-    context: dict = {}
-    job: Job | None = None
-    try:
-        job = db.get_job(job_id)
-        if job is None:
-            reporter.fail(f"Job {job_id} not found in database.")
-            return f"Job {job_id} not found"
+        context: dict = {}
+        job: Job | None = None
+        try:
+            job = db.get_job(job_id)
+            if job is None:
+                reporter.fail(f"Job {job_id} not found in database.")
+                return f"Job {job_id} not found"
 
-        job.status = JobStatus.PROCESSING
-        db.update_job(job)
+            job.status = JobStatus.PROCESSING
+            db.update_job(job)
 
-        common_stages = [
-            PreprocessStage(),
-            TranscribeStage(
-                model_name=job.model_name,
-                compute_type=settings.compute_type,
-                device=settings.device,
-            ),
-            AlignStage(device=settings.device),
-            DiarizeStage(
-                hf_token=settings.hf_token,
-                device=settings.device,
-                enabled=job.enable_diarization,
-                heartbeat_interval=settings.diarize_heartbeat_interval,
-            ),
-            AssignSpeakersStage(),
-            PostprocessStage(convert_to_traditional=job.convert_to_traditional),
-        ]
+            common_stages = [
+                PreprocessStage(),
+                TranscribeStage(
+                    model_name=job.model_name,
+                    compute_type=settings.compute_type,
+                    device=settings.device,
+                ),
+                AlignStage(device=settings.device),
+                DiarizeStage(
+                    hf_token=settings.hf_token,
+                    device=settings.device,
+                    enabled=job.enable_diarization,
+                    heartbeat_interval=settings.diarize_heartbeat_interval,
+                ),
+                AssignSpeakersStage(),
+                PostprocessStage(convert_to_traditional=job.convert_to_traditional),
+            ]
 
-        # The LLM correction stage is only appended when the user opted in
-        # *and* an Ollama endpoint is configured at the deployment level.
-        # Empty base URL acts as a kill-switch — even opted-in jobs just
-        # skip it silently, so operators can disable the feature globally
-        # without redeploying the web tier. The import is lazy so workers
-        # built without the worker-llm extras (httpx) can still boot and
-        # process non-LLM jobs.
-        llm_enabled = job.llm_correction_enabled and bool(settings.ollama_base_url)
-        if llm_enabled:
-            from whisper_ui.pipeline.llm_correction import LLMCorrectionStage
+            # The LLM correction stage is only appended when the user opted in
+            # *and* an Ollama endpoint is configured at the deployment level.
+            # Empty base URL acts as a kill-switch — even opted-in jobs just
+            # skip it silently, so operators can disable the feature globally
+            # without redeploying the web tier. The import is lazy so workers
+            # built without the worker-llm extras (httpx) can still boot and
+            # process non-LLM jobs.
+            llm_enabled = job.llm_correction_enabled and bool(settings.ollama_base_url)
+            if llm_enabled:
+                from whisper_ui.pipeline.llm_correction import LLMCorrectionStage
 
-            common_stages.append(
-                LLMCorrectionStage(
-                    base_url=settings.ollama_base_url,
-                    model=settings.ollama_model,
-                    keep_alive=settings.ollama_keep_alive,
-                    chunk_size=settings.llm_chunk_size,
-                    chunk_context=settings.llm_chunk_context,
-                    temperature=settings.llm_temperature,
-                    request_timeout=float(settings.ollama_request_timeout),
+                common_stages.append(
+                    LLMCorrectionStage(
+                        base_url=settings.ollama_base_url,
+                        model=settings.ollama_model,
+                        keep_alive=settings.ollama_keep_alive,
+                        chunk_size=settings.llm_chunk_size,
+                        chunk_context=settings.llm_chunk_context,
+                        temperature=settings.llm_temperature,
+                        request_timeout=float(settings.ollama_request_timeout),
+                    )
                 )
-            )
 
-        context = {
-            "language": job.language,
-            "batch_size": settings.batch_size,
-            "num_speakers": job.num_speakers,
-        }
+            context = {
+                "language": job.language,
+                "batch_size": settings.batch_size,
+                "num_speakers": job.num_speakers,
+            }
 
-        if job.source_url:
-            download_dir = str(filestore.prepare_upload_path(job.id, "_").parent)
-            stages = [DownloadStage(max_duration=settings.youtube_max_duration), *common_stages]
-            stage_weights = STAGE_WEIGHTS_WITH_DOWNLOAD_AND_LLM if llm_enabled else STAGE_WEIGHTS_WITH_DOWNLOAD
-            context["source_url"] = job.source_url
-            context["download_dir"] = download_dir
-            context["input_path"] = ""
-        else:
-            stages = common_stages
-            stage_weights = STAGE_WEIGHTS_WITH_LLM if llm_enabled else None
-            context["input_path"] = job.filepath
+            if job.source_url:
+                download_dir = str(filestore.prepare_upload_path(job.id, "_").parent)
+                stages = [DownloadStage(max_duration=settings.youtube_max_duration), *common_stages]
+                stage_weights = STAGE_WEIGHTS_WITH_DOWNLOAD_AND_LLM if llm_enabled else STAGE_WEIGHTS_WITH_DOWNLOAD
+                context["source_url"] = job.source_url
+                context["download_dir"] = download_dir
+                context["input_path"] = ""
+            else:
+                stages = common_stages
+                stage_weights = STAGE_WEIGHTS_WITH_LLM if llm_enabled else None
+                context["input_path"] = job.filepath
 
-        on_progress = _make_throttled_progress_reporter(reporter, db, job)
+            on_progress = make_throttled_progress_reporter(reporter, db, job)
 
-        orchestrator = PipelineOrchestrator(stages, on_progress=on_progress, stage_weights=stage_weights)
+            orchestrator = PipelineOrchestrator(stages, on_progress=on_progress, stage_weights=stage_weights)
 
-        result = orchestrator.run(context)
-        _cleanup_preprocessed(context)
+            result = orchestrator.run(context)
+            _cleanup_preprocessed(context)
 
-        if job.source_url and context.get("video_title"):
-            job.filename = context["video_title"]
-        result_path = filestore.save_result(job_id, result)
+            if job.source_url and context.get("video_title"):
+                job.filename = context["video_title"]
+            result_path = filestore.save_result(job_id, result)
 
-        job.status = JobStatus.COMPLETED
-        job.progress = 1.0
-        job.progress_message = PIPELINE_COMPLETE
-        job.result_path = str(result_path)
-        job.duration = result.duration
-        db.update_job(job)
-        reporter.complete(str(result_path))
-
-        logger.info("Job %s completed successfully.", job_id)
-        return f"Job {job_id} completed"
-
-    except BaseTimeoutException as e:
-        _cleanup_preprocessed(context)
-        timeout_seconds = _extract_rq_timeout_seconds(e)
-        error_msg = JOBS_TIMEOUT_ERROR.format(seconds=timeout_seconds)
-        logger.exception("Job %s timed out: %s", job_id, error_msg)
-        if job is not None:
-            job.status = JobStatus.FAILED
-            job.error = error_msg[:ERROR_MAX_LENGTH]
-            job.progress_message = f"Failed: {error_msg[:ERROR_DISPLAY_LENGTH]}"
+            job.status = JobStatus.COMPLETED
+            job.progress = 1.0
+            job.progress_message = PIPELINE_COMPLETE
+            job.result_path = str(result_path)
+            job.duration = result.duration
             db.update_job(job)
-        reporter.fail(error_msg)
-        return f"Job {job_id} timed out: {error_msg}"
+            reporter.complete(str(result_path))
 
-    except Exception as e:
-        _cleanup_preprocessed(context)
-        error_msg = str(e)
-        logger.exception("Job %s failed: %s", job_id, error_msg)
-        if job is not None:
-            job.status = JobStatus.FAILED
-            job.error = error_msg[:ERROR_MAX_LENGTH]
-            job.progress_message = f"Failed: {error_msg[:ERROR_DISPLAY_LENGTH]}"
-            db.update_job(job)
-        reporter.fail(error_msg)
-        return f"Job {job_id} failed: {error_msg}"
+            logger.info("Job %s completed successfully.", job_id)
+            return f"Job {job_id} completed"
 
-    finally:
-        db.close()
+        except BaseTimeoutException as e:
+            _cleanup_preprocessed(context)
+            timeout_seconds = _extract_rq_timeout_seconds(e)
+            error_msg = JOBS_TIMEOUT_ERROR.format(seconds=timeout_seconds)
+            logger.exception("Job %s timed out: %s", job_id, error_msg)
+            if job is not None:
+                job.status = JobStatus.FAILED
+                job.error = error_msg[:ERROR_MAX_LENGTH]
+                job.progress_message = f"Failed: {error_msg[:ERROR_DISPLAY_LENGTH]}"
+                db.update_job(job)
+            reporter.fail(error_msg)
+            return f"Job {job_id} timed out: {error_msg}"
+
+        except Exception as e:
+            _cleanup_preprocessed(context)
+            error_msg = str(e)
+            logger.exception("Job %s failed: %s", job_id, error_msg)
+            if job is not None:
+                job.status = JobStatus.FAILED
+                job.error = error_msg[:ERROR_MAX_LENGTH]
+                job.progress_message = f"Failed: {error_msg[:ERROR_DISPLAY_LENGTH]}"
+                db.update_job(job)
+            reporter.fail(error_msg)
+            return f"Job {job_id} failed: {error_msg}"

--- a/src/whisper_ui/worker/tasks.py
+++ b/src/whisper_ui/worker/tasks.py
@@ -22,14 +22,14 @@ from whisper_ui.pipeline.align import AlignStage
 from whisper_ui.pipeline.assign_speakers import AssignSpeakersStage
 from whisper_ui.pipeline.diarize import DiarizeStage
 from whisper_ui.pipeline.download import DownloadStage
-from whisper_ui.pipeline.orchestrator import (
+from whisper_ui.pipeline.orchestrator import PipelineOrchestrator
+from whisper_ui.pipeline.postprocess import PostprocessStage
+from whisper_ui.pipeline.preprocess import PreprocessStage
+from whisper_ui.pipeline.progress_bands import (
     STAGE_WEIGHTS_WITH_DOWNLOAD,
     STAGE_WEIGHTS_WITH_DOWNLOAD_AND_LLM,
     STAGE_WEIGHTS_WITH_LLM,
-    PipelineOrchestrator,
 )
-from whisper_ui.pipeline.postprocess import PostprocessStage
-from whisper_ui.pipeline.preprocess import PreprocessStage
 from whisper_ui.pipeline.transcribe import TranscribeStage
 from whisper_ui.storage.database import JobDatabase
 from whisper_ui.storage.filestore import FileStore

--- a/tests/integration/test_pipeline_dag_parallelism.py
+++ b/tests/integration/test_pipeline_dag_parallelism.py
@@ -287,65 +287,88 @@ def test_stage_failure_cancels_downstream_and_marks_job_failed(monkeypatch, fake
             assert not sub.is_finished, f"sub-job {sub.func_name} should not have finished after transcribe failure"
 
 
-def test_progress_reporter_never_regresses_across_parallel_branches(monkeypatch, fake_redis, fake_settings, tmp_path):
-    """The throttled reporter must never hand a smaller progress value to
-    the Redis hash than its previous call, even when transcribe_align and
-    diarize are writing concurrently. Monotonicity is what the htmx
-    progress bar depends on — a regression here would manifest as the bar
-    visibly jumping backwards mid-job.
+def test_parallel_branch_progress_never_regresses_in_redis(monkeypatch, fake_redis, fake_settings, tmp_path):
+    """End-to-end monotonicity check for the DAG path. Two real
+    ``RedisProgressReporter`` instances (one per parallel branch) pound
+    the same parent job_id from different threads with interleaved
+    progress values; the final stored progress must equal the highest
+    value any branch ever reported, and the full write history — read
+    back via ``RedisProgressReporter.get_progress`` after each call —
+    must never show a regression.
+
+    This is the PR #39 review fix for R2 (Gemini + user): the previous
+    version of this test was named "never_regresses" but its assertion
+    only checked ``0.0 <= v <= 1.0``, which passed even while the bar
+    was visibly jumping backwards under parallel worker writes.
     """
-    db = MagicMock()
-    job = Job(
-        id="job-progress",
-        filename="m.mp3",
-        filepath=str(tmp_path / "m.mp3"),
-        status=JobStatus.QUEUED,
-        duration=30.0,
-        enable_diarization=True,
-    )
-    db.get_job.return_value = job
+    from whisper_ui.worker.progress import RedisProgressReporter
 
-    filestore = MagicMock()
-    filestore.prepare_upload_path.return_value = tmp_path / "subdir" / "m.mp3"
-    filestore.save_result.return_value = tmp_path / "result.json"
+    parent_id = "job-parallel-mono"
+    transcribe_reporter = RedisProgressReporter(fake_redis, parent_id)
+    diarize_reporter = RedisProgressReporter(fake_redis, parent_id)
 
-    reported: list[float] = []
-    reporter_lock = threading.Lock()
+    # Interleave writes so the server-side Lua max is the only thing
+    # keeping progress monotonic. If it were a plain HSET the "0.20"
+    # write from transcribe would clobber the "0.72" diarize write.
+    writes = [
+        (transcribe_reporter, 0.10, "transcribe starting"),
+        (diarize_reporter, 0.72, "diarize running"),
+        (transcribe_reporter, 0.20, "transcribe chunk 2"),
+        (transcribe_reporter, 0.55, "transcribe chunk 3"),
+        (diarize_reporter, 0.85, "diarize running"),
+        (transcribe_reporter, 0.60, "align starting"),
+    ]
 
-    class _RecordingReporter:
-        def report(self, progress: float, message: str) -> None:
-            with reporter_lock:
-                reported.append(progress)
+    history: list[float] = []
+    for reporter, progress, message in writes:
+        reporter.report(progress, message)
+        after = RedisProgressReporter.get_progress(fake_redis, parent_id)
+        history.append(float(after["progress"]))
 
-        def complete(self, _path: str) -> None: ...
+    # Core invariant: every consecutive pair is non-decreasing.
+    for i in range(1, len(history)):
+        assert history[i] >= history[i - 1], (
+            f"progress regressed between step {i - 1} ({history[i - 1]}) and step {i} ({history[i]}); "
+            f"full history: {history}"
+        )
 
-        def fail(self, _msg: str) -> None: ...
+    # And the final value is the max of all writes, which is diarize's 0.85.
+    assert history[-1] == 0.85
 
-    runtime = WorkerRuntime(
-        settings=fake_settings,
-        redis=fake_redis,
-        reporter=_RecordingReporter(),
-        db=db,
-        filestore=filestore,
-    )
+    # Message must reflect the latest write even when progress did not
+    # advance (the 0.20 transcribe write that was rejected still updated
+    # its message). This is what lets the UI show the current stage name.
+    final = RedisProgressReporter.get_progress(fake_redis, parent_id)
+    assert final["message"] == "align starting"
 
-    @contextlib.contextmanager
-    def _builder(_job_id):
-        yield runtime
 
-    timeline: list = []
-    with _stub_stages(monkeypatch, timeline):
-        _install_runtime(monkeypatch, _builder)
-        enqueue_pipeline(job, redis=fake_redis, settings=fake_settings, filestore=filestore)
-        _drain_queues(fake_redis)
+def test_parallel_reporters_from_threads_never_regress(fake_redis):
+    """Same invariant as above but driven from real threads writing
+    concurrently. Catches races the sequential-interleave test cannot
+    see — if the Lua EVAL were somehow non-atomic, the thread version
+    would surface it as a regression under load.
+    """
+    from whisper_ui.worker.progress import RedisProgressReporter
 
-    assert reported, "reporter should have been called at least once"
-    # Within a single throttled closure the monotonicity guard enforces
-    # non-decreasing values. Across stages, each task creates its own
-    # closure, so a later stage starting lower than the previous stage's
-    # final value is acceptable and expected (bands overlap slightly).
-    # What must never happen is an individual stage emitting a regression.
-    for i in range(1, len(reported)):
-        # Allow at most the transition between stage bands (which can drop).
-        # We only assert strictly that no value is wildly out of [0, 1].
-        assert 0.0 <= reported[i] <= 1.0
+    parent_id = "job-parallel-mono-threaded"
+    n_writes = 200
+
+    def writer(start: float, step: float, label: str) -> None:
+        reporter = RedisProgressReporter(fake_redis, parent_id)
+        for i in range(n_writes):
+            reporter.report(start + i * step, f"{label}-{i}")
+
+    threads = [
+        threading.Thread(target=writer, args=(0.00, 0.003, "transcribe")),
+        threading.Thread(target=writer, args=(0.20, 0.003, "diarize")),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    final = RedisProgressReporter.get_progress(fake_redis, parent_id)
+    final_progress = float(final["progress"])
+    # The highest value any writer produced is 0.20 + 199 * 0.003 ≈ 0.797
+    expected_max = max(0.00 + (n_writes - 1) * 0.003, 0.20 + (n_writes - 1) * 0.003)
+    assert final_progress == pytest.approx(expected_max, abs=1e-6)

--- a/tests/integration/test_pipeline_dag_parallelism.py
+++ b/tests/integration/test_pipeline_dag_parallelism.py
@@ -53,6 +53,7 @@ def fake_settings() -> MagicMock:
     settings.youtube_max_duration = 3600
     settings.diarize_heartbeat_interval = 30
     settings.hf_token = "fake-token-not-real"
+    settings.redis_processing_expiry = 7200
     return settings
 
 

--- a/tests/integration/test_pipeline_dag_parallelism.py
+++ b/tests/integration/test_pipeline_dag_parallelism.py
@@ -289,6 +289,61 @@ def test_stage_failure_cancels_downstream_and_marks_job_failed(monkeypatch, fake
                 assert not sub.is_finished, f"sub-job {sub.func_name} should not have finished after transcribe failure"
 
 
+def test_retry_progress_starts_fresh_after_stale_writer(fake_redis):
+    """End-to-end regression for PR #39 Round 2 R2-2. Reproduces the
+    exact sequence from the reviewer's reproducer: attempt 1 writes
+    0.85 → retry route deletes the progress key → stale attempt-1
+    late writer re-seeds 0.85 → attempt 2 wants to start from 0.05.
+
+    Before the fix the Lua max-write rejected 0.05 as "less than
+    0.85" and the UI saw attempt 2 stuck at 85% under attempt 2's
+    message — directly undermining the retry isolation the PR
+    promises. With the generation-aware reset branch, attempt 2's
+    higher caller_gen triggers the reset path and the hash is
+    rewritten cleanly from 0.05.
+    """
+    from whisper_ui.worker.progress import RedisProgressReporter
+
+    # Attempt 1 — a stage reporter writes 0.85.
+    attempt1_reporter = RedisProgressReporter(fake_redis, "job-retry-progress", generation=1)
+    attempt1_reporter.report(0.85, "attempt1 diarize")
+
+    stored = {
+        k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else v
+        for k, v in fake_redis.hgetall("job:job-retry-progress").items()
+    }
+    assert stored["progress"] == "0.85"
+
+    # User clicks retry — web/routes/jobs.py deletes the progress key.
+    fake_redis.delete("job:job-retry-progress")
+
+    # Stale attempt-1 late writer re-seeds 0.85 via its still-live
+    # reporter before it observes the stop. Without the generation
+    # stamp on the hash this would still be indistinguishable from a
+    # fresh reset, but here it re-writes with generation=1.
+    attempt1_reporter.report(0.85, "attempt1 stale late")
+
+    stored = {
+        k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else v
+        for k, v in fake_redis.hgetall("job:job-retry-progress").items()
+    }
+    assert stored["progress"] == "0.85"
+    assert stored["generation"] == "1"
+
+    # Attempt 2's first stage reports under the new generation.
+    attempt2_reporter = RedisProgressReporter(fake_redis, "job-retry-progress", generation=2)
+    attempt2_reporter.report(0.05, "attempt2 preprocess starting")
+
+    stored = {
+        k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else v
+        for k, v in fake_redis.hgetall("job:job-retry-progress").items()
+    }
+    # The stale 0.85 high-water mark must NOT pin the fresh attempt.
+    assert stored["progress"] == "0.05", f"attempt 2's 0.05 was rejected by the stale 0.85 max-write; stored={stored}"
+    assert stored["message"] == "attempt2 preprocess starting"
+    assert stored["generation"] == "2"
+
+
 def test_retry_isolates_new_attempt_from_stale_sibling_writes(monkeypatch, fake_redis, fake_settings, tmp_path):
     """End-to-end retry isolation (PR #39 R3 Layer 2). Simulates a stale
     diarize that is still running after transcribe_align failed and a

--- a/tests/integration/test_pipeline_dag_parallelism.py
+++ b/tests/integration/test_pipeline_dag_parallelism.py
@@ -1,0 +1,351 @@
+"""End-to-end DAG execution tests that drive the dispatcher through real
+``rq.SimpleWorker`` burst runs backed by fakeredis.
+
+These tests exercise the full chain from ``enqueue_pipeline`` → RQ worker
+loop → stage task body → ``finalize_success`` / ``finalize_failure``. The
+real pipeline stages are monkey-patched with lightweight recorders so the
+tests run in a few milliseconds while still touching every seam the DAG
+refactor introduced (context store round-trip, fan-in, progress reporter,
+failure cancellation).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+import fakeredis
+import pytest
+from rq import SimpleWorker
+from rq.job import Job as RQJob
+
+from whisper_ui.core.constants import (
+    WORKER_QUEUE_CPU,
+    WORKER_QUEUE_GPU,
+    WORKER_QUEUE_IO,
+)
+from whisper_ui.core.models import Job, JobStatus, TranscriptResult
+from whisper_ui.worker import pipeline_dispatcher
+from whisper_ui.worker.context_store import PipelineContextStore
+from whisper_ui.worker.pipeline_dispatcher import enqueue_pipeline
+from whisper_ui.worker.runtime import WorkerRuntime
+
+
+@pytest.fixture
+def fake_redis() -> fakeredis.FakeRedis:
+    return fakeredis.FakeRedis()
+
+
+@pytest.fixture
+def fake_settings() -> MagicMock:
+    settings = MagicMock()
+    settings.batch_size = 16
+    settings.ollama_base_url = ""
+    settings.job_timeout_default = 3600
+    settings.job_timeout_floor = 300
+    settings.job_timeout_max = 14_400
+    settings.job_timeout_audio_multiplier = 2.0
+    settings.compute_type = "int8"
+    settings.device = "cpu"
+    settings.youtube_max_duration = 3600
+    settings.diarize_heartbeat_interval = 30
+    settings.hf_token = "fake-token-not-real"
+    return settings
+
+
+class _RecorderStage:
+    """Drop-in PipelineStage double that records its name + the order it ran.
+
+    ``timeline`` is the list the test reads after the burst to check how
+    stages interleaved across jobs. Each recorder returns ``new_keys`` as
+    context updates so the dispatcher's declared output_keys behaviour is
+    exercised unchanged.
+    """
+
+    def __init__(self, name: str, timeline: list, new_keys: dict[str, Any], delay: float = 0.0):
+        self._name = name
+        self._timeline = timeline
+        self._new_keys = new_keys
+        self._delay = delay
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def execute(self, context: dict, on_progress=None) -> dict:
+        self._timeline.append((self._name, time.monotonic()))
+        if self._delay:
+            time.sleep(self._delay)
+        if on_progress:
+            on_progress(1.0, f"{self._name}-done")
+        out = dict(context)
+        out.update(self._new_keys)
+        return out
+
+    def cleanup(self) -> None:
+        pass
+
+
+@contextlib.contextmanager
+def _stub_stages(monkeypatch, timeline: list):
+    """Replace every heavy PipelineStage constructor with recorder doubles.
+
+    ``stage_tasks`` imports stage classes at module load time so the patches
+    must target the attribute path the lambdas inside run_* functions use.
+    """
+    stubs = {
+        "PreprocessStage": _RecorderStage("preprocess", timeline, {"audio_path": "/tmp/fake.wav", "duration": 10.0}),
+        "TranscribeStage": _RecorderStage("transcribe", timeline, {"transcription_result": {"segments": []}}),
+        "AlignStage": _RecorderStage("align", timeline, {"aligned_result": {"segments": []}}),
+        "DiarizeStage": _RecorderStage("diarize", timeline, {"diarize_result": [("SPK0", 0.0, 1.0)]}),
+        "AssignSpeakersStage": _RecorderStage("assign_speakers", timeline, {"final_result": {"segments": []}}),
+        "PostprocessStage": _RecorderStage(
+            "postprocess",
+            timeline,
+            {"transcript_result": TranscriptResult(language="zh", duration=10.0)},
+        ),
+    }
+
+    for attr, stage in stubs.items():
+        monkeypatch.setattr(
+            f"whisper_ui.worker.stage_tasks.{attr}",
+            lambda *args, _s=stage, **kwargs: _s,
+        )
+    yield
+
+
+@contextlib.contextmanager
+def _fake_runtime_factory(fake_redis, fake_settings, db, filestore):
+    """Install a build_worker_runtime stand-in that returns the same fake
+    resources for every stage task invocation in the test.
+    """
+    runtime = WorkerRuntime(
+        settings=fake_settings,
+        redis=fake_redis,
+        reporter=MagicMock(),
+        db=db,
+        filestore=filestore,
+    )
+
+    @contextlib.contextmanager
+    def _builder(job_id):
+        yield runtime
+
+    yield runtime, _builder
+
+
+def _install_runtime(monkeypatch, builder):
+    monkeypatch.setattr("whisper_ui.worker.stage_tasks.build_worker_runtime", builder)
+    monkeypatch.setattr("whisper_ui.worker.pipeline_dispatcher.build_worker_runtime", builder)
+
+
+def _drain_queues(fake_redis) -> list[str]:
+    """Run a burst SimpleWorker across every queue until all jobs settle.
+
+    Returns the collected log of finished sub-job ids in execution order.
+    The worker loop keeps cycling until no jobs are picked up anywhere — RQ
+    dependency resolution promotes deferred jobs to their target queue only
+    after their dependencies complete, so a single burst pass is not enough
+    when the DAG has chained stages.
+    """
+    finished: list[str] = []
+    queues_by_name = {
+        name: __import__("rq").Queue(name=name, connection=fake_redis)
+        for name in (WORKER_QUEUE_IO, WORKER_QUEUE_GPU, WORKER_QUEUE_CPU)
+    }
+
+    for _ in range(50):  # hard cap to guarantee test termination
+        progressed = False
+        for queue in queues_by_name.values():
+            if queue.count == 0:
+                continue
+            worker = SimpleWorker([queue], connection=fake_redis)
+            worker.work(burst=True, with_scheduler=False)
+            progressed = True
+        if not progressed:
+            break
+        finished.append("cycle")
+    return finished
+
+
+def test_full_dag_runs_through_simple_worker_and_marks_job_completed(monkeypatch, fake_redis, fake_settings, tmp_path):
+    """Happy-path integration: enqueue a file-upload job, drive the workers
+    through every queue, and verify finalize_success fired and the Job row
+    reached COMPLETED with a result path.
+    """
+    db = MagicMock()
+    db.get_job = MagicMock()
+
+    job = Job(
+        id="job-dag",
+        filename="meeting.mp3",
+        filepath=str(tmp_path / "meeting.mp3"),
+        status=JobStatus.QUEUED,
+        duration=60.0,
+        enable_diarization=True,
+    )
+    db.get_job.return_value = job
+
+    filestore = MagicMock()
+    filestore.prepare_upload_path.return_value = tmp_path / "subdir" / "meeting.mp3"
+    filestore.save_result.return_value = tmp_path / "result.json"
+
+    timeline: list = []
+
+    with (
+        _stub_stages(monkeypatch, timeline),
+        _fake_runtime_factory(fake_redis, fake_settings, db, filestore) as (_, builder),
+    ):
+        _install_runtime(monkeypatch, builder)
+
+        enqueue_pipeline(job, redis=fake_redis, settings=fake_settings, filestore=filestore)
+
+        _drain_queues(fake_redis)
+
+    # Every stage should have fired exactly once.
+    stage_names = [name for name, _ts in timeline]
+    assert stage_names.count("preprocess") == 1
+    assert stage_names.count("transcribe") == 1
+    assert stage_names.count("align") == 1
+    assert stage_names.count("diarize") == 1
+    assert stage_names.count("assign_speakers") == 1
+    assert stage_names.count("postprocess") == 1
+
+    # transcribe and align must be back-to-back (same run_transcribe_align task).
+    transcribe_ts = next(t for n, t in timeline if n == "transcribe")
+    align_ts = next(t for n, t in timeline if n == "align")
+    assert align_ts >= transcribe_ts
+
+    # assign_speakers must fan in after both transcribe_align and diarize.
+    diarize_ts = next(t for n, t in timeline if n == "diarize")
+    assign_ts = next(t for n, t in timeline if n == "assign_speakers")
+    assert assign_ts >= align_ts
+    assert assign_ts >= diarize_ts
+
+    # finalize_success should have marked the job COMPLETED.
+    assert job.status == JobStatus.COMPLETED
+    assert job.result_path == str(tmp_path / "result.json")
+
+    # The context store should be wiped by the finaliser.
+    assert PipelineContextStore(fake_redis, job.id).load() == {}
+
+
+def test_stage_failure_cancels_downstream_and_marks_job_failed(monkeypatch, fake_redis, fake_settings, tmp_path):
+    """When a mid-chain stage raises, every dependent sub-job that has not
+    yet started must be cancelled and the parent Job must flip to FAILED.
+    This is the behaviour the dispatcher promises via finalize_failure;
+    losing it would leave zombie sub-jobs deferred forever.
+    """
+    db = MagicMock()
+    job = Job(
+        id="job-failing",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.QUEUED,
+        duration=60.0,
+        enable_diarization=True,
+    )
+    db.get_job.return_value = job
+
+    filestore = MagicMock()
+    filestore.prepare_upload_path.return_value = tmp_path / "subdir" / "m.mp3"
+
+    class _ExplodingTranscribe:
+        name = "transcribe"
+
+        def execute(self, context, on_progress=None):
+            raise RuntimeError("gpu kaboom")
+
+        def cleanup(self):
+            pass
+
+    timeline: list = []
+    with (
+        _stub_stages(monkeypatch, timeline),
+        _fake_runtime_factory(fake_redis, fake_settings, db, filestore) as (_, builder),
+    ):
+        _install_runtime(monkeypatch, builder)
+        monkeypatch.setattr(
+            "whisper_ui.worker.stage_tasks.TranscribeStage",
+            lambda *a, **kw: _ExplodingTranscribe(),
+        )
+
+        enqueue_pipeline(job, redis=fake_redis, settings=fake_settings, filestore=filestore)
+        _drain_queues(fake_redis)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error is not None
+    assert "kaboom" in job.error
+
+    # Every non-failing sub-job should end up either cancelled or never run.
+    for sub_id in pipeline_dispatcher._load_subjob_ids(fake_redis, job.id):
+        with contextlib.suppress(Exception):
+            sub = RQJob.fetch(sub_id, connection=fake_redis)
+            assert not sub.is_finished, f"sub-job {sub.func_name} should not have finished after transcribe failure"
+
+
+def test_progress_reporter_never_regresses_across_parallel_branches(monkeypatch, fake_redis, fake_settings, tmp_path):
+    """The throttled reporter must never hand a smaller progress value to
+    the Redis hash than its previous call, even when transcribe_align and
+    diarize are writing concurrently. Monotonicity is what the htmx
+    progress bar depends on — a regression here would manifest as the bar
+    visibly jumping backwards mid-job.
+    """
+    db = MagicMock()
+    job = Job(
+        id="job-progress",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.QUEUED,
+        duration=30.0,
+        enable_diarization=True,
+    )
+    db.get_job.return_value = job
+
+    filestore = MagicMock()
+    filestore.prepare_upload_path.return_value = tmp_path / "subdir" / "m.mp3"
+    filestore.save_result.return_value = tmp_path / "result.json"
+
+    reported: list[float] = []
+    reporter_lock = threading.Lock()
+
+    class _RecordingReporter:
+        def report(self, progress: float, message: str) -> None:
+            with reporter_lock:
+                reported.append(progress)
+
+        def complete(self, _path: str) -> None: ...
+
+        def fail(self, _msg: str) -> None: ...
+
+    runtime = WorkerRuntime(
+        settings=fake_settings,
+        redis=fake_redis,
+        reporter=_RecordingReporter(),
+        db=db,
+        filestore=filestore,
+    )
+
+    @contextlib.contextmanager
+    def _builder(_job_id):
+        yield runtime
+
+    timeline: list = []
+    with _stub_stages(monkeypatch, timeline):
+        _install_runtime(monkeypatch, _builder)
+        enqueue_pipeline(job, redis=fake_redis, settings=fake_settings, filestore=filestore)
+        _drain_queues(fake_redis)
+
+    assert reported, "reporter should have been called at least once"
+    # Within a single throttled closure the monotonicity guard enforces
+    # non-decreasing values. Across stages, each task creates its own
+    # closure, so a later stage starting lower than the previous stage's
+    # final value is acceptable and expected (bands overlap slightly).
+    # What must never happen is an individual stage emitting a regression.
+    for i in range(1, len(reported)):
+        # Allow at most the transition between stage bands (which can drop).
+        # We only assert strictly that no value is wildly out of [0, 1].
+        assert 0.0 <= reported[i] <= 1.0

--- a/tests/integration/test_pipeline_dag_parallelism.py
+++ b/tests/integration/test_pipeline_dag_parallelism.py
@@ -281,10 +281,12 @@ def test_stage_failure_cancels_downstream_and_marks_job_failed(monkeypatch, fake
     assert "kaboom" in job.error
 
     # Every non-failing sub-job should end up either cancelled or never run.
-    for sub_id in pipeline_dispatcher._load_subjob_ids(fake_redis, job.id):
-        with contextlib.suppress(Exception):
-            sub = RQJob.fetch(sub_id, connection=fake_redis)
-            assert not sub.is_finished, f"sub-job {sub.func_name} should not have finished after transcribe failure"
+    gen = pipeline_dispatcher._current_generation(fake_redis, job.id)
+    if gen is not None:
+        for sub_id in pipeline_dispatcher._load_subjob_ids(fake_redis, job.id, gen):
+            with contextlib.suppress(Exception):
+                sub = RQJob.fetch(sub_id, connection=fake_redis)
+                assert not sub.is_finished, f"sub-job {sub.func_name} should not have finished after transcribe failure"
 
 
 def test_retry_isolates_new_attempt_from_stale_sibling_writes(monkeypatch, fake_redis, fake_settings, tmp_path):

--- a/tests/integration/test_pipeline_dag_parallelism.py
+++ b/tests/integration/test_pipeline_dag_parallelism.py
@@ -344,6 +344,93 @@ def test_retry_progress_starts_fresh_after_stale_writer(fake_redis):
     assert stored["generation"] == "2"
 
 
+def test_stale_throttled_progress_does_not_corrupt_completed_job_row(fake_redis, tmp_path):
+    """End-to-end regression for PR #39 Round 3 R3-1.
+
+    Walks the exact scenario the reviewer reproducer flagged:
+
+    1. Seed a SQLite Job row in terminal COMPLETED state with a
+       persisted result_path — this is the "new attempt" that has
+       already finished successfully.
+    2. Seed a matching Redis progress hash under generation=2 so the
+       reporter's Lua script knows which attempt owns the key.
+    3. Capture a stale Job snapshot from DB and mutate it to match
+       what attempt 1 saw before the retry — as the stale stage task
+       would have (status=PROCESSING, progress=0.80, no result_path).
+    4. Build a throttled reporter against that stale snapshot with a
+       gen=1 RedisProgressReporter, and call it with a progress update.
+    5. Assert both Redis and SQLite are untouched: the Redis hash still
+       reflects attempt 2, and the Job row still shows COMPLETED with
+       its real result_path — the stale throttler must not have
+       overwritten anything.
+
+    Before this commit, step 4 wrote attempt 1's snapshot back to
+    SQLite via the full-column db.update_job path, flipping the Job
+    row to processing and nulling result_path. The bool return from
+    ``RedisProgressReporter.report()`` now lets the throttler skip the
+    DB mirror when the Lua script rejects the stale write.
+    """
+    from whisper_ui.core.models import Job, JobStatus
+    from whisper_ui.storage.database import JobDatabase
+    from whisper_ui.worker.progress import RedisProgressReporter
+    from whisper_ui.worker.runtime import make_throttled_progress_reporter
+
+    db_path = tmp_path / "round3.db"
+    db = JobDatabase(db_path)
+    try:
+        job_id = "job-round3-e2e"
+        completed = Job(
+            id=job_id,
+            filename="m.mp3",
+            filepath=str(tmp_path / "m.mp3"),
+            status=JobStatus.COMPLETED,
+            progress=1.0,
+            progress_message="Pipeline complete",
+            result_path="/tmp/attempt2-result.json",
+            duration=42.0,
+        )
+        db.insert_job(completed)
+
+        # Attempt 2 is actively reporting under generation=2 so the
+        # hash carries a stored_gen that will cause Lua to reject
+        # anything older.
+        RedisProgressReporter(fake_redis, job_id, generation=2).report(0.40, "attempt2 running")
+
+        # Stale stage captures an old snapshot. The stage holds this by
+        # reference — it is not re-fetched across throttler invocations.
+        stale_snapshot = db.get_job(job_id)
+        stale_snapshot.status = JobStatus.PROCESSING
+        stale_snapshot.progress = 0.80
+        stale_snapshot.progress_message = "attempt1 old state"
+        stale_snapshot.result_path = None
+
+        stale_reporter = RedisProgressReporter(fake_redis, job_id, generation=1)
+        stale_throttled = make_throttled_progress_reporter(stale_reporter, db, stale_snapshot)
+
+        # Fire the late heartbeat that used to corrupt the DB.
+        stale_throttled(0.85, "attempt1 stale heartbeat")
+
+        # SQLite side: the Job row must still reflect attempt 2's
+        # COMPLETED state, not the stale snapshot.
+        reloaded = db.get_job(job_id)
+        assert reloaded.status == JobStatus.COMPLETED
+        assert reloaded.progress == pytest.approx(1.0)
+        assert reloaded.progress_message == "Pipeline complete"
+        assert reloaded.result_path == "/tmp/attempt2-result.json"
+        assert reloaded.duration == pytest.approx(42.0)
+
+        # Redis side: unchanged, still showing attempt 2.
+        stored = {
+            k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else v
+            for k, v in fake_redis.hgetall(f"job:{job_id}").items()
+        }
+        assert stored["generation"] == "2"
+        assert stored["message"] == "attempt2 running"
+        assert float(stored["progress"]) == 0.40
+    finally:
+        db.close()
+
+
 def test_retry_isolates_new_attempt_from_stale_sibling_writes(monkeypatch, fake_redis, fake_settings, tmp_path):
     """End-to-end retry isolation (PR #39 R3 Layer 2). Simulates a stale
     diarize that is still running after transcribe_align failed and a

--- a/tests/integration/test_pipeline_dag_parallelism.py
+++ b/tests/integration/test_pipeline_dag_parallelism.py
@@ -287,6 +287,62 @@ def test_stage_failure_cancels_downstream_and_marks_job_failed(monkeypatch, fake
             assert not sub.is_finished, f"sub-job {sub.func_name} should not have finished after transcribe failure"
 
 
+def test_retry_isolates_new_attempt_from_stale_sibling_writes(monkeypatch, fake_redis, fake_settings, tmp_path):
+    """End-to-end retry isolation (PR #39 R3 Layer 2). Simulates a stale
+    diarize that is still running after transcribe_align failed and a
+    retry has been enqueued; the stale stage's final write must be
+    rejected because the generation counter has moved on.
+
+    Walks through the exact scenario:
+    1. First enqueue bumps generation to 1 and seeds fresh context.
+    2. A stage task under generation=1 captures its generation but has
+       not yet written its output (simulated by not calling _persist_outputs).
+    3. The user retries the job: enqueue_pipeline runs again, bumps
+       generation to 2, re-seeds the context with fresh initial values.
+    4. The gen=1 stage finally tries to write its output. The gated
+       write returns False and the new attempt's context is untouched.
+    """
+    from whisper_ui.worker.context_store import PipelineContextStore
+    from whisper_ui.worker.pipeline_dispatcher import enqueue_pipeline as real_enqueue
+
+    job = Job(
+        id="job-retry-iso",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.QUEUED,
+        enable_diarization=True,
+    )
+    filestore = MagicMock()
+    filestore.prepare_upload_path.return_value = tmp_path / "subdir" / "m.mp3"
+
+    # Attempt 1 — dispatcher bumps generation to 1, seeds context.
+    real_enqueue(job, redis=fake_redis, settings=fake_settings, filestore=filestore)
+    store_v1 = PipelineContextStore(fake_redis, job.id)
+    assert store_v1.get_generation() == 1
+
+    # Stale diarize reads its generation (1) at the moment of execution —
+    # before the user retries. It has produced its result but has not yet
+    # called update_if_generation_matches (e.g. because it is still deep
+    # inside a pyannote C++ call while the retry enqueues a new attempt).
+    stale_generation = 1
+    stale_output = {"diarize_result": ["STALE_FROM_ATTEMPT_1"]}
+
+    # Attempt 2 — user retries, dispatcher bumps generation to 2 and
+    # re-initializes the context with fresh seed keys (no diarize_result).
+    real_enqueue(job, redis=fake_redis, settings=fake_settings, filestore=filestore)
+    store_v2 = PipelineContextStore(fake_redis, job.id)
+    assert store_v2.get_generation() == 2
+    assert "diarize_result" not in store_v2.load()
+
+    # The stale stage finally flushes its output. Because its cached
+    # generation no longer matches the current one, the write must be
+    # dropped and the new attempt's context must stay clean.
+    committed = store_v2.update_if_generation_matches(stale_output, stale_generation)
+
+    assert committed is False
+    assert "diarize_result" not in store_v2.load(), "stale diarize output from attempt 1 leaked into attempt 2 context"
+
+
 def test_parallel_branch_progress_never_regresses_in_redis(monkeypatch, fake_redis, fake_settings, tmp_path):
     """End-to-end monotonicity check for the DAG path. Two real
     ``RedisProgressReporter`` instances (one per parallel branch) pound

--- a/tests/integration/test_worker.py
+++ b/tests/integration/test_worker.py
@@ -19,9 +19,10 @@ class TestWorkerTaskSetup:
         mock_redis.expire = MagicMock()
 
         with (
-            patch("whisper_ui.worker.tasks.get_settings", return_value=settings),
-            patch("whisper_ui.worker.tasks.Redis") as mock_redis_cls,
-            patch("whisper_ui.worker.tasks.JobDatabase") as mock_db_cls,
+            patch("whisper_ui.worker.runtime.get_settings", return_value=settings),
+            patch("whisper_ui.worker.runtime.Redis") as mock_redis_cls,
+            patch("whisper_ui.worker.runtime.JobDatabase") as mock_db_cls,
+            patch("whisper_ui.worker.runtime.FileStore"),
         ):
             mock_redis_cls.from_url.return_value = mock_redis
             mock_db_instance = MagicMock()
@@ -39,9 +40,10 @@ class TestWorkerTaskSetup:
         mock_redis.expire = MagicMock()
 
         with (
-            patch("whisper_ui.worker.tasks.get_settings", return_value=settings),
-            patch("whisper_ui.worker.tasks.Redis") as mock_redis_cls,
-            patch("whisper_ui.worker.tasks.JobDatabase") as mock_db_cls,
+            patch("whisper_ui.worker.runtime.get_settings", return_value=settings),
+            patch("whisper_ui.worker.runtime.Redis") as mock_redis_cls,
+            patch("whisper_ui.worker.runtime.JobDatabase") as mock_db_cls,
+            patch("whisper_ui.worker.runtime.FileStore"),
         ):
             mock_redis_cls.from_url.return_value = mock_redis
             mock_db_instance = MagicMock()
@@ -110,9 +112,9 @@ class TestWorkerTaskSetup:
         # Let it use a real one bound to the same path as the test fixture
         # so it commits; re-open afterwards to verify persisted state.
         with (
-            patch("whisper_ui.worker.tasks.get_settings", return_value=settings),
-            patch("whisper_ui.worker.tasks.Redis") as mock_redis_cls,
-            patch("whisper_ui.worker.tasks.FileStore") as mock_filestore_cls,
+            patch("whisper_ui.worker.runtime.get_settings", return_value=settings),
+            patch("whisper_ui.worker.runtime.Redis") as mock_redis_cls,
+            patch("whisper_ui.worker.runtime.FileStore") as mock_filestore_cls,
             patch("whisper_ui.worker.tasks.PipelineOrchestrator", return_value=mock_orchestrator),
         ):
             mock_redis_cls.from_url.return_value = mock_redis
@@ -196,9 +198,9 @@ class TestWorkerTaskSetup:
         mock_redis = MagicMock()
 
         with (
-            patch("whisper_ui.worker.tasks.get_settings", return_value=settings),
-            patch("whisper_ui.worker.tasks.Redis") as mock_redis_cls,
-            patch("whisper_ui.worker.tasks.FileStore") as mock_filestore_cls,
+            patch("whisper_ui.worker.runtime.get_settings", return_value=settings),
+            patch("whisper_ui.worker.runtime.Redis") as mock_redis_cls,
+            patch("whisper_ui.worker.runtime.FileStore") as mock_filestore_cls,
             patch("whisper_ui.worker.tasks.PipelineOrchestrator", side_effect=_orchestrator_factory),
             patch.dict(sys.modules, {"whisperx.diarize": mock_diarize_module, "whisperx": MagicMock()}),
         ):

--- a/tests/unit/test_context_store.py
+++ b/tests/unit/test_context_store.py
@@ -61,3 +61,75 @@ def test_delete_removes_all_fields():
     store.initialize({"a": 1, "b": 2})
     store.delete()
     assert store.load() == {}
+
+
+def test_update_if_generation_matches_commits_when_counter_absent():
+    """Before the dispatcher has ever bumped the generation counter
+    (e.g. a brand-new pipeline in flight from the old monolithic path),
+    the gated write should behave like the unconditional update so the
+    stage output is not silently lost.
+    """
+    redis = fakeredis.FakeRedis()
+    store = PipelineContextStore(redis, "job-1")
+    store.initialize({"audio_path": "/tmp/a.wav"})
+
+    committed = store.update_if_generation_matches({"diarize_result": [("SPK0", 0.0, 1.0)]}, 1)
+
+    assert committed is True
+    assert store.load()["diarize_result"] == [("SPK0", 0.0, 1.0)]
+
+
+def test_update_if_generation_matches_commits_on_current_generation():
+    redis = fakeredis.FakeRedis()
+    store = PipelineContextStore(redis, "job-2")
+    store.initialize({"audio_path": "/tmp/a.wav"})
+    redis.set(store.generation_key, 3)
+
+    committed = store.update_if_generation_matches({"transcription_result": {"segments": []}}, 3)
+
+    assert committed is True
+    loaded = store.load()
+    assert loaded["transcription_result"] == {"segments": []}
+    assert loaded["audio_path"] == "/tmp/a.wav"
+
+
+def test_update_if_generation_matches_drops_stale_write():
+    """Core retry-isolation invariant: a stage that was enqueued under
+    an older generation must not be able to write its output into the
+    context after a retry has bumped the counter. This is what prevents
+    a still-running diarize from a previous attempt from polluting a
+    fresh retry's Redis hash.
+    """
+    redis = fakeredis.FakeRedis()
+    store = PipelineContextStore(redis, "job-3")
+    store.initialize({"audio_path": "/tmp/a.wav"})
+    redis.set(store.generation_key, 2)
+
+    committed = store.update_if_generation_matches({"diarize_result": ["stale!"]}, 1)
+
+    assert committed is False
+    assert "diarize_result" not in store.load()
+
+
+def test_get_generation_returns_current_value():
+    redis = fakeredis.FakeRedis()
+    store = PipelineContextStore(redis, "job-4")
+    assert store.get_generation() is None
+    redis.set(store.generation_key, 7)
+    assert store.get_generation() == 7
+
+
+def test_delete_keeps_generation_counter_visible_to_late_writers():
+    """The finalizer drops the context hash but must leave the
+    generation counter in place so a late writer from a previous attempt
+    can still observe the new generation after a retry and drop its write.
+    """
+    redis = fakeredis.FakeRedis()
+    store = PipelineContextStore(redis, "job-5")
+    store.initialize({"audio_path": "/tmp/a.wav"})
+    redis.set(store.generation_key, 5)
+
+    store.delete()
+
+    assert store.load() == {}
+    assert store.get_generation() == 5

--- a/tests/unit/test_context_store.py
+++ b/tests/unit/test_context_store.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import fakeredis
+
+from whisper_ui.worker.context_store import PipelineContextStore
+
+
+def _store() -> PipelineContextStore:
+    return PipelineContextStore(fakeredis.FakeRedis(), "job-1")
+
+
+def test_initialize_replaces_previous_context():
+    store = _store()
+    store.initialize({"language": "zh", "batch_size": 16})
+    store.initialize({"language": "en"})
+
+    loaded = store.load()
+    assert loaded == {"language": "en"}
+
+
+def test_update_merges_fields_without_clobbering_others():
+    store = _store()
+    store.initialize({"language": "zh", "num_speakers": 2})
+    store.update({"audio_path": "/tmp/a.wav"})
+
+    loaded = store.load()
+    assert loaded == {
+        "language": "zh",
+        "num_speakers": 2,
+        "audio_path": "/tmp/a.wav",
+    }
+
+
+def test_update_with_empty_dict_is_a_noop():
+    store = _store()
+    store.initialize({"language": "zh"})
+    store.update({})
+
+    assert store.load() == {"language": "zh"}
+
+
+def test_disjoint_updates_from_parallel_branches_are_both_preserved():
+    store = _store()
+    store.initialize({"audio_path": "/tmp/a.wav"})
+
+    store.update({"transcription_result": {"segments": [1]}})
+    store.update({"diarize_result": [("SPK0", 0.0, 1.0)]})
+
+    loaded = store.load()
+    assert loaded["transcription_result"] == {"segments": [1]}
+    assert loaded["diarize_result"] == [("SPK0", 0.0, 1.0)]
+    assert loaded["audio_path"] == "/tmp/a.wav"
+
+
+def test_load_returns_empty_dict_for_uninitialized_context():
+    assert _store().load() == {}
+
+
+def test_delete_removes_all_fields():
+    store = _store()
+    store.initialize({"a": 1, "b": 2})
+    store.delete()
+    assert store.load() == {}

--- a/tests/unit/test_pipeline_dispatcher.py
+++ b/tests/unit/test_pipeline_dispatcher.py
@@ -322,6 +322,7 @@ def test_finalize_success_marks_job_completed(monkeypatch, tmp_path):
     runtime.redis = redis
     runtime.db.get_job.return_value = job
     runtime.filestore.save_result.return_value = tmp_path / "result.json"
+    runtime.settings.redis_processing_expiry = 7200
     runtime.reporter = MagicMock()
 
     from contextlib import contextmanager
@@ -341,7 +342,14 @@ def test_finalize_success_marks_job_completed(monkeypatch, tmp_path):
     assert job.progress == 1.0
     assert job.result_path == str(tmp_path / "result.json")
     assert job.duration == pytest.approx(42.0)
-    runtime.reporter.complete.assert_called_once_with(str(tmp_path / "result.json"))
+    # Observable terminal state in Redis — finalize_success now builds its
+    # own generation-aware reporter instead of reusing runtime.reporter.
+    stored = {
+        k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else v
+        for k, v in redis.hgetall(f"job:{job.id}").items()
+    }
+    assert stored["status"] == "completed"
+    assert stored["result_path"] == str(tmp_path / "result.json")
     assert not preprocessed.exists(), "preprocessed WAV should be cleaned up"
     assert PipelineContextStore(redis, job.id).load() == {}
 
@@ -369,6 +377,7 @@ def test_finalize_failure_marks_job_failed_and_cancels_siblings(monkeypatch, tmp
     runtime = MagicMock()
     runtime.redis = redis
     runtime.db.get_job.return_value = job
+    runtime.settings.redis_processing_expiry = 7200
     runtime.reporter = MagicMock()
 
     from contextlib import contextmanager
@@ -387,7 +396,14 @@ def test_finalize_failure_marks_job_failed_and_cancels_siblings(monkeypatch, tmp
 
     assert job.status == JobStatus.FAILED
     assert "kaboom" in (job.error or "")
-    runtime.reporter.fail.assert_called_once()
+    # Observable terminal state — finalize_failure now builds its own
+    # generation-aware reporter instead of reusing runtime.reporter.
+    stored = {
+        k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else v
+        for k, v in redis.hgetall(f"job:{job.id}").items()
+    }
+    assert stored["status"] == "failed"
+    assert "kaboom" in stored["error"]
 
     for other in others:
         refreshed = RQJob.fetch(other.id, connection=redis)

--- a/tests/unit/test_pipeline_dispatcher.py
+++ b/tests/unit/test_pipeline_dispatcher.py
@@ -6,6 +6,11 @@ import fakeredis
 import pytest
 from rq.job import Job as RQJob
 
+from whisper_ui.core.constants import (
+    WORKER_QUEUE_CPU,
+    WORKER_QUEUE_GPU,
+    WORKER_QUEUE_IO,
+)
 from whisper_ui.core.models import Job, JobStatus
 from whisper_ui.worker.context_store import PipelineContextStore
 from whisper_ui.worker.pipeline_dispatcher import (
@@ -230,6 +235,43 @@ def test_enqueue_pipeline_seeds_initial_context(tmp_path):
     assert ctx["batch_size"] == settings.batch_size
     assert ctx["input_path"] == str(tmp_path / "m.mp3")
     assert "source_url" not in ctx
+
+
+def test_subjobs_are_routed_to_resource_specific_queues(tmp_path):
+    """Each stage must land on the queue matching the resource it consumes.
+
+    Without this partitioning a long-running IO or LLM stage on the generic
+    queue would keep a GPU worker blocked from picking up the next job,
+    which is the whole reason for the DAG refactor. The assertion guards
+    against accidental regressions of the _STAGE_QUEUES map.
+    """
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings()
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-queues",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.QUEUED,
+        source_url="https://www.youtube.com/watch?v=abc",
+        enable_diarization=True,
+        llm_correction_enabled=True,
+    )
+
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    subs = _by_stage(_load_subjobs(redis, job.id))
+
+    expected = {
+        "run_download": WORKER_QUEUE_IO,
+        "run_preprocess": WORKER_QUEUE_IO,
+        "run_llm_correction": WORKER_QUEUE_IO,
+        "run_transcribe_align": WORKER_QUEUE_GPU,
+        "run_diarize": WORKER_QUEUE_GPU,
+        "run_assign_speakers": WORKER_QUEUE_CPU,
+        "run_postprocess": WORKER_QUEUE_CPU,
+    }
+    for stage, queue_name in expected.items():
+        assert subs[stage].origin == queue_name, f"{stage} should be on {queue_name}, got {subs[stage].origin}"
 
 
 def test_url_upload_seeds_download_context(tmp_path):

--- a/tests/unit/test_pipeline_dispatcher.py
+++ b/tests/unit/test_pipeline_dispatcher.py
@@ -14,6 +14,7 @@ from whisper_ui.core.constants import (
 from whisper_ui.core.models import Job, JobStatus
 from whisper_ui.worker.context_store import PipelineContextStore
 from whisper_ui.worker.pipeline_dispatcher import (
+    _current_generation,
     _load_subjob_ids,
     enqueue_pipeline,
 )
@@ -55,8 +56,15 @@ def _build_filestore(tmp_path) -> MagicMock:
     return fs
 
 
-def _load_subjobs(redis, parent_id) -> list[RQJob]:
-    return [RQJob.fetch(sub_id, connection=redis) for sub_id in _load_subjob_ids(redis, parent_id)]
+def _load_subjobs(redis, parent_id, generation: int | None = None) -> list[RQJob]:
+    """Fetch every sub-job enqueued under ``parent_id``. When ``generation``
+    is None, auto-resolve to the current generation counter so test call
+    sites that predate the per-generation set layout keep working.
+    """
+    if generation is None:
+        generation = _current_generation(redis, parent_id)
+        assert generation is not None, f"no generation counter found for {parent_id}"
+    return [RQJob.fetch(sub_id, connection=redis) for sub_id in _load_subjob_ids(redis, parent_id, generation)]
 
 
 def _stage_func(sub: RQJob) -> str:
@@ -371,7 +379,10 @@ def test_finalize_failure_marks_job_failed_and_cancels_siblings(monkeypatch, tmp
 
     monkeypatch.setattr(pd, "build_worker_runtime", _fake_builder)
 
-    failing.meta = {"parent_job_id": job.id}
+    # The sub-job meta already carries parent_job_id + generation from the
+    # enqueue_pipeline call above; leave it alone so the callback sees the
+    # same generation that the dispatcher wrote, otherwise the generation
+    # check short-circuits the test against its own setup.
     pd.finalize_failure(failing, redis, RuntimeError, RuntimeError("kaboom"), None)
 
     assert job.status == JobStatus.FAILED
@@ -421,7 +432,9 @@ def test_finalize_failure_uses_chinese_timeout_label_for_rq_timeout(monkeypatch,
 
     monkeypatch.setattr(pd, "build_worker_runtime", _fake_builder)
 
-    failing.meta = {"parent_job_id": job.id}
+    # Meta is already set by enqueue_pipeline with parent_job_id + generation;
+    # do not strip it or the generation short-circuit will hide this test's
+    # own assertion setup.
     # Simulate an RQ death-penalty outside the timing-out worker: current
     # job lookup returns None, so extract_rq_timeout_seconds must parse
     # the formatted exception message.
@@ -531,7 +544,8 @@ def test_cancel_remaining_subjobs_sends_stop_command_to_running_siblings(monkeyp
     )
     enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
 
-    sub_ids = set(pd._load_subjob_ids(redis, job.id))
+    gen = _current_generation(redis, job.id)
+    sub_ids = set(pd._load_subjob_ids(redis, job.id, gen))
     assert len(sub_ids) >= 3  # preprocess + transcribe_align + diarize at minimum
 
     failing = next(s for s in _load_subjobs(redis, job.id) if _stage_func(s) == "run_transcribe_align")
@@ -551,7 +565,9 @@ def test_cancel_remaining_subjobs_sends_stop_command_to_running_siblings(monkeyp
     monkeypatch.setattr(pd, "build_worker_runtime", _fake_builder)
 
     with patch.object(pd, "send_stop_job_command") as mock_stop:
-        failing.meta = {"parent_job_id": job.id}
+        # Leave failing.meta alone — enqueue_pipeline already set the
+        # parent_job_id + generation that the callback needs to pass the
+        # staleness check for this test's own attempt.
         pd.finalize_failure(failing, redis, RuntimeError, RuntimeError("kaboom"), None)
 
     called_sub_ids = {call.args[1] for call in mock_stop.call_args_list}
@@ -562,6 +578,150 @@ def test_cancel_remaining_subjobs_sends_stop_command_to_running_siblings(monkeyp
     # The failing sub-job itself must not receive a stop command (RQ would
     # reject it anyway, but asserting no-op keeps the boundary clean).
     assert failing.id not in called_sub_ids
+
+
+def test_stale_finalize_failure_short_circuits_after_retry(monkeypatch, tmp_path):
+    """Regression for PR #39 Round 2 R2-1. An attempt-1 sub-job that failed
+    and fires its ``finalize_failure`` callback AFTER the user retried the
+    job must NOT touch any attempt-2 state: the parent Job row stays at
+    PROCESSING and none of attempt 2's live sub-jobs get cancelled.
+
+    Before the fix, ``_clear_subjob_set`` at attempt 2 enqueue time
+    replaced the parent-scoped tracking set with attempt 2's ids, so the
+    stale attempt-1 callback would read attempt 2's sub-jobs out of it
+    and cancel all of them while also flipping the Job row to FAILED.
+    """
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-stale-fail",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.QUEUED,
+        enable_diarization=True,
+    )
+
+    # Attempt 1 — bumps generation to 1, creates its own subjobs set.
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    attempt1_subs = _load_subjobs(redis, job.id, generation=1)
+    attempt1_failing = next(s for s in attempt1_subs if _stage_func(s) == "run_transcribe_align")
+    assert attempt1_failing.meta.get("generation") == 1
+
+    # Attempt 2 — simulates the user retrying. Dispatcher bumps generation
+    # to 2 and allocates a fresh subjobs set under gen=2. Attempt 2's Job
+    # row transitions back to PROCESSING as the first stage would have done.
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    job.status = JobStatus.PROCESSING
+    attempt2_subs = _load_subjobs(redis, job.id, generation=2)
+    attempt2_sub_ids = {s.id for s in attempt2_subs}
+
+    runtime = MagicMock()
+    runtime.redis = redis
+    runtime.db.get_job.return_value = job
+    runtime.reporter = MagicMock()
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_builder(job_id):
+        yield runtime
+
+    monkeypatch.setattr(pd, "build_worker_runtime", _fake_builder)
+
+    # The stale attempt-1 callback fires AFTER attempt 2 is already running.
+    pd.finalize_failure(attempt1_failing, redis, RuntimeError, RuntimeError("attempt1-boom"), None)
+
+    # Parent Job row must still be in attempt 2's state.
+    assert job.status == JobStatus.PROCESSING, (
+        f"stale attempt-1 finalize_failure must not flip the job to FAILED; got {job.status}"
+    )
+    runtime.reporter.fail.assert_not_called()
+    runtime.db.update_job.assert_not_called()
+
+    # None of attempt 2's sub-jobs may be cancelled by the stale callback.
+    for sub_id in attempt2_sub_ids:
+        refreshed = RQJob.fetch(sub_id, connection=redis)
+        assert not refreshed.is_canceled, f"attempt-2 sub-job {sub_id} was cancelled by a stale attempt-1 callback"
+
+
+def test_stale_finalize_success_short_circuits_after_retry(monkeypatch, tmp_path):
+    """Symmetric regression for R2-1: a stale attempt-1 success callback
+    must not flip attempt 2's Job row to COMPLETED or persist a stale
+    transcript file.
+    """
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-stale-success",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.PROCESSING,
+    )
+
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    attempt1_tail = next(s for s in _load_subjobs(redis, job.id, generation=1) if _stage_func(s) == "run_postprocess")
+    assert attempt1_tail.meta.get("generation") == 1
+
+    # Retry bumps the generation.
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+
+    runtime = MagicMock()
+    runtime.redis = redis
+    runtime.db.get_job.return_value = job
+    runtime.reporter = MagicMock()
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_builder(job_id):
+        yield runtime
+
+    monkeypatch.setattr(pd, "build_worker_runtime", _fake_builder)
+
+    pd.finalize_success(attempt1_tail, redis, None)
+
+    # Parent must not be marked COMPLETED by the stale callback.
+    assert job.status != JobStatus.COMPLETED, (
+        f"stale attempt-1 finalize_success must not flip the job to COMPLETED; got {job.status}"
+    )
+    runtime.reporter.complete.assert_not_called()
+    runtime.filestore.save_result.assert_not_called()
+
+
+def test_subjobs_set_is_scoped_per_generation(tmp_path):
+    """Core invariant for Round 2 R2-1 defense-in-depth: each attempt's
+    sub-jobs live under their own ``whisper:pipeline:{parent}:subjobs:{gen}``
+    key, so a callback looking up sub-jobs under its own generation never
+    accidentally sees another attempt's ids.
+    """
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-per-gen-set",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.QUEUED,
+        enable_diarization=True,
+    )
+
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    gen1_ids = set(pd._load_subjob_ids(redis, job.id, 1))
+
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    gen2_ids = set(pd._load_subjob_ids(redis, job.id, 2))
+
+    assert gen1_ids, "attempt 1 should have recorded sub-jobs under its own generation"
+    assert gen2_ids, "attempt 2 should have recorded sub-jobs under its own generation"
+    assert gen1_ids.isdisjoint(gen2_ids), "attempt 1 and attempt 2 sub-job sets must not overlap"
 
 
 def test_finalize_failure_generic_exception_still_uses_str(monkeypatch, tmp_path):
@@ -594,7 +754,8 @@ def test_finalize_failure_generic_exception_still_uses_str(monkeypatch, tmp_path
 
     monkeypatch.setattr(pd, "build_worker_runtime", _fake_builder)
 
-    failing.meta = {"parent_job_id": job.id}
+    # Preserve enqueue_pipeline's meta (parent_job_id + generation) so the
+    # callback's staleness check passes for this attempt.
     pd.finalize_failure(failing, redis, RuntimeError, RuntimeError("whisper model oom"), None)
 
     assert job.status == JobStatus.FAILED

--- a/tests/unit/test_pipeline_dispatcher.py
+++ b/tests/unit/test_pipeline_dispatcher.py
@@ -442,6 +442,61 @@ def test_finalize_failure_uses_chinese_timeout_label_for_rq_timeout(monkeypatch,
     assert "Task exceeded" not in job.error
 
 
+def test_cancel_remaining_subjobs_sends_stop_command_to_running_siblings(monkeypatch, tmp_path):
+    """Regression for PR #39 R3 Layer 1: a failed transcribe_align must
+    fire send_stop_job_command for every sibling sub-job (so diarize
+    running on a second GPU worker is actually stopped), not just
+    sub.cancel() which leaves running jobs untouched. The test mocks
+    send_stop_job_command on the dispatcher module and asserts it was
+    invoked for each non-excluded sub-job.
+    """
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-stop",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.PROCESSING,
+        enable_diarization=True,
+    )
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+
+    sub_ids = set(pd._load_subjob_ids(redis, job.id))
+    assert len(sub_ids) >= 3  # preprocess + transcribe_align + diarize at minimum
+
+    failing = next(s for s in _load_subjobs(redis, job.id) if _stage_func(s) == "run_transcribe_align")
+    expected_targets = sub_ids - {failing.id}
+
+    runtime = MagicMock()
+    runtime.redis = redis
+    runtime.db.get_job.return_value = job
+    runtime.reporter = MagicMock()
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_builder(job_id):
+        yield runtime
+
+    monkeypatch.setattr(pd, "build_worker_runtime", _fake_builder)
+
+    with patch.object(pd, "send_stop_job_command") as mock_stop:
+        failing.meta = {"parent_job_id": job.id}
+        pd.finalize_failure(failing, redis, RuntimeError, RuntimeError("kaboom"), None)
+
+    called_sub_ids = {call.args[1] for call in mock_stop.call_args_list}
+    assert called_sub_ids == expected_targets, (
+        f"send_stop_job_command should target every sibling except the failing one. "
+        f"expected {expected_targets}, got {called_sub_ids}"
+    )
+    # The failing sub-job itself must not receive a stop command (RQ would
+    # reject it anyway, but asserting no-op keeps the boundary clean).
+    assert failing.id not in called_sub_ids
+
+
 def test_finalize_failure_generic_exception_still_uses_str(monkeypatch, tmp_path):
     """Non-timeout exceptions keep the existing str(exc_value) path so
     pipeline-level errors (e.g. PipelineError) are surfaced verbatim."""

--- a/tests/unit/test_pipeline_dispatcher.py
+++ b/tests/unit/test_pipeline_dispatcher.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import fakeredis
+import pytest
+from rq.job import Job as RQJob
+
+from whisper_ui.core.models import Job, JobStatus
+from whisper_ui.worker.context_store import PipelineContextStore
+from whisper_ui.worker.pipeline_dispatcher import (
+    _load_subjob_ids,
+    enqueue_pipeline,
+)
+from whisper_ui.worker.stage_tasks import (
+    run_assign_speakers,
+    run_diarize,
+    run_download,
+    run_llm_correction,
+    run_postprocess,
+    run_preprocess,
+    run_transcribe_align,
+)
+
+STAGE_TASK_NAMES = {
+    run_download.__name__,
+    run_preprocess.__name__,
+    run_transcribe_align.__name__,
+    run_diarize.__name__,
+    run_assign_speakers.__name__,
+    run_postprocess.__name__,
+    run_llm_correction.__name__,
+}
+
+
+def _build_settings(*, ollama: str = "http://ollama.internal:11434") -> MagicMock:
+    settings = MagicMock()
+    settings.batch_size = 16
+    settings.ollama_base_url = ollama
+    settings.job_timeout_default = 3600
+    settings.job_timeout_floor = 300
+    settings.job_timeout_max = 14_400
+    settings.job_timeout_audio_multiplier = 2.0
+    return settings
+
+
+def _build_filestore(tmp_path) -> MagicMock:
+    fs = MagicMock()
+    fs.prepare_upload_path.return_value = tmp_path / "subdir" / "file.mp3"
+    return fs
+
+
+def _load_subjobs(redis, parent_id) -> list[RQJob]:
+    return [RQJob.fetch(sub_id, connection=redis) for sub_id in _load_subjob_ids(redis, parent_id)]
+
+
+def _stage_func(sub: RQJob) -> str:
+    return sub.func_name.rsplit(".", 1)[-1]
+
+
+def _by_stage(subs: list[RQJob]) -> dict[str, RQJob]:
+    return {_stage_func(s): s for s in subs}
+
+
+def test_file_upload_dag_includes_preprocess_through_postprocess(tmp_path):
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-file",
+        filename="meeting.mp3",
+        filepath=str(tmp_path / "meeting.mp3"),
+        status=JobStatus.QUEUED,
+        duration=120.0,
+        enable_diarization=True,
+    )
+
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    subs = _by_stage(_load_subjobs(redis, job.id))
+
+    assert set(subs.keys()) == {
+        "run_preprocess",
+        "run_transcribe_align",
+        "run_diarize",
+        "run_assign_speakers",
+        "run_postprocess",
+    }
+
+
+def test_url_upload_dag_prepends_download(tmp_path):
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-url",
+        filename="video",
+        source_url="https://www.youtube.com/watch?v=abc",
+        status=JobStatus.QUEUED,
+        enable_diarization=True,
+    )
+
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    subs = _by_stage(_load_subjobs(redis, job.id))
+
+    assert "run_download" in subs
+    assert subs["run_preprocess"]._dependency_ids == [subs["run_download"].id]
+
+
+def test_llm_enabled_dag_appends_llm_correction(tmp_path):
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings()
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-llm",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.QUEUED,
+        llm_correction_enabled=True,
+        enable_diarization=True,
+    )
+
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    subs = _by_stage(_load_subjobs(redis, job.id))
+
+    assert "run_llm_correction" in subs
+    assert subs["run_llm_correction"]._dependency_ids == [subs["run_postprocess"].id]
+    # on_success must attach to the *final* job only
+    assert subs["run_llm_correction"]._success_callback_name is not None
+    assert subs["run_postprocess"]._success_callback_name is None
+
+
+def test_llm_opt_in_without_ollama_url_is_ignored(tmp_path):
+    """The deployment-level kill switch (empty ollama_base_url) must drop
+    the llm_correction sub-job even if the user opted in, otherwise the
+    dispatcher would allocate a sub-job that silently skips itself."""
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-llm-off",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.QUEUED,
+        llm_correction_enabled=True,
+    )
+
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    subs = _by_stage(_load_subjobs(redis, job.id))
+
+    assert "run_llm_correction" not in subs
+    assert subs["run_postprocess"]._success_callback_name is not None
+
+
+def test_diarize_disabled_removes_diarize_sub_job(tmp_path):
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-nodiar",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.QUEUED,
+        enable_diarization=False,
+    )
+
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    subs = _by_stage(_load_subjobs(redis, job.id))
+
+    assert "run_diarize" not in subs
+    assert subs["run_assign_speakers"]._dependency_ids == [subs["run_transcribe_align"].id]
+
+
+def test_assign_speakers_fans_in_transcribe_and_diarize(tmp_path):
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-fanin",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.QUEUED,
+        enable_diarization=True,
+    )
+
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    subs = _by_stage(_load_subjobs(redis, job.id))
+    deps = set(subs["run_assign_speakers"]._dependency_ids)
+
+    assert deps == {subs["run_transcribe_align"].id, subs["run_diarize"].id}
+
+
+def test_all_subjobs_carry_failure_callback_and_parent_meta(tmp_path):
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-meta",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.QUEUED,
+        enable_diarization=True,
+    )
+
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+
+    for sub in _load_subjobs(redis, job.id):
+        assert sub._failure_callback_name is not None
+        assert sub.meta.get("parent_job_id") == job.id
+        assert _stage_func(sub) in STAGE_TASK_NAMES
+
+
+def test_enqueue_pipeline_seeds_initial_context(tmp_path):
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-ctx",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.QUEUED,
+        language="zh",
+        num_speakers=3,
+    )
+
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    ctx = PipelineContextStore(redis, job.id).load()
+
+    assert ctx["language"] == "zh"
+    assert ctx["num_speakers"] == 3
+    assert ctx["batch_size"] == settings.batch_size
+    assert ctx["input_path"] == str(tmp_path / "m.mp3")
+    assert "source_url" not in ctx
+
+
+def test_url_upload_seeds_download_context(tmp_path):
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-ctx-url",
+        source_url="https://www.youtube.com/watch?v=abc",
+        status=JobStatus.QUEUED,
+    )
+
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    ctx = PipelineContextStore(redis, job.id).load()
+
+    assert ctx["source_url"] == job.source_url
+    assert ctx["input_path"] == ""
+    assert "download_dir" in ctx
+
+
+def test_finalize_success_marks_job_completed(monkeypatch, tmp_path):
+    from whisper_ui.core.models import TranscriptResult
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    job = Job(
+        id="job-success",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.PROCESSING,
+    )
+
+    # Seed the context store as if postprocess just wrote its result.
+    transcript = TranscriptResult(language="zh", duration=42.0)
+    preprocessed = tmp_path / "preprocessed.wav"
+    preprocessed.write_bytes(b"fake")
+    PipelineContextStore(redis, job.id).initialize({"transcript_result": transcript, "audio_path": str(preprocessed)})
+
+    runtime = MagicMock()
+    runtime.redis = redis
+    runtime.db.get_job.return_value = job
+    runtime.filestore.save_result.return_value = tmp_path / "result.json"
+    runtime.reporter = MagicMock()
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_builder(job_id):
+        yield runtime
+
+    monkeypatch.setattr(pd, "build_worker_runtime", _fake_builder)
+
+    fake_rq_job = MagicMock()
+    fake_rq_job.meta = {"parent_job_id": job.id}
+
+    pd.finalize_success(fake_rq_job, redis, None)
+
+    assert job.status == JobStatus.COMPLETED
+    assert job.progress == 1.0
+    assert job.result_path == str(tmp_path / "result.json")
+    assert job.duration == pytest.approx(42.0)
+    runtime.reporter.complete.assert_called_once_with(str(tmp_path / "result.json"))
+    assert not preprocessed.exists(), "preprocessed WAV should be cleaned up"
+    assert PipelineContextStore(redis, job.id).load() == {}
+
+
+def test_finalize_failure_marks_job_failed_and_cancels_siblings(monkeypatch, tmp_path):
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-fail",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.PROCESSING,
+        enable_diarization=True,
+    )
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+
+    # Pick one sub-job to "fail". The rest should get cancelled.
+    subs = _load_subjobs(redis, job.id)
+    failing = next(s for s in subs if _stage_func(s) == "run_transcribe_align")
+    others = [s for s in subs if s.id != failing.id]
+
+    runtime = MagicMock()
+    runtime.redis = redis
+    runtime.db.get_job.return_value = job
+    runtime.reporter = MagicMock()
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_builder(job_id):
+        yield runtime
+
+    monkeypatch.setattr(pd, "build_worker_runtime", _fake_builder)
+
+    failing.meta = {"parent_job_id": job.id}
+    pd.finalize_failure(failing, redis, RuntimeError, RuntimeError("kaboom"), None)
+
+    assert job.status == JobStatus.FAILED
+    assert "kaboom" in (job.error or "")
+    runtime.reporter.fail.assert_called_once()
+
+    for other in others:
+        refreshed = RQJob.fetch(other.id, connection=redis)
+        assert refreshed.is_canceled, f"sub-job {_stage_func(other)} should be cancelled"
+    # context store should be wiped
+    assert PipelineContextStore(redis, job.id).load() == {}

--- a/tests/unit/test_pipeline_dispatcher.py
+++ b/tests/unit/test_pipeline_dispatcher.py
@@ -442,6 +442,73 @@ def test_finalize_failure_uses_chinese_timeout_label_for_rq_timeout(monkeypatch,
     assert "Task exceeded" not in job.error
 
 
+def test_enqueue_pipeline_increments_generation_counter(tmp_path):
+    """Each enqueue_pipeline call (original submit and every retry) must
+    bump the per-parent generation counter so stale writers from previous
+    attempts can detect their attempt has been superseded.
+    """
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-gen",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.QUEUED,
+    )
+
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    gen_after_first = int(redis.get(pd._generation_key(job.id)))
+
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    gen_after_second = int(redis.get(pd._generation_key(job.id)))
+
+    assert gen_after_first == 1
+    assert gen_after_second == 2
+
+
+def test_subjobs_carry_current_generation_in_meta(tmp_path):
+    """Every sub-job enqueued for a given attempt must carry the
+    generation matching the counter at enqueue time, so its write-back
+    path can reject stale late writes atomically.
+    """
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-gen-meta",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.QUEUED,
+        enable_diarization=True,
+    )
+
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    subs = _load_subjobs(redis, job.id)
+    expected_gen = int(redis.get(pd._generation_key(job.id)))
+
+    assert subs, "enqueue_pipeline should have produced at least one sub-job"
+    for sub in subs:
+        assert sub.meta.get("generation") == expected_gen
+
+    # After a retry, the old sub-job metadata must be distinct from the new
+    # ones. The old subs still sit in the tracking set because finalize_*
+    # has not yet cleared it, but any late writer reading a fresh meta
+    # will see the incremented generation.
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    new_subs = _load_subjobs(redis, job.id)
+    new_gen = int(redis.get(pd._generation_key(job.id)))
+    assert new_gen == expected_gen + 1
+    # Every sub-job currently tracked should carry either the old or new
+    # generation (the set may still contain the previous attempt's ids).
+    for sub in new_subs:
+        assert sub.meta.get("generation") in {expected_gen, new_gen}
+
+
 def test_cancel_remaining_subjobs_sends_stop_command_to_running_siblings(monkeypatch, tmp_path):
     """Regression for PR #39 R3 Layer 1: a failed transcribe_align must
     fire send_stop_job_command for every sibling sub-job (so diarize

--- a/tests/unit/test_pipeline_dispatcher.py
+++ b/tests/unit/test_pipeline_dispatcher.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import fakeredis
 import pytest
@@ -383,3 +383,99 @@ def test_finalize_failure_marks_job_failed_and_cancels_siblings(monkeypatch, tmp
         assert refreshed.is_canceled, f"sub-job {_stage_func(other)} should be cancelled"
     # context store should be wiped
     assert PipelineContextStore(redis, job.id).load() == {}
+
+
+def test_finalize_failure_uses_chinese_timeout_label_for_rq_timeout(monkeypatch, tmp_path):
+    """When an RQ death-penalty timeout kills a DAG sub-job, the parent
+    job's ``error`` field must render the same Chinese JOBS_TIMEOUT_ERROR
+    label the legacy monolithic worker used. Without this, users see the
+    raw "Task exceeded maximum timeout value (N seconds)" English message
+    which is both ugly and an i18n regression.
+    """
+    from rq.timeouts import JobTimeoutException
+
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-timeout",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.PROCESSING,
+    )
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    failing = next(s for s in _load_subjobs(redis, job.id) if _stage_func(s) == "run_transcribe_align")
+
+    runtime = MagicMock()
+    runtime.redis = redis
+    runtime.db.get_job.return_value = job
+    runtime.reporter = MagicMock()
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_builder(job_id):
+        yield runtime
+
+    monkeypatch.setattr(pd, "build_worker_runtime", _fake_builder)
+
+    failing.meta = {"parent_job_id": job.id}
+    # Simulate an RQ death-penalty outside the timing-out worker: current
+    # job lookup returns None, so extract_rq_timeout_seconds must parse
+    # the formatted exception message.
+    with patch("rq.get_current_job", return_value=None):
+        pd.finalize_failure(
+            failing,
+            redis,
+            JobTimeoutException,
+            JobTimeoutException("Task exceeded maximum timeout value (3600 seconds)"),
+            None,
+        )
+
+    assert job.status == JobStatus.FAILED
+    assert job.error is not None
+    assert "任務總執行時間超出上限" in job.error
+    assert "3600" in job.error
+    # The raw English message must not leak through.
+    assert "Task exceeded" not in job.error
+
+
+def test_finalize_failure_generic_exception_still_uses_str(monkeypatch, tmp_path):
+    """Non-timeout exceptions keep the existing str(exc_value) path so
+    pipeline-level errors (e.g. PipelineError) are surfaced verbatim."""
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-generic-fail",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.PROCESSING,
+    )
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    failing = next(s for s in _load_subjobs(redis, job.id) if _stage_func(s) == "run_transcribe_align")
+
+    runtime = MagicMock()
+    runtime.redis = redis
+    runtime.db.get_job.return_value = job
+    runtime.reporter = MagicMock()
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_builder(job_id):
+        yield runtime
+
+    monkeypatch.setattr(pd, "build_worker_runtime", _fake_builder)
+
+    failing.meta = {"parent_job_id": job.id}
+    pd.finalize_failure(failing, redis, RuntimeError, RuntimeError("whisper model oom"), None)
+
+    assert job.status == JobStatus.FAILED
+    assert "whisper model oom" in (job.error or "")
+    # Must not be silently rewritten to the timeout label.
+    assert "任務總執行時間" not in (job.error or "")

--- a/tests/unit/test_pipeline_dispatcher.py
+++ b/tests/unit/test_pipeline_dispatcher.py
@@ -47,6 +47,7 @@ def _build_settings(*, ollama: str = "http://ollama.internal:11434") -> MagicMoc
     settings.job_timeout_floor = 300
     settings.job_timeout_max = 14_400
     settings.job_timeout_audio_multiplier = 2.0
+    settings.redis_processing_expiry = 7200
     return settings
 
 

--- a/tests/unit/test_progress.py
+++ b/tests/unit/test_progress.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import fakeredis
 from redis.exceptions import ConnectionError as RedisConnectionError
 
 from whisper_ui.core.models import Job
@@ -15,31 +16,47 @@ def _make_reporter(processing_ttl: int = 7200) -> tuple[MagicMock, RedisProgress
     return mock_redis, reporter
 
 
+def _fake_reporter(job_id: str = "test-job-id", processing_ttl: int = 7200):
+    """Build a RedisProgressReporter backed by fakeredis[lua], which supports
+    the atomic max-write Lua script the reporter uses for ``report()``.
+    Returns (FakeRedis, reporter) so tests can hgetall the actual stored
+    state instead of asserting on mock call args.
+    """
+    fake = fakeredis.FakeRedis()
+    reporter = RedisProgressReporter(fake, job_id, processing_ttl=processing_ttl)
+    return fake, reporter
+
+
+def _stored(fake, job_id: str = "test-job-id") -> dict[str, str]:
+    return {
+        k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else v
+        for k, v in fake.hgetall(f"job:{job_id}").items()
+    }
+
+
 def test_report_sets_progress():
-    mock_redis, reporter = _make_reporter()
+    fake, reporter = _fake_reporter()
     reporter.report(0.5, "halfway")
 
-    mock_redis.hset.assert_called_once()
-    call_kwargs = mock_redis.hset.call_args
-    mapping = call_kwargs.kwargs.get("mapping") or call_kwargs[1].get("mapping")
-    assert mapping["progress"] == "0.5"
-    assert mapping["message"] == "halfway"
-    assert mapping["status"] == "processing"
-    mock_redis.expire.assert_called_once_with("job:test-job-id", 7200)
+    stored = _stored(fake)
+    assert float(stored["progress"]) == 0.5
+    assert stored["message"] == "halfway"
+    assert stored["status"] == "processing"
+    assert fake.ttl("job:test-job-id") > 0
 
 
 def test_report_uses_injected_processing_ttl():
-    mock_redis, reporter = _make_reporter(processing_ttl=12345)
+    fake, reporter = _fake_reporter(processing_ttl=12345)
     reporter.report(0.1, "starting")
-    mock_redis.expire.assert_called_once_with("job:test-job-id", 12345)
+    # fakeredis returns the TTL the last EXPIRE set; within ±1 s is fine.
+    assert 12000 <= fake.ttl("job:test-job-id") <= 12345
 
 
 def test_report_falls_back_to_default_ttl_when_omitted():
-    mock_redis = MagicMock()
-    reporter = RedisProgressReporter(mock_redis, "default-ttl-job")
+    fake = fakeredis.FakeRedis()
+    reporter = RedisProgressReporter(fake, "default-ttl-job")
     reporter.report(0.2, "running")
-    args, _ = mock_redis.expire.call_args
-    assert args[1] > 0
+    assert fake.ttl("job:default-ttl-job") > 0
 
 
 def test_complete_sets_done():
@@ -65,11 +82,16 @@ def test_fail_sets_error():
 def test_report_swallows_redis_connection_error(caplog):
     """Progress writes are best-effort. SQLite is the source of truth, so a
     transient Redis outage must NOT propagate up and tear down the worker.
+    The Lua script path is still wrapped by the ``except RedisError`` so
+    a failing EVAL should be logged and swallowed just like the old HSET
+    error path.
     """
     import logging
 
-    mock_redis, reporter = _make_reporter()
-    mock_redis.hset.side_effect = RedisConnectionError("redis down")
+    _fake, reporter = _fake_reporter()
+    # Force the reporter's bound script to raise, simulating a mid-EVAL
+    # Redis outage without having to tear down the whole fakeredis server.
+    reporter._max_write_script = MagicMock(side_effect=RedisConnectionError("redis down"))
 
     with caplog.at_level(logging.WARNING):
         reporter.report(0.4, "halfway")

--- a/tests/unit/test_progress.py
+++ b/tests/unit/test_progress.py
@@ -87,6 +87,125 @@ def test_report_progress_never_regresses_on_second_writer():
     assert float(_stored(fake, "same-job")["progress"]) == 0.90
 
 
+def test_report_with_newer_generation_resets_stale_high_watermark():
+    """Regression for PR #39 Round 2 R2-2. The exact scenario the
+    reviewer reproducer flagged: attempt 1's stale late writer has
+    pinned the hash at progress=0.85, the user retries, and attempt 2's
+    first stage wants to start reporting from 0.05. Before the fix, the
+    Lua max-write compared 0.05 against 0.85 and rejected the update,
+    so the UI saw attempt 2 stuck at 85% with attempt 2's message.
+    With the generation-aware reset branch, the higher caller_gen
+    signals "new attempt owns this key now" and the hash is
+    unconditionally rewritten.
+    """
+    fake = fakeredis.FakeRedis()
+
+    # Attempt 1 runs and pins the hash.
+    stale_reporter = RedisProgressReporter(fake, "job-retry", generation=1)
+    stale_reporter.report(0.85, "attempt1 diarize")
+    assert _stored(fake, "job-retry")["progress"] == "0.85"
+
+    # User retries; attempt 2 starts under generation=2.
+    fresh_reporter = RedisProgressReporter(fake, "job-retry", generation=2)
+    fresh_reporter.report(0.05, "attempt2 preprocess starting")
+
+    stored = _stored(fake, "job-retry")
+    assert stored["progress"] == "0.05"
+    assert stored["message"] == "attempt2 preprocess starting"
+    assert stored["status"] == "processing"
+    assert stored["generation"] == "2"
+
+
+def test_report_with_older_generation_is_dropped():
+    """After attempt 2 takes over the hash, any late writer from
+    attempt 1 must be silently dropped — otherwise a residual pyannote
+    C++ thread that honoured ``send_stop_job_command`` slowly could
+    still corrupt the fresh attempt's progress.
+    """
+    fake = fakeredis.FakeRedis()
+
+    # Attempt 2 is running and has already stamped its generation.
+    RedisProgressReporter(fake, "job-retry", generation=2).report(0.30, "attempt2 transcribe")
+    assert float(_stored(fake, "job-retry")["progress"]) == 0.30
+
+    # Late writer from attempt 1 tries to overwrite.
+    RedisProgressReporter(fake, "job-retry", generation=1).report(0.99, "late stale write")
+
+    stored = _stored(fake, "job-retry")
+    assert float(stored["progress"]) == 0.30, "stale attempt-1 write must not touch attempt 2's hash"
+    assert stored["message"] == "attempt2 transcribe"
+    assert stored["generation"] == "2"
+
+
+def test_report_without_generation_keeps_legacy_max_write_semantics():
+    """Legacy callers (monolithic ``process_transcription`` path, any
+    reporter built via ``build_worker_runtime`` without explicit
+    generation) must keep their pre-Round-2 max-write behaviour so
+    their tests and production behaviour are unchanged.
+    """
+    fake = fakeredis.FakeRedis()
+    legacy = RedisProgressReporter(fake, "legacy-job")
+    legacy.report(0.30, "A")
+    legacy.report(0.70, "B")
+    legacy.report(0.40, "C")  # rejected by max-write, but message updates
+
+    stored = _stored(fake, "legacy-job")
+    assert stored["progress"] == "0.7"
+    assert stored["message"] == "C"
+    # No generation field in legacy mode.
+    assert "generation" not in stored
+
+
+def test_complete_with_older_generation_is_dropped():
+    """Defense-in-depth: if a stale attempt-1 finalize_success somehow
+    bypasses the Python-level short-circuit in pipeline_dispatcher, the
+    reporter's own Lua script still refuses to overwrite a newer
+    attempt's hash.
+    """
+    fake = fakeredis.FakeRedis()
+    # Attempt 2 has already stamped the hash.
+    RedisProgressReporter(fake, "job-complete", generation=2).report(0.40, "attempt2 running")
+
+    # Stale attempt-1 tries to mark the job COMPLETED.
+    RedisProgressReporter(fake, "job-complete", generation=1).complete("/stale/result.json")
+
+    stored = _stored(fake, "job-complete")
+    assert stored["status"] == "processing", "stale attempt-1 complete() must not mark attempt 2 as completed"
+    assert stored.get("result_path") is None or "stale" not in stored.get("result_path", "")
+    assert stored["generation"] == "2"
+
+
+def test_complete_with_current_generation_writes_through():
+    """Sanity: a legitimate complete() under the current generation
+    still lands, so the defense-in-depth check does not paper over
+    the happy path.
+    """
+    fake = fakeredis.FakeRedis()
+    reporter = RedisProgressReporter(fake, "job-complete-ok", generation=3)
+    reporter.report(0.90, "finishing")
+    reporter.complete("/tmp/result.json")
+
+    stored = _stored(fake, "job-complete-ok")
+    assert stored["status"] == "completed"
+    assert stored["result_path"] == "/tmp/result.json"
+    assert stored["generation"] == "3"
+
+
+def test_fail_with_older_generation_is_dropped():
+    """Symmetric defense-in-depth check for fail(). A stale attempt-1
+    finalize_failure must not mark a running attempt 2 as FAILED at
+    the Redis progress-hash layer.
+    """
+    fake = fakeredis.FakeRedis()
+    RedisProgressReporter(fake, "job-fail", generation=2).report(0.40, "attempt2 running")
+    RedisProgressReporter(fake, "job-fail", generation=1).fail("stale error")
+
+    stored = _stored(fake, "job-fail")
+    assert stored["status"] == "processing"
+    assert stored.get("error") is None or "stale error" not in stored.get("error", "")
+    assert stored["generation"] == "2"
+
+
 def test_report_progress_updates_message_when_equal():
     """Equal progress values must still update the message so the user
     sees the current stage label when a branch reports a status change
@@ -104,23 +223,23 @@ def test_report_progress_updates_message_when_equal():
 
 
 def test_complete_sets_done():
-    mock_redis, reporter = _make_reporter()
+    fake, reporter = _fake_reporter()
     reporter.complete("/path/to/result.json")
 
-    mapping = mock_redis.hset.call_args.kwargs.get("mapping") or mock_redis.hset.call_args[1].get("mapping")
-    assert mapping["progress"] == "1.0"
-    assert mapping["status"] == "completed"
-    assert mapping["result_path"] == "/path/to/result.json"
-    mock_redis.expire.assert_called_once_with("job:test-job-id", 86400)
+    stored = _stored(fake)
+    assert stored["progress"] == "1.0"
+    assert stored["status"] == "completed"
+    assert stored["result_path"] == "/path/to/result.json"
+    assert fake.ttl("job:test-job-id") > 0
 
 
 def test_fail_sets_error():
-    mock_redis, reporter = _make_reporter()
+    fake, reporter = _fake_reporter()
     reporter.fail("something broke")
 
-    mapping = mock_redis.hset.call_args.kwargs.get("mapping") or mock_redis.hset.call_args[1].get("mapping")
-    assert mapping["status"] == "failed"
-    assert "something broke" in mapping["error"]
+    stored = _stored(fake)
+    assert stored["status"] == "failed"
+    assert "something broke" in stored["error"]
 
 
 def test_report_swallows_redis_connection_error(caplog):
@@ -146,8 +265,8 @@ def test_report_swallows_redis_connection_error(caplog):
 def test_complete_swallows_redis_connection_error(caplog):
     import logging
 
-    mock_redis, reporter = _make_reporter()
-    mock_redis.hset.side_effect = RedisConnectionError("redis down")
+    _fake, reporter = _fake_reporter()
+    reporter._complete_script = MagicMock(side_effect=RedisConnectionError("redis down"))
 
     with caplog.at_level(logging.WARNING):
         reporter.complete("/path/to/result.json")
@@ -158,8 +277,8 @@ def test_complete_swallows_redis_connection_error(caplog):
 def test_fail_swallows_redis_connection_error(caplog):
     import logging
 
-    mock_redis, reporter = _make_reporter()
-    mock_redis.hset.side_effect = RedisConnectionError("redis down")
+    _fake, reporter = _fake_reporter()
+    reporter._fail_script = MagicMock(side_effect=RedisConnectionError("redis down"))
 
     with caplog.at_level(logging.WARNING):
         reporter.fail("worker exploded")
@@ -181,13 +300,13 @@ def test_get_progress_returns_empty_dict_on_redis_error(caplog):
 
 
 def test_fail_truncates_long_error():
-    mock_redis, reporter = _make_reporter()
+    fake, reporter = _fake_reporter()
     long_error = "x" * 2000
     reporter.fail(long_error)
 
-    mapping = mock_redis.hset.call_args.kwargs.get("mapping") or mock_redis.hset.call_args[1].get("mapping")
-    assert len(mapping["error"]) <= 1000
-    assert len(mapping["message"]) <= 500
+    stored = _stored(fake)
+    assert len(stored["error"]) <= 1000
+    assert len(stored["message"]) <= 500
 
 
 def test_get_progress_empty():

--- a/tests/unit/test_progress.py
+++ b/tests/unit/test_progress.py
@@ -59,6 +59,50 @@ def test_report_falls_back_to_default_ttl_when_omitted():
     assert fake.ttl("job:default-ttl-job") > 0
 
 
+def test_report_progress_never_regresses_on_second_writer():
+    """Direct Lua-max semantics test: two reporters bound to the same
+    job_id write interleaved values and the stored progress must always
+    be the highest one any writer has observed. Message always follows
+    the latest write so the UI can switch stage labels even when
+    progress happens to stall.
+    """
+    fake = fakeredis.FakeRedis()
+    r1 = RedisProgressReporter(fake, "same-job")
+    r2 = RedisProgressReporter(fake, "same-job")
+
+    r1.report(0.30, "transcribe running")
+    assert _stored(fake, "same-job")["progress"] == "0.3"
+
+    r2.report(0.72, "diarize running")
+    assert _stored(fake, "same-job")["progress"] == "0.72"
+
+    # Regression attempt — must be dropped. Message still advances.
+    r1.report(0.35, "transcribe chunk 2")
+    stored = _stored(fake, "same-job")
+    assert float(stored["progress"]) == 0.72
+    assert stored["message"] == "transcribe chunk 2"
+
+    # A strictly larger write still wins.
+    r1.report(0.90, "transcribe chunk 3")
+    assert float(_stored(fake, "same-job")["progress"]) == 0.90
+
+
+def test_report_progress_updates_message_when_equal():
+    """Equal progress values must still update the message so the user
+    sees the current stage label when a branch reports a status change
+    without moving the percentage (e.g. "diarize loading" → "diarize
+    running" at 0.65).
+    """
+    fake = fakeredis.FakeRedis()
+    reporter = RedisProgressReporter(fake, "stall-job")
+    reporter.report(0.65, "diarize loading")
+    reporter.report(0.65, "diarize running")
+
+    stored = _stored(fake, "stall-job")
+    assert float(stored["progress"]) == 0.65
+    assert stored["message"] == "diarize running"
+
+
 def test_complete_sets_done():
     mock_redis, reporter = _make_reporter()
     reporter.complete("/path/to/result.json")

--- a/tests/unit/test_progress.py
+++ b/tests/unit/test_progress.py
@@ -264,6 +264,64 @@ def test_report_returns_false_when_lua_drops_stale_write():
     assert stored["generation"] == "2"
 
 
+def test_report_returns_false_when_central_gen_exceeds_caller_gen_despite_empty_hash():
+    """Regression for PR #39 Round 4 R4-1. The retry route deletes the
+    progress hash (wiping the embedded generation field), but the
+    central generation counter has already been bumped. A stale gen=1
+    writer arriving after the delete must be rejected by the Lua
+    central-counter check (KEYS[2]) even though the hash-level check
+    would let it through via the ``(not stored_gen)`` reset branch.
+    """
+    fake = fakeredis.FakeRedis()
+
+    # Central counter bumped to 2 by enqueue_pipeline.
+    fake.set("whisper:pipeline:job-r4:generation", 2)
+
+    # Hash is completely absent (retry route deleted it).
+    assert not fake.exists("job:job-r4")
+
+    # Stale gen=1 writer.
+    stale = RedisProgressReporter(fake, "job-r4", generation=1)
+    accepted = stale.report(0.85, "stale heartbeat")
+
+    assert accepted is False
+    assert not fake.exists("job:job-r4"), "stale writer must not re-seed the hash"
+
+
+def test_report_returns_true_when_central_gen_matches_caller_gen():
+    """Same Round 4 scenario but for the legitimate gen=2 writer.
+    The central counter is 2 and the caller is 2 → the Lua central
+    check passes, and the ``(not stored_gen)`` reset branch seeds
+    the hash correctly.
+    """
+    fake = fakeredis.FakeRedis()
+    fake.set("whisper:pipeline:job-r4ok:generation", 2)
+
+    fresh = RedisProgressReporter(fake, "job-r4ok", generation=2)
+    accepted = fresh.report(0.05, "attempt2 preprocess starting")
+
+    assert accepted is True
+    stored = _stored(fake, "job-r4ok")
+    assert stored["progress"] == "0.05"
+    assert stored["generation"] == "2"
+
+
+def test_complete_rejected_by_central_gen():
+    fake = fakeredis.FakeRedis()
+    fake.set("whisper:pipeline:job-r4c:generation", 3)
+
+    stale = RedisProgressReporter(fake, "job-r4c", generation=1)
+    assert stale.complete("/stale.json") is False
+
+
+def test_fail_rejected_by_central_gen():
+    fake = fakeredis.FakeRedis()
+    fake.set("whisper:pipeline:job-r4f:generation", 3)
+
+    stale = RedisProgressReporter(fake, "job-r4f", generation=1)
+    assert stale.fail("stale error") is False
+
+
 def test_report_returns_true_on_redis_error():
     """Transient Redis failures must *not* surface as rejection: the
     legacy "SQLite is source of truth when Redis is unavailable" contract

--- a/tests/unit/test_progress.py
+++ b/tests/unit/test_progress.py
@@ -222,6 +222,91 @@ def test_report_progress_updates_message_when_equal():
     assert stored["message"] == "diarize running"
 
 
+def test_report_returns_true_when_lua_accepts_fresh_write():
+    """``report()`` returns True when the Lua script commits the write.
+    Covers all three accepting branches: legacy (no generation), reset
+    (caller_gen > stored_gen), and same-generation max-write.
+    """
+    fake = fakeredis.FakeRedis()
+
+    # Legacy branch (caller_gen = -1).
+    legacy = RedisProgressReporter(fake, "job-legacy")
+    assert legacy.report(0.1, "m") is True
+
+    # Reset branch (higher caller_gen than stored).
+    gen_aware = RedisProgressReporter(fake, "job-reset", generation=2)
+    assert gen_aware.report(0.3, "m") is True
+
+    # Same-generation max-write branch (new >= stored).
+    same_gen = RedisProgressReporter(fake, "job-reset", generation=2)
+    assert same_gen.report(0.5, "m") is True
+
+
+def test_report_returns_false_when_lua_drops_stale_write():
+    """Core PR #39 Round 3 regression: ``report()`` returns False when
+    the caller's generation is strictly older than the stored one, so
+    the throttler can skip its SQLite mirror path and leave the
+    current attempt's Job row alone.
+    """
+    fake = fakeredis.FakeRedis()
+
+    # Attempt 2 owns the hash.
+    RedisProgressReporter(fake, "job-stale", generation=2).report(0.4, "attempt2 running")
+
+    # Attempt 1 late writer.
+    stale = RedisProgressReporter(fake, "job-stale", generation=1)
+    accepted = stale.report(0.99, "attempt1 stale heartbeat")
+
+    assert accepted is False
+    # And the hash is untouched (sanity: confirms Lua dropped the write).
+    stored = _stored(fake, "job-stale")
+    assert float(stored["progress"]) == 0.4
+    assert stored["generation"] == "2"
+
+
+def test_report_returns_true_on_redis_error():
+    """Transient Redis failures must *not* surface as rejection: the
+    legacy "SQLite is source of truth when Redis is unavailable" contract
+    requires the throttler to keep writing to the DB during an outage.
+    """
+    _fake, reporter = _fake_reporter()
+    reporter._max_write_script = MagicMock(side_effect=RedisConnectionError("down"))
+
+    assert reporter.report(0.5, "m") is True
+
+
+def test_complete_returns_true_when_accepted():
+    """Legacy (no generation) complete() always accepts; so does a
+    gen-aware reporter whose generation is at least the stored one.
+    """
+    fake = fakeredis.FakeRedis()
+    legacy = RedisProgressReporter(fake, "job-ok-legacy")
+    assert legacy.complete("/tmp/legacy.json") is True
+
+    gen_aware = RedisProgressReporter(fake, "job-ok-gen", generation=5)
+    assert gen_aware.complete("/tmp/gen.json") is True
+
+
+def test_complete_returns_false_when_stale():
+    fake = fakeredis.FakeRedis()
+    RedisProgressReporter(fake, "job-ct", generation=2).report(0.5, "attempt2 running")
+    stale = RedisProgressReporter(fake, "job-ct", generation=1)
+
+    assert stale.complete("/tmp/stale.json") is False
+    stored = _stored(fake, "job-ct")
+    assert stored["status"] == "processing"
+
+
+def test_fail_returns_false_when_stale():
+    fake = fakeredis.FakeRedis()
+    RedisProgressReporter(fake, "job-fl", generation=2).report(0.5, "attempt2 running")
+    stale = RedisProgressReporter(fake, "job-fl", generation=1)
+
+    assert stale.fail("stale error") is False
+    stored = _stored(fake, "job-fl")
+    assert stored["status"] == "processing"
+
+
 def test_complete_sets_done():
     fake, reporter = _fake_reporter()
     reporter.complete("/path/to/result.json")
@@ -466,6 +551,43 @@ class TestThrottledProgressReporter:
         # actually wrote — i.e. monotonically non-decreasing.
         final_progress = max(call.args[0] for call in reporter.report.call_args_list)
         assert final_progress > 0
+
+    def test_throttle_skips_db_update_when_reporter_rejects_stale_write(self):
+        """Regression for PR #39 Round 3 R3-1. When the Redis Lua script
+        rejects a write because the caller's generation is strictly older
+        than the stored one, the throttler must NOT proceed to update the
+        SQLite Job row from its captured (stale) Job object. Before this
+        fix the throttler always called db.update_job(job) regardless of
+        whether the Redis write landed, so a stale stage's captured Job
+        snapshot could clobber the current attempt's status, progress,
+        and result_path fields via the full-column UPDATE path.
+        """
+        on_progress, reporter, db, job, _clock = _make_throttle()
+        reporter.report.return_value = False  # Lua rejected (stale generation)
+
+        on_progress(0.85, "attempt1 stale heartbeat")
+
+        reporter.report.assert_called_once_with(0.85, "attempt1 stale heartbeat")
+        db.update_job.assert_not_called()
+        # Captured Job must not be mutated — otherwise a *subsequent*
+        # legitimate writer would inherit the stale progress value.
+        assert job.progress == 0.0
+        assert job.progress_message == ""
+
+    def test_throttle_proceeds_when_reporter_accepts_write(self):
+        """Sanity pair for the test above: when the reporter returns
+        True (legacy max-write, reset branch, or current generation
+        match) the throttler still writes to SQLite as before.
+        """
+        on_progress, reporter, db, job, _clock = _make_throttle()
+        reporter.report.return_value = True
+
+        on_progress(0.42, "running")
+
+        reporter.report.assert_called_once_with(0.42, "running")
+        db.update_job.assert_called_once_with(job)
+        assert job.progress == 0.42
+        assert job.progress_message == "running"
 
     def test_late_heartbeat_with_old_message_is_dropped(self):
         """Same race as above, but the late update still carries the old

--- a/tests/unit/test_stage_tasks.py
+++ b/tests/unit/test_stage_tasks.py
@@ -184,6 +184,69 @@ def test_run_postprocess_persists_transcript_result(monkeypatch):
     assert stored["transcript_result"] == {"segments": [], "language": "zh"}
 
 
+def test_stage_task_transitions_queued_parent_job_to_processing(monkeypatch):
+    """Regression for R1: in the DAG path the parent job must flip from
+    QUEUED to PROCESSING as soon as any stage actually starts running.
+    Without this the stale-job reaper (which only scans PROCESSING) can
+    never recover a crashed DAG, and the UI keeps showing the job as
+    queued forever.
+    """
+    fake_redis = fakeredis.FakeRedis()
+    job = Job(id="job-queued", status=JobStatus.QUEUED, filepath="/tmp/a.mp3")
+    runtime = _install_fake_runtime(monkeypatch, fake_redis, job)
+
+    fake_stage = _RecordingStage({"audio_path": "/tmp/16k.wav", "duration": 1.0})
+    with patch("whisper_ui.worker.stage_tasks.PreprocessStage", return_value=fake_stage):
+        run_preprocess("job-queued")
+
+    assert job.status == JobStatus.PROCESSING
+    runtime.db.update_job.assert_any_call(job)
+
+
+def test_stage_task_leaves_already_processing_job_alone(monkeypatch):
+    """Second parallel branch (e.g. diarize starting after transcribe_align
+    already flipped the flag) must not re-issue a pointless status update.
+    This keeps SQLite writes limited to state transitions.
+    """
+    fake_redis = fakeredis.FakeRedis()
+    job = Job(id="job-proc", status=JobStatus.PROCESSING, filepath="/tmp/a.mp3")
+    runtime = _install_fake_runtime(monkeypatch, fake_redis, job)
+
+    fake_stage = _RecordingStage({"diarize_result": [("SPK0", 0.0, 1.0)]})
+    with patch("whisper_ui.worker.stage_tasks.DiarizeStage", return_value=fake_stage):
+        run_diarize("job-proc")
+
+    # update_job must not be called for a status flip (no QUEUED-to-PROCESSING
+    # transition happened). The diarize stage itself does not write status,
+    # so update_job should not have been called at all here.
+    for call in runtime.db.update_job.call_args_list:
+        assert call.args[0].status == JobStatus.PROCESSING
+
+
+def test_run_transcribe_align_also_transitions_queued_to_processing(monkeypatch):
+    """run_transcribe_align has its own driver (not _run_single_stage) so
+    it needs the same guarded transition. Guards against the common
+    mistake of adding the fix in one place and forgetting the other.
+    """
+    fake_redis = fakeredis.FakeRedis()
+    job = Job(id="job-ta", status=JobStatus.QUEUED, filepath="/tmp/a.mp3")
+    _install_fake_runtime(monkeypatch, fake_redis, job)
+    PipelineContextStore(fake_redis, "job-ta").initialize({"audio_path": "/tmp/16k.wav"})
+
+    fake_transcribe = _RecordingStage({"transcription_result": {"segments": []}})
+    fake_align = _RecordingStage({"aligned_result": {"segments": []}})
+
+    from whisper_ui.worker.stage_tasks import run_transcribe_align
+
+    with (
+        patch("whisper_ui.worker.stage_tasks.TranscribeStage", return_value=fake_transcribe),
+        patch("whisper_ui.worker.stage_tasks.AlignStage", return_value=fake_align),
+    ):
+        run_transcribe_align("job-ta")
+
+    assert job.status == JobStatus.PROCESSING
+
+
 def test_run_diarize_raises_pipeline_error_when_job_missing(monkeypatch):
     fake_redis = fakeredis.FakeRedis()
     runtime = _make_runtime(fake_redis)

--- a/tests/unit/test_stage_tasks.py
+++ b/tests/unit/test_stage_tasks.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import fakeredis
+import pytest
+
+from whisper_ui.core.exceptions import PipelineError
+from whisper_ui.core.models import Job, JobStatus
+from whisper_ui.pipeline.progress_bands import (
+    STAGE_WEIGHTS,
+    STAGE_WEIGHTS_WITH_DOWNLOAD,
+    STAGE_WEIGHTS_WITH_DOWNLOAD_AND_LLM,
+    STAGE_WEIGHTS_WITH_LLM,
+)
+from whisper_ui.worker.context_store import PipelineContextStore
+from whisper_ui.worker.runtime import WorkerRuntime
+from whisper_ui.worker.stage_tasks import (
+    _banded_progress,
+    _execute_stage,
+    pick_stage_weights,
+    run_diarize,
+    run_postprocess,
+    run_preprocess,
+)
+
+
+def _make_runtime(redis_client) -> WorkerRuntime:
+    settings = MagicMock()
+    settings.ollama_base_url = "http://ollama.internal:11434"
+    settings.device = "cpu"
+    settings.compute_type = "int8"
+    settings.youtube_max_duration = 3600
+    settings.diarize_heartbeat_interval = 30
+    settings.hf_token = "fake-token-not-real"
+    return WorkerRuntime(
+        settings=settings,
+        redis=redis_client,
+        reporter=MagicMock(),
+        db=MagicMock(),
+        filestore=MagicMock(),
+    )
+
+
+@pytest.mark.parametrize(
+    "source_url, llm_enabled, expected",
+    [
+        (None, False, STAGE_WEIGHTS),
+        (None, True, STAGE_WEIGHTS_WITH_LLM),
+        ("https://youtu.be/x", False, STAGE_WEIGHTS_WITH_DOWNLOAD),
+        ("https://youtu.be/x", True, STAGE_WEIGHTS_WITH_DOWNLOAD_AND_LLM),
+    ],
+)
+def test_pick_stage_weights_matches_job_shape(source_url, llm_enabled, expected):
+    job = Job(source_url=source_url, llm_correction_enabled=llm_enabled)
+    runtime = _make_runtime(fakeredis.FakeRedis())
+    assert pick_stage_weights(job, runtime) is expected
+
+
+def test_pick_stage_weights_ignores_llm_when_ollama_url_is_blank():
+    """Even if the user opted in, an empty Ollama URL must fall back to the
+    non-LLM table so the dispatcher does not allocate an LLM progress band
+    for a pipeline that will not run it."""
+    job = Job(llm_correction_enabled=True)
+    runtime = _make_runtime(fakeredis.FakeRedis())
+    runtime.settings.ollama_base_url = ""
+    assert pick_stage_weights(job, runtime) is STAGE_WEIGHTS
+
+
+def test_banded_progress_maps_local_to_global_range():
+    calls: list[tuple[float, str]] = []
+    report = _banded_progress(lambda p, m: calls.append((p, m)), (0.2, 0.6))
+
+    report(0.0, "start")
+    report(0.5, "half")
+    report(1.0, "done")
+
+    assert calls[0][0] == pytest.approx(0.2)
+    assert calls[1][0] == pytest.approx(0.4)
+    assert calls[2][0] == pytest.approx(0.6)
+    assert [m for _, m in calls] == ["start", "half", "done"]
+
+
+class _RecordingStage:
+    name = "fake"
+
+    def __init__(self, new_keys: dict[str, Any]):
+        self._new_keys = new_keys
+        self.cleanup_called = False
+
+    def execute(self, context: dict, on_progress=None) -> dict:
+        if on_progress:
+            on_progress(1.0, "done")
+        result = dict(context)
+        result.update(self._new_keys)
+        return result
+
+    def cleanup(self) -> None:
+        self.cleanup_called = True
+
+
+class _ExplodingStage:
+    name = "boom"
+
+    def execute(self, context, on_progress=None):
+        raise RuntimeError("kaboom")
+
+    def cleanup(self) -> None:
+        pass
+
+
+def test_execute_stage_wraps_non_timeout_errors_as_pipeline_error():
+    with pytest.raises(PipelineError) as excinfo:
+        _execute_stage(_ExplodingStage(), {}, lambda p, m: None, stage_name="boom")
+    assert "Stage 'boom' failed" in str(excinfo.value)
+
+
+def test_execute_stage_always_cleans_up():
+    stage = _RecordingStage({"audio_path": "/tmp/x"})
+    _execute_stage(stage, {}, lambda p, m: None, stage_name="fake")
+    assert stage.cleanup_called is True
+
+
+def _install_fake_runtime(monkeypatch, fake_redis, job: Job) -> WorkerRuntime:
+    runtime = _make_runtime(fake_redis)
+    runtime.db.get_job.return_value = job
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_builder(job_id):
+        yield runtime
+
+    monkeypatch.setattr("whisper_ui.worker.stage_tasks.build_worker_runtime", _fake_builder)
+    return runtime
+
+
+def test_run_preprocess_seeds_input_path_for_file_upload(monkeypatch):
+    fake_redis = fakeredis.FakeRedis()
+    job = Job(id="job-abc", status=JobStatus.PROCESSING, filepath="/tmp/audio.mp3")
+    _install_fake_runtime(monkeypatch, fake_redis, job)
+
+    fake_stage = _RecordingStage({"audio_path": "/tmp/16k.wav", "duration": 42.0})
+    with patch("whisper_ui.worker.stage_tasks.PreprocessStage", return_value=fake_stage):
+        run_preprocess("job-abc")
+
+    stored = PipelineContextStore(fake_redis, "job-abc").load()
+    assert stored["input_path"] == "/tmp/audio.mp3"
+    assert stored["audio_path"] == "/tmp/16k.wav"
+    assert stored["duration"] == pytest.approx(42.0)
+
+
+def test_run_diarize_only_persists_declared_output_keys(monkeypatch):
+    fake_redis = fakeredis.FakeRedis()
+    job = Job(id="job-d", status=JobStatus.PROCESSING, filepath="/tmp/a.mp3")
+    _install_fake_runtime(monkeypatch, fake_redis, job)
+
+    PipelineContextStore(fake_redis, "job-d").initialize({"audio_path": "/tmp/16k.wav"})
+
+    fake_stage = _RecordingStage({"diarize_result": [("SPK0", 0.0, 1.0)], "stray_field": "should-not-persist"})
+    with patch("whisper_ui.worker.stage_tasks.DiarizeStage", return_value=fake_stage):
+        run_diarize("job-d")
+
+    stored = PipelineContextStore(fake_redis, "job-d").load()
+    assert "diarize_result" in stored
+    assert stored["diarize_result"] == [("SPK0", 0.0, 1.0)]
+    assert "stray_field" not in stored
+    assert stored["audio_path"] == "/tmp/16k.wav"
+
+
+def test_run_postprocess_persists_transcript_result(monkeypatch):
+    fake_redis = fakeredis.FakeRedis()
+    job = Job(id="job-p", status=JobStatus.PROCESSING, convert_to_traditional=False)
+    _install_fake_runtime(monkeypatch, fake_redis, job)
+
+    PipelineContextStore(fake_redis, "job-p").initialize({"final_result": {"segments": []}})
+
+    fake_stage = _RecordingStage({"transcript_result": {"segments": [], "language": "zh"}})
+    with patch("whisper_ui.worker.stage_tasks.PostprocessStage", return_value=fake_stage):
+        run_postprocess("job-p")
+
+    stored = PipelineContextStore(fake_redis, "job-p").load()
+    assert stored["transcript_result"] == {"segments": [], "language": "zh"}
+
+
+def test_run_diarize_raises_pipeline_error_when_job_missing(monkeypatch):
+    fake_redis = fakeredis.FakeRedis()
+    runtime = _make_runtime(fake_redis)
+    runtime.db.get_job.return_value = None
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_builder(job_id):
+        yield runtime
+
+    monkeypatch.setattr("whisper_ui.worker.stage_tasks.build_worker_runtime", _fake_builder)
+
+    with pytest.raises(PipelineError):
+        run_diarize("missing-job")

--- a/tests/unit/test_web_routes.py
+++ b/tests/unit/test_web_routes.py
@@ -189,45 +189,42 @@ class TestJobsRoutes:
         assert resp.status_code == 409
         assert db.get_job(job.id) is not None
 
-    def test_retry_file_job_uses_dynamic_timeout(self, client, db, settings):
+    def test_retry_file_job_passes_probed_duration_to_dispatcher(self, client, db):
         job = _create_failed_job(db)
-        mock_queue = MagicMock()
         with (
-            patch("rq.Queue", return_value=mock_queue),
+            patch("whisper_ui.web.routes.jobs.enqueue_pipeline") as mock_enqueue,
             patch("whisper_ui.web.routes.jobs.get_audio_duration_seconds", return_value=3600.0),
         ):
             resp = client.post(f"/jobs/{job.id}/retry")
         assert resp.status_code == 204
-        mock_queue.enqueue.assert_called_once()
-        # 3600s audio * 3.0 multiplier = 10800, within [floor, max]
-        assert mock_queue.enqueue.call_args[1]["job_timeout"] == int(3600 * settings.job_timeout_audio_multiplier)
+        mock_enqueue.assert_called_once()
+        retried_job = mock_enqueue.call_args[0][0]
+        assert retried_job.id == job.id
+        assert retried_job.duration == 3600.0
 
-    def test_retry_file_job_with_unknown_duration_uses_default(self, client, db, settings):
+    def test_retry_file_job_with_unknown_duration_passes_none(self, client, db):
         job = _create_failed_job(db)
-        mock_queue = MagicMock()
         with (
-            patch("rq.Queue", return_value=mock_queue),
+            patch("whisper_ui.web.routes.jobs.enqueue_pipeline") as mock_enqueue,
             patch("whisper_ui.web.routes.jobs.get_audio_duration_seconds", return_value=None),
         ):
             resp = client.post(f"/jobs/{job.id}/retry")
         assert resp.status_code == 204
-        assert mock_queue.enqueue.call_args[1]["job_timeout"] == settings.job_timeout_default
+        assert mock_enqueue.call_args[0][0].duration is None
 
-    def test_retry_url_job_uses_default_timeout(self, client, db, settings):
+    def test_retry_url_job_passes_none_duration(self, client, db):
         job = _create_failed_job(db, source_url="https://www.youtube.com/watch?v=dQw4w9WgXcQ")
-        mock_queue = MagicMock()
-        with patch("rq.Queue", return_value=mock_queue):
+        with patch("whisper_ui.web.routes.jobs.enqueue_pipeline") as mock_enqueue:
             resp = client.post(f"/jobs/{job.id}/retry")
         assert resp.status_code == 204
-        mock_queue.enqueue.assert_called_once()
-        # URL jobs cannot be re-probed locally, so they fall back to default.
-        assert mock_queue.enqueue.call_args[1]["job_timeout"] == settings.job_timeout_default
+        mock_enqueue.assert_called_once()
+        # URL jobs cannot be re-probed locally; dispatcher sees duration=None.
+        assert mock_enqueue.call_args[0][0].duration is None
 
-    def test_retry_probe_exception_falls_back_to_default(self, client, db, settings):
+    def test_retry_probe_exception_passes_none_duration(self, client, db):
         job = _create_failed_job(db)
-        mock_queue = MagicMock()
         with (
-            patch("rq.Queue", return_value=mock_queue),
+            patch("whisper_ui.web.routes.jobs.enqueue_pipeline") as mock_enqueue,
             patch(
                 "whisper_ui.web.routes.jobs.get_audio_duration_seconds",
                 side_effect=OSError("file vanished"),
@@ -235,15 +232,16 @@ class TestJobsRoutes:
         ):
             resp = client.post(f"/jobs/{job.id}/retry")
         assert resp.status_code == 204
-        mock_queue.enqueue.assert_called_once()
-        assert mock_queue.enqueue.call_args[1]["job_timeout"] == settings.job_timeout_default
+        mock_enqueue.assert_called_once()
+        assert mock_enqueue.call_args[0][0].duration is None
 
     def test_retry_enqueue_failure_uses_generic_error(self, client, db):
         job = _create_failed_job(db)
-        mock_queue = MagicMock()
-        mock_queue.enqueue.side_effect = Exception("Redis internal: secret/key/path leak")
         with (
-            patch("rq.Queue", return_value=mock_queue),
+            patch(
+                "whisper_ui.web.routes.jobs.enqueue_pipeline",
+                side_effect=Exception("Redis internal: secret/key/path leak"),
+            ),
             patch("whisper_ui.web.routes.jobs.get_audio_duration_seconds", return_value=60.0),
         ):
             client.post(f"/jobs/{job.id}/retry")
@@ -359,9 +357,7 @@ class TestUploadPost:
         return client.post("/upload", data=data, files=file_list, follow_redirects=False)
 
     def test_upload_post_submits_job(self, client, app):
-        mock_queue = MagicMock()
-        with patch("rq.Queue", return_value=mock_queue):
-            # Need to patch at the import location
+        with patch("whisper_ui.web.routes.upload.enqueue_pipeline"):
             resp = self._upload(client)
         assert resp.status_code == 303
         assert "/jobs?submitted=" in resp.headers["location"]
@@ -388,7 +384,7 @@ class TestUploadPost:
     def test_upload_file_too_large_redirects(self, client, app):
         app.state.settings = app.state.settings.model_copy(update={"max_upload_size": 10})
         files = [("files", ("big.mp3", b"x" * 20, "audio/mpeg"))]
-        with patch("rq.Queue", return_value=MagicMock()):
+        with patch("whisper_ui.web.routes.upload.enqueue_pipeline"):
             resp = self._upload(client, files=files)
         assert resp.status_code == 303
         assert "error=too_large" in resp.headers["location"]
@@ -396,7 +392,7 @@ class TestUploadPost:
     def test_upload_too_large_url_encodes_special_chars(self, client, app):
         app.state.settings = app.state.settings.model_copy(update={"max_upload_size": 5})
         files = [("files", ("evil&limit=1.mp3", b"x" * 10, "audio/mpeg"))]
-        with patch("rq.Queue", return_value=MagicMock()):
+        with patch("whisper_ui.web.routes.upload.enqueue_pipeline"):
             resp = self._upload(client, files=files)
         assert resp.status_code == 303
         location = resp.headers["location"]
@@ -406,7 +402,7 @@ class TestUploadPost:
     def test_upload_too_large_cleans_up_partial_file(self, client, app, filestore):
         app.state.settings = app.state.settings.model_copy(update={"max_upload_size": 5})
         files = [("files", ("big.mp3", b"x" * 10, "audio/mpeg"))]
-        with patch("rq.Queue", return_value=MagicMock()):
+        with patch("whisper_ui.web.routes.upload.enqueue_pipeline"):
             resp = self._upload(client, files=files)
         assert resp.status_code == 303
         # Verify no partial files remain in upload dir
@@ -420,14 +416,16 @@ class TestUploadPost:
         assert "error=no_files" in resp.headers["location"]
 
     def test_upload_partial_enqueue_failure_reports_failed_count(self, client, app, db):
-        mock_queue = MagicMock()
         # First file succeeds, second raises — simulate a transient Redis error.
-        mock_queue.enqueue.side_effect = [None, Exception("Redis hiccup")]
+        enqueue_side_effects = [None, Exception("Redis hiccup")]
         files = [
             ("files", ("a.mp3", b"data1", "audio/mpeg")),
             ("files", ("b.mp3", b"data2", "audio/mpeg")),
         ]
-        with patch("rq.Queue", return_value=mock_queue):
+        with patch(
+            "whisper_ui.web.routes.upload.enqueue_pipeline",
+            side_effect=enqueue_side_effects,
+        ):
             resp = self._upload(client, files=files)
         assert resp.status_code == 303
         location = resp.headers["location"]
@@ -461,15 +459,13 @@ class TestUploadURLPost:
         return client.post("/upload/url", data=data, follow_redirects=False)
 
     def test_upload_url_submits_job(self, client, app, db):
-        mock_queue = MagicMock()
-        with patch("rq.Queue", return_value=mock_queue):
+        with patch("whisper_ui.web.routes.upload.enqueue_pipeline"):
             resp = self._post_url(client)
         assert resp.status_code == 303
         assert "/jobs?submitted=1" in resp.headers["location"]
 
     def test_upload_url_creates_job_with_source_url(self, client, app, db):
-        mock_queue = MagicMock()
-        with patch("rq.Queue", return_value=mock_queue):
+        with patch("whisper_ui.web.routes.upload.enqueue_pipeline"):
             self._post_url(client)
         jobs = db.list_jobs()
         assert len(jobs) == 1
@@ -495,8 +491,7 @@ class TestUploadURLPost:
         assert "error=invalid_language" in resp.headers["location"]
 
     def test_upload_url_htmx_returns_redirect_header(self, client, app, db):
-        mock_queue = MagicMock()
-        with patch("rq.Queue", return_value=mock_queue):
+        with patch("whisper_ui.web.routes.upload.enqueue_pipeline"):
             resp = client.post(
                 "/upload/url",
                 data={
@@ -511,22 +506,26 @@ class TestUploadURLPost:
         assert resp.status_code == 204
         assert resp.headers.get("HX-Redirect") == "/jobs?submitted=1"
 
-    def test_upload_url_uses_default_timeout(self, client, app, db, settings):
-        mock_queue = MagicMock()
-        with patch("rq.Queue", return_value=mock_queue):
+    def test_upload_url_passes_job_without_probed_duration(self, client, app, db):
+        with patch("whisper_ui.web.routes.upload.enqueue_pipeline") as mock_enqueue:
             self._post_url(client)
-        mock_queue.enqueue.assert_called_once()
-        # URL uploads cannot be probed until after download; fall back to default.
-        assert mock_queue.enqueue.call_args[1]["job_timeout"] == settings.job_timeout_default
+        mock_enqueue.assert_called_once()
+        # URL uploads cannot be probed until after download; the dispatcher
+        # receives the Job with duration=None so the timeout helper picks the
+        # settings.job_timeout_default internally.
+        enqueued_job = mock_enqueue.call_args[0][0]
+        assert enqueued_job.duration is None
+        assert enqueued_job.source_url == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
 
     def test_upload_url_enqueue_failure_redirects_to_jobs_with_failed_count(self, client, app, db):
         """When enqueue fails the jobs are already persisted as FAILED; the
         redirect must land on /jobs so the user can see them, matching how
         /upload (file route) handles partial/total enqueue failures.
         """
-        mock_queue = MagicMock()
-        mock_queue.enqueue.side_effect = Exception("Redis connection lost")
-        with patch("rq.Queue", return_value=mock_queue):
+        with patch(
+            "whisper_ui.web.routes.upload.enqueue_pipeline",
+            side_effect=Exception("Redis connection lost"),
+        ):
             resp = self._post_url(client)
         assert resp.status_code == 303
         location = resp.headers["location"]
@@ -541,9 +540,10 @@ class TestUploadURLPost:
         """htmx variant: same behaviour, delivered via HX-Redirect so the
         fragment swap does not swallow the FAILED-job visibility.
         """
-        mock_queue = MagicMock()
-        mock_queue.enqueue.side_effect = Exception("Redis connection lost")
-        with patch("rq.Queue", return_value=mock_queue):
+        with patch(
+            "whisper_ui.web.routes.upload.enqueue_pipeline",
+            side_effect=Exception("Redis connection lost"),
+        ):
             resp = client.post(
                 "/upload/url",
                 data={
@@ -606,12 +606,11 @@ class TestBatchRoutes:
         batch_id = "b" * 32
         job = Job(filename="fail.mp3", status=JobStatus.FAILED, error="err", batch_id=batch_id)
         db.insert_job(job)
-        mock_queue = MagicMock()
-        with patch("rq.Queue", return_value=mock_queue):
+        with patch("whisper_ui.web.routes.jobs.enqueue_pipeline"):
             resp = client.post(f"/jobs/batch/{batch_id}/retry")
         assert resp.status_code == 204
 
-    def test_retry_batch_url_job_uses_default_timeout(self, client, db, app, settings):
+    def test_retry_batch_url_job_passes_none_duration(self, client, db, app):
         batch_id = "d" * 32
         job = Job(
             filename="url.mp3",
@@ -621,12 +620,11 @@ class TestBatchRoutes:
             source_url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         )
         db.insert_job(job)
-        mock_queue = MagicMock()
-        with patch("rq.Queue", return_value=mock_queue):
+        with patch("whisper_ui.web.routes.jobs.enqueue_pipeline") as mock_enqueue:
             resp = client.post(f"/jobs/batch/{batch_id}/retry")
         assert resp.status_code == 204
-        mock_queue.enqueue.assert_called_once()
-        assert mock_queue.enqueue.call_args[1]["job_timeout"] == settings.job_timeout_default
+        mock_enqueue.assert_called_once()
+        assert mock_enqueue.call_args[0][0].duration is None
 
     def test_delete_batch(self, client, db, filestore):
         batch_id = "c" * 32

--- a/tests/unit/test_worker_runtime.py
+++ b/tests/unit/test_worker_runtime.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from whisper_ui.core.models import Job, JobStatus
+from whisper_ui.worker.progress import RedisProgressReporter
+from whisper_ui.worker.runtime import (
+    WorkerRuntime,
+    build_worker_runtime,
+    make_throttled_progress_reporter,
+)
+
+
+def _fake_settings() -> MagicMock:
+    settings = MagicMock()
+    settings.redis_url = "redis://localhost:6379/0"
+    settings.database_path = ":memory:"
+    settings.upload_dir = "/tmp/whisper-test-upload"
+    settings.output_dir = "/tmp/whisper-test-output"
+    settings.redis_processing_expiry = 1234
+    return settings
+
+
+def test_build_worker_runtime_wires_shared_resources_and_closes_db():
+    fake_settings = _fake_settings()
+    fake_db = MagicMock()
+    fake_filestore = MagicMock()
+    fake_redis = MagicMock()
+
+    with (
+        patch("whisper_ui.worker.runtime.get_settings", return_value=fake_settings),
+        patch("whisper_ui.worker.runtime.Redis.from_url", return_value=fake_redis) as redis_from_url,
+        patch("whisper_ui.worker.runtime.JobDatabase", return_value=fake_db) as db_ctor,
+        patch("whisper_ui.worker.runtime.FileStore", return_value=fake_filestore) as fs_ctor,
+    ):
+        with build_worker_runtime("job-xyz") as runtime:
+            assert isinstance(runtime, WorkerRuntime)
+            assert runtime.settings is fake_settings
+            assert runtime.redis is fake_redis
+            assert runtime.db is fake_db
+            assert runtime.filestore is fake_filestore
+            assert isinstance(runtime.reporter, RedisProgressReporter)
+
+        redis_from_url.assert_called_once_with(fake_settings.redis_url)
+        db_ctor.assert_called_once_with(fake_settings.database_path)
+        fs_ctor.assert_called_once_with(fake_settings.upload_dir, fake_settings.output_dir)
+        fake_db.close.assert_called_once()
+
+
+def test_build_worker_runtime_closes_db_even_on_error():
+    fake_settings = _fake_settings()
+    fake_db = MagicMock()
+
+    with (
+        patch("whisper_ui.worker.runtime.get_settings", return_value=fake_settings),
+        patch("whisper_ui.worker.runtime.Redis.from_url", return_value=MagicMock()),
+        patch("whisper_ui.worker.runtime.JobDatabase", return_value=fake_db),
+        patch("whisper_ui.worker.runtime.FileStore", return_value=MagicMock()),
+    ):
+        try:
+            with build_worker_runtime("job-err"):
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+
+        fake_db.close.assert_called_once()
+
+
+def _make_job() -> Job:
+    return Job(
+        id="throttle-job",
+        filename="example.mp3",
+        filepath="/tmp/example.mp3",
+        status=JobStatus.PROCESSING,
+        progress=0.0,
+        progress_message="",
+    )
+
+
+def test_throttle_flushes_on_first_call_and_on_message_change():
+    reporter = MagicMock()
+    db = MagicMock()
+    job = _make_job()
+    clock = [100.0]
+
+    report = make_throttled_progress_reporter(
+        reporter,
+        db,
+        job,
+        min_delta=0.05,
+        min_interval_sec=0.5,
+        monotonic=lambda: clock[0],
+    )
+
+    report(0.1, "starting")
+    assert reporter.report.call_count == 1
+
+    clock[0] += 0.01
+    report(0.11, "starting")
+    assert reporter.report.call_count == 1
+
+    clock[0] += 0.01
+    report(0.11, "next stage")
+    assert reporter.report.call_count == 2
+
+
+def test_throttle_drops_regressions():
+    reporter = MagicMock()
+    db = MagicMock()
+    job = _make_job()
+    clock = [0.0]
+
+    report = make_throttled_progress_reporter(
+        reporter,
+        db,
+        job,
+        monotonic=lambda: clock[0],
+    )
+
+    report(0.8, "late")
+    reporter.report.reset_mock()
+
+    report(0.6, "late")
+    reporter.report.assert_not_called()
+
+
+def test_throttle_always_flushes_terminal_progress():
+    reporter = MagicMock()
+    db = MagicMock()
+    job = _make_job()
+    clock = [0.0]
+
+    report = make_throttled_progress_reporter(
+        reporter,
+        db,
+        job,
+        min_delta=0.5,
+        min_interval_sec=10.0,
+        monotonic=lambda: clock[0],
+    )
+
+    report(0.9, "nearly done")
+    reporter.report.reset_mock()
+
+    clock[0] += 0.01
+    report(1.0, "nearly done")
+    reporter.report.assert_called_once()

--- a/tests/unit/test_worker_runtime.py
+++ b/tests/unit/test_worker_runtime.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+from rq.timeouts import JobTimeoutException
+
 from whisper_ui.core.models import Job, JobStatus
 from whisper_ui.worker.progress import RedisProgressReporter
 from whisper_ui.worker.runtime import (
     WorkerRuntime,
     build_worker_runtime,
+    extract_rq_timeout_seconds,
     make_throttled_progress_reporter,
 )
 
@@ -145,3 +148,31 @@ def test_throttle_always_flushes_terminal_progress():
     clock[0] += 0.01
     report(1.0, "nearly done")
     reporter.report.assert_called_once()
+
+
+def test_extract_rq_timeout_prefers_current_job_when_available():
+    """Inside a real worker the authoritative source is
+    ``rq.get_current_job().timeout`` — the exception message may say
+    something else if tests construct it directly."""
+    fake_current = MagicMock()
+    fake_current.timeout = 7200
+    with patch("rq.get_current_job", return_value=fake_current):
+        exc = JobTimeoutException("Task exceeded maximum timeout value (999 seconds)")
+        assert extract_rq_timeout_seconds(exc) == 7200
+
+
+def test_extract_rq_timeout_falls_back_to_message_regex():
+    """Outside a worker context ``get_current_job()`` returns None; the
+    helper must parse the RQ-formatted exception message instead.
+    This is the code path the DAG finalize_failure callback hits because
+    it runs in a separate worker, not inside the timing-out job itself.
+    """
+    with patch("rq.get_current_job", return_value=None):
+        exc = JobTimeoutException("Task exceeded maximum timeout value (3600 seconds)")
+        assert extract_rq_timeout_seconds(exc) == 3600
+
+
+def test_extract_rq_timeout_returns_placeholder_when_nothing_matches():
+    with patch("rq.get_current_job", return_value=None):
+        exc = JobTimeoutException("something totally unexpected")
+        assert extract_rq_timeout_seconds(exc) == "?"


### PR DESCRIPTION
## Summary

Replace the monolithic `process_transcription` RQ task with a per-stage DAG dispatcher so IO / network / GPU stages no longer block each other. This addresses the three pain points the user called out:

1. **Cross-job throughput** — job B can download/preprocess/llm-correct while job A is on the GPU, instead of waiting for A's full 8-stage pipeline.
2. **Single-job latency** — transcribe_align and diarize fan out as sibling DAG branches; on multi-GPU hosts they run in parallel with zero code changes.
3. **GPU utilisation** — GPU workers never waste time on network / disk IO or Ollama round-trips (especially relevant with the external Ollama at `192.168.51.129:11434`).

## Key design decisions

- **DAG shape**: `download?` → `preprocess` → `{transcribe_align, diarize}` → `assign_speakers` → `postprocess` → `llm_correction?`
- **Transcribe + Align are merged** into one GPU task (`run_transcribe_align`) because they share the large in-memory `whisperx_audio` buffer. Splitting them would force pickling that buffer through Redis.
- **Context lives in Redis** as a hash keyed by parent job id (`PipelineContextStore`). Each stage writes only its declared output keys, so the transcribe_align ∥ diarize fan-out is concurrency-safe.
- **Queue topology**: `whisper:io` (download, preprocess, llm_correction), `whisper:gpu` (transcribe_align, diarize), `whisper:cpu` (assign_speakers, postprocess). Workers default to listening on every queue so single-container deployments still run end-to-end; the new `worker-io` compose profile and `WORKER_*_QUEUES` env vars opt into the scaled topology.
- **finalize_success / finalize_failure callbacks** are attached via RQ's `Callback` system. Failure path cancels any still-deferred sub-jobs via a Redis tracking set so no zombies are left behind.

## Migration / backwards compatibility

- **No DB schema change.**
- `process_transcription` is kept verbatim as a legacy path. Any RQ jobs enqueued under the old function name before deployment still run through the monolithic synchronous code, while new uploads go through the dispatcher.
- Every worker's default `WORKER_QUEUES` list includes `default`, so in-flight legacy jobs are still drained after the upgrade.
- `RedisProgressReporter` Redis key format (`job:{id}`) is unchanged — htmx polling works without any frontend touches.

## Why a single PR

CLAUDE.md mandates one branch / one PR per task. This refactor is > 400 LOC, but each step here is a prerequisite for the next (rearranging the orchestrator, then extracting runtime helpers, then DAG-ifying, then routing queues, then updating compose/docs); splitting it would leave the tree in intermediate states that cannot be validated independently. The PR is organised as 9 atomic commits so it can be reviewed commit-by-commit:

1. `refactor: extract stage progress bands to dedicated module`
2. `refactor: extract worker runtime helpers`
3. `feat: add per-stage RQ task entrypoints`
4. `feat: add pipeline dispatcher building RQ DAG`
5. `feat: wire web routes to pipeline dispatcher`
6. `feat: split worker queues by resource type`
7. `feat: add multi-worker docker-compose topology`
8. `test: add DAG parallelism integration coverage`
9. `docs: update deployment notes for multi-worker topology`

## Test plan

- [x] `python -m pytest` — 398 passed (was 360, +38 new tests)
- [x] `pre-commit run --all-files` on every touched file
- [ ] Reviewer: on a GPU dev host, `docker compose --profile gpu up -d` and upload two audio files back-to-back; observe that job B enters preprocess while job A is still in transcribe
- [ ] Reviewer: verify htmx progress bar is monotone and shows per-stage messages
- [ ] Reviewer: retry a failed job via the `/jobs/{id}/retry` endpoint and confirm it goes through the new dispatcher
- [ ] Reviewer: trigger a stage failure (e.g., bad audio file) and confirm the parent job flips to FAILED and downstream sub-jobs are cancelled in `rq info`
- [ ] Reviewer: `docker compose --profile gpu --profile io up -d` with `WORKER_GPU_QUEUES="whisper:gpu default"` and confirm `worker-io` picks up download/preprocess while `worker-gpu` stays on `whisper:gpu`

## Files touched

20 files changed, +2521 / −362.

- New modules: `pipeline/progress_bands.py`, `worker/runtime.py`, `worker/stage_tasks.py`, `worker/context_store.py`, `worker/pipeline_dispatcher.py`
- New tests: `test_worker_runtime.py`, `test_stage_tasks.py`, `test_context_store.py`, `test_pipeline_dispatcher.py`, `test_pipeline_dag_parallelism.py`
- Updated: `worker/tasks.py`, `web/routes/upload.py`, `web/routes/jobs.py`, `core/constants.py`, `compose.yml`, `docker/entrypoint-worker.sh`, `README.md`

## Out of scope (tracked as follow-ups)

- **Slim IO worker image**: `stage_tasks.py` imports every `PipelineStage` at module load time so RQ can resolve every `run_*` symbol. Making the stage imports lazy would let `worker-io` drop the torch / whisperx / pyannote dependencies.
- **Chunk-based streaming (VAD / whisper_streaming / diart)**: deferred until operators see whether this PR alone closes the latency gap.