### PR TITLE
fix: pre-release hardening and cleanup

### DIFF
--- a/src/whisper_ui/export/srt.py
+++ b/src/whisper_ui/export/srt.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from whisper_ui.export.utils import format_timestamp
+from whisper_ui.export.utils import collapse_newlines, format_timestamp
 
 if TYPE_CHECKING:
     from whisper_ui.core.models import Segment, TranscriptResult
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 def _format_text(segment: Segment) -> str:
     prefix = f"[{segment.speaker}] " if segment.speaker else ""
-    return f"{prefix}{segment.text}"
+    return collapse_newlines(f"{prefix}{segment.text}")
 
 
 class SrtExporter:

--- a/src/whisper_ui/export/utils.py
+++ b/src/whisper_ui/export/utils.py
@@ -7,3 +7,17 @@ def format_timestamp(seconds: float, ms_separator: str = ",") -> str:
     s = int(seconds % 60)
     ms = int((seconds % 1) * 1000)
     return f"{h:02d}:{m:02d}:{s:02d}{ms_separator}{ms:03d}"
+
+
+def collapse_newlines(text: str) -> str:
+    """Collapse any embedded line breaks into single spaces.
+
+    SRT and VTT are newline-delimited cue formats: a blank line terminates a
+    cue, so a newline inside ``segment.text`` (which the optional LLM
+    correction stage can emit) would split or truncate the cue. Collapsing to
+    spaces keeps each cue on a single line and the output well-formed.
+
+    Only line boundaries are touched; ordinary spacing inside the text is
+    preserved.
+    """
+    return " ".join(text.splitlines())

--- a/src/whisper_ui/export/vtt.py
+++ b/src/whisper_ui/export/vtt.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from whisper_ui.export.utils import format_timestamp
+from whisper_ui.export.utils import collapse_newlines, format_timestamp
 
 if TYPE_CHECKING:
     from whisper_ui.core.models import Segment, TranscriptResult
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 def _format_text(segment: Segment) -> str:
     prefix = f"<v {segment.speaker}>" if segment.speaker else ""
-    return f"{prefix}{segment.text}"
+    return collapse_newlines(f"{prefix}{segment.text}")
 
 
 class VttExporter:

--- a/src/whisper_ui/pipeline/download.py
+++ b/src/whisper_ui/pipeline/download.py
@@ -56,6 +56,11 @@ class DownloadStage:
             "outtmpl": str(download_dir / "video.%(ext)s"),
             "merge_output_format": "mp4",
             "noplaylist": True,
+            # Defense in depth: the URL is already whitelisted and canonicalised
+            # to a youtube.com/watch URL by validate_youtube_url, but pinning the
+            # extractor stops yt-dlp from ever falling back to the generic
+            # extractor and fetching an arbitrary (e.g. internal) host.
+            "allowed_extractors": ["youtube"],
             "socket_timeout": YT_DLP_SOCKET_TIMEOUT,
             "progress_hooks": [progress_hook],
             "quiet": True,

--- a/src/whisper_ui/pipeline/llm_correction.py
+++ b/src/whisper_ui/pipeline/llm_correction.py
@@ -174,10 +174,6 @@ class LLMCorrectionStage:
         segments = transcript.segments
         chunks = self._build_chunks(segments)
         total = len(chunks)
-        if total == 0:
-            if on_progress:
-                on_progress(1.0, LLM_CORRECTION_SKIPPED)
-            return context
 
         client = self._get_client()
         failed_chunks: list[int] = []

--- a/src/whisper_ui/web/routes/auth_routes.py
+++ b/src/whisper_ui/web/routes/auth_routes.py
@@ -25,6 +25,7 @@ import logging
 import re
 import sqlite3
 from typing import Annotated
+from urllib.parse import quote
 
 from fastapi import APIRouter, Form, Query, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
@@ -223,8 +224,6 @@ def _login_error_redirect(request: Request, next_url: str, error: str) -> Respon
     safe_next = _safe_next(next_url)
     target = f"/login?error={error}"
     if safe_next != "/":
-        from urllib.parse import quote
-
         target += f"&next={quote(safe_next)}"
     return _redirect_after_auth(request, target)
 

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -122,6 +122,17 @@ class TestDownloadStageWithMock:
             with pytest.raises(DownloadError, match="Failed to download"):
                 stage.execute(context)
 
+    def test_restricts_yt_dlp_to_youtube_extractor(self, context, download_dir):
+        mock_ydl = self._make_mock_ydl(download_dir)
+        mock_module = MagicMock()
+        mock_module.YoutubeDL.return_value = mock_ydl
+
+        with patch.dict("sys.modules", {"yt_dlp": mock_module}):
+            DownloadStage().execute(context)
+
+        ydl_opts = mock_module.YoutubeDL.call_args.args[0]
+        assert ydl_opts["allowed_extractors"] == ["youtube"]
+
     def test_cleanup_is_noop(self):
         stage = DownloadStage()
         stage.cleanup()  # Should not raise

--- a/tests/unit/test_export_srt.py
+++ b/tests/unit/test_export_srt.py
@@ -28,3 +28,17 @@ def test_srt_format_metadata():
     assert exporter.format_name == "SRT"
     assert exporter.file_extension == ".srt"
     assert exporter.mime_type == "text/plain"
+
+
+def test_srt_collapses_newlines_in_text_to_keep_cue_single_line():
+    # A newline inside the text (the LLM-correction stage can emit one) would
+    # otherwise split the cue and break the blank-line block delimiter.
+    result = TranscriptResult(
+        segments=[Segment(start=0.0, end=1.0, text="line one\nline two", speaker="SPEAKER_00")],
+    )
+    lines = SrtExporter().export(result).decode("utf-8").split("\n")
+
+    assert lines[0] == "1"
+    assert lines[1] == "00:00:00,000 --> 00:00:01,000"
+    assert lines[2] == "[SPEAKER_00] line one line two"
+    assert lines[3] == ""

--- a/tests/unit/test_export_vtt.py
+++ b/tests/unit/test_export_vtt.py
@@ -24,3 +24,14 @@ def test_vtt_format_metadata():
     assert exporter.format_name == "VTT"
     assert exporter.file_extension == ".vtt"
     assert exporter.mime_type == "text/vtt"
+
+
+def test_vtt_collapses_newlines_in_text_to_keep_cue_single_line():
+    # A newline inside the text would otherwise terminate the cue early at the
+    # blank-line delimiter; collapse it so the cue stays on one line.
+    result = TranscriptResult(
+        segments=[Segment(start=0.0, end=1.5, text="line one\nline two", speaker="SPEAKER_00")],
+    )
+    lines = VttExporter().export(result).decode("utf-8").split("\n")
+
+    assert lines == ["WEBVTT", "", "00:00:00.000 --> 00:00:01.500", "<v SPEAKER_00>line one line two", ""]


### PR DESCRIPTION
## Why
發布前 code review 後的小幅強健性與清理修補；無功能變更、無破壞性變更。

## How
- **fix**: SRT/VTT 匯出時收斂 cue 文字中的換行，避免 LLM 校正輸出含 `\n` 時破壞字幕區塊結構（新增 `export/utils.collapse_newlines`，srt/vtt 共用）。
- **fix**: yt-dlp 設定 `allowed_extractors=["youtube"]`，作為 URL 白名單之外的縱深防禦，杜絕 fallback 到 generic extractor 抓取任意主機。
- **refactor**: 移除 `llm_correction` 中不可達的 `total == 0` 守衛（空 segments 已於前一個 guard 攔截）。
- **refactor**: `auth_routes` 內聯 `quote` import 上移至模組頂部。

## 評估後否決（記錄）
- **S1 bootstrap admin TOCTOU**：前端單一 uvicorn 程序、`count`→`create` 間無 `await`，race 不成立，修正屬 YAGNI。
- **C1 統一 htmx 重導 helper**：`_unauthenticated_response`(401) 與 `_redirect_after_auth`(204) 狀態碼/語意/變更理由不同，屬巧合重複，依 CLAUDE.md DRY 原則不提取。

## Tests
新增 SRT/VTT 換行與 yt-dlp extractor 測試；`ruff check` + `ruff format --check` 全清，全套 687 unit tests 通過（1 integration deselected）。