### PR TITLE
chore: release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-05-22
+
 ### Added
 
 - Centralised stdlib `logging` setup in `whisper_ui.core.logging_setup`.
@@ -59,6 +61,46 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `max-size: 20m` and `max-file: 5` (100 MB per container) so the
   log volume from the new structured access log cannot fill
   `/var/lib/docker` on long-running deployments.
+
+### Fixed
+
+- Admin endpoints `activate`, `deactivate`, and `toggle-admin` now
+  surface a `user_not_found` error for missing user IDs instead of
+  returning 500. Previously only `toggle-admin` / `reset-password`
+  (via a pre-check) showed the friendly message; the sibling endpoints
+  leaked the underlying `ValueError` from `users_repo.set_active` /
+  `set_admin`. The `toggle-admin` path also defensively catches the
+  TOCTOU race between the pre-check and the actual update.
+- Batch ZIP entries for URL-source jobs no longer carry the YouTube
+  URL as the filename (which produced entries like `watch?v=abc.srt`
+  that some Windows extractors reject). URL jobs now use the job id
+  as the entry name; uploaded media keeps its original basename.
+
+### Documentation
+
+- `SECURITY.md` rewritten to match v2.1.0: documents the session-cookie
+  authentication, CSRF (Origin-vs-Host), per-user + per-IP rate limit,
+  owner isolation, session-version revocation, defense-in-depth
+  headers, upload hardening, and YouTube URL whitelist that are all
+  shipped. Replaces the previous text which claimed these controls were
+  intentionally omitted. Deployment best practices section updated
+  with `SESSION_SECRET`, `SESSION_HTTPS_ONLY`, `TRUST_PROXY_HEADERS`,
+  and `REDIS_PASSWORD` guidance.
+- `CONTRIBUTING.md` migrated from `pip install -e ".[dev]"` to
+  `uv sync --extra dev`; duplicated architecture tree replaced with a
+  pointer to README's `## Project Structure` (which now also carries
+  the layer dependency direction block).
+- README config table drops the misleading `LOG_JSON` row (env var
+  was never wired up).
+- Internal docstrings added to `JobDatabase` (thread-safety contract),
+  `PostprocessStage._converter` (per-instance lifecycle), the three
+  pipeline TTL constants (`PIPELINE_STATE_TTL_SECONDS`,
+  `Settings.redis_processing_expiry`, `_DEFAULT_PROCESSING_TTL`), and
+  the three generation-gating enforcement sites
+  (`pipeline_callbacks.is_stale_callback`,
+  `progress._LUA_TERMINAL_GENERATION_GATE`,
+  `context_store._GENERATION_GATED_HSET_LUA`) so the shared-state
+  contracts are discoverable from the code.
 
 ## [2.1.0] - 2026-05-21
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.1.0"
+version = "2.2.0"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3807,7 +3807,7 @@ wheels = [
 
 [[package]]
 name = "whisper-ui"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Release notes drawn from `CHANGELOG.md` [2.2.0]. Merging this PR is the last step before tagging `v2.2.0`; the tag push is what triggers `.github/workflows/docker-publish.yaml` to publish `:2.2.0`, `:2.2`, and `:latest` images for `whisper-ui-frontend`, `whisper-ui-worker`, and `whisper-ui-worker-cpu` to GHCR.

## Highlights

### Added — observability (PR #53)

- Centralised `logging` setup (`whisper_ui.core.logging_setup`) with `LOG_LEVEL` env and one dictConfig across frontend and worker.
- `RequestIdMiddleware` outermost on the frontend; renders `[req=<id> user=<name>]` on every log line and echoes `X-Request-ID` back.
- Structured access log on `whisper_ui.web.access` (method / path / status / duration_ms / ip), replacing uvicorn's stock access log.
- Audit logging across previously silent paths (rate-limit decisions, session lifecycle, upload pipeline, job delete/retry, stage transitions, pipeline failures, filestore deletes, schema migrations).
- `recover_stale_jobs` WARNING line lists the recovered job ids (capped at 20 + overflow count).

### Changed — observability follow-throughs (PR #53)

- Worker container starts via `python -m whisper_ui.worker` (thin wrapper that runs `setup_logging()` then delegates to `rq.cli.main`) so dictConfig applies inside the RQ worker process.
- `audio_probe.get_audio_duration_seconds` gains a `job_id` log-correlation kwarg; absolute path no longer logged (PII / storage layout leak); three failure modes (`TimeoutExpired`, `FileNotFoundError`, other `OSError`) now distinct.
- All `compose.yml` services pin `logging.driver=json-file` with `max-size: 20m`, `max-file: 5` (100 MB per container).

### Fixed — admin UX + batch ZIP (PR #54)

- Admin `activate`, `deactivate`, `toggle-admin` now return `user_not_found` for missing user IDs instead of leaking `ValueError` as 500. `toggle-admin` also defensively catches the TOCTOU race between pre-check and update.
- Batch ZIP entries for URL-source jobs use the job id rather than the canonical YouTube URL (`watch?v=…`), so entries no longer break Windows extractors. Uploaded media keeps its original basename.

### Documentation (PR #54)

- `SECURITY.md` rewritten to describe the v2.1.0 controls actually shipped; deployment best practices updated.
- `CONTRIBUTING.md` switched from `pip install -e ".[dev]"` to `uv sync --extra dev`; architecture tree replaced with a pointer to README's `## Project Structure` (which now also carries the layer dependency direction).
- README config table drops the never-wired `LOG_JSON` row.
- Internal docstrings added to `JobDatabase` (thread-safety contract), `PostprocessStage._converter` (per-instance lifecycle), the three pipeline TTL constants, and the three generation-gating enforcement sites.

## Migration / breaking?

None. Worker container start command and `audio_probe` signature changes are internal; existing deployments need only `docker compose pull && docker compose up -d` after the new images publish.

## Test plan

- [x] `uv run pytest` — 664 unit tests pass
- [x] `uv run pytest -m integration` — 1 marker'd integration test passes
- [x] `pre-commit run --all-files` — clean

Post-merge:

- [ ] Tag `v2.2.0` (annotated) on the merge commit and push; verify docker-publish workflow builds all three images.
- [ ] `docker compose pull && docker compose up -d` on the deployment host; verify `/health` returns ok and a sample upload still works end-to-end.