### PR TITLE
fix: forward auth env vars to frontend container

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -35,6 +35,17 @@ services:
       # job is explicitly deleted. >0 has the web app hourly reclaim the
       # upload directory of COMPLETED jobs older than that many days.
       - UPLOAD_RETENTION_DAYS=${UPLOAD_RETENTION_DAYS:-0}
+      # Auth / session — see README "Multi-user authentication". Leaving
+      # SESSION_SECRET empty makes the app fall back to a per-process
+      # random secret (logs WARNING) which invalidates every session on
+      # restart; set it to a stable value in production:
+      #   SESSION_SECRET=$(openssl rand -hex 32)
+      - SESSION_SECRET=${SESSION_SECRET:-}
+      - SESSION_HTTPS_ONLY=${SESSION_HTTPS_ONLY:-false}
+      - MAX_LOGIN_ATTEMPTS=${MAX_LOGIN_ATTEMPTS:-5}
+      - MAX_LOGIN_ATTEMPTS_PER_IP=${MAX_LOGIN_ATTEMPTS_PER_IP:-20}
+      - LOGIN_LOCKOUT_SECONDS=${LOGIN_LOCKOUT_SECONDS:-900}
+      - TRUST_PROXY_HEADERS=${TRUST_PROXY_HEADERS:-false}
     volumes:
       - app-data:/app/data
     depends_on:


### PR DESCRIPTION
## Why

PR #50 added six auth-related Settings fields (SESSION_SECRET, SESSION_HTTPS_ONLY, MAX_LOGIN_ATTEMPTS, MAX_LOGIN_ATTEMPTS_PER_IP, LOGIN_LOCKOUT_SECONDS, TRUST_PROXY_HEADERS) and listed them in `.env.example`, but `compose.yml` was not updated to forward those values into the frontend container.

Result: in any deployment using the bundled compose file, the new env vars are ignored. The most user-visible consequence is `SESSION_SECRET` falling back to a per-process random secret (with a startup WARNING), which invalidates every logged-in user on every container restart.

Discovered while preparing an existing deployment for the multi-user auth feature.

## How

Add the six env-var passes to the `frontend` service's `environment:` block, matching the existing `${VAR:-default}` pattern. Worker services do not need these — only the FastAPI tier reads them.

Defaults match `Settings`:
- `SESSION_SECRET` empty (operator MUST set in `.env`)
- `SESSION_HTTPS_ONLY=false`
- `MAX_LOGIN_ATTEMPTS=5`
- `MAX_LOGIN_ATTEMPTS_PER_IP=20`
- `LOGIN_LOCKOUT_SECONDS=900`
- `TRUST_PROXY_HEADERS=false`

## Test plan

- [x] `docker compose config` resolves all six vars under the frontend service
- [x] Existing services unaffected (only added lines to one block)
- [ ] After merge: pull new images, restart, confirm `docker exec whisper-ui-frontend-1 env | grep SESSION_SECRET` shows the configured value