### PR TITLE
chore: release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-05-24
+
 ### Added
 
 - v2 UI redesign across Login, Dashboard, Upload, Jobs, and Viewer
@@ -52,6 +54,26 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   written by `RedisProgressReporter` is unchanged.
 - `JOBS_SEARCH_PLACEHOLDER` updated to mention 網址 since the
   search now matches source URLs.
+- Dependencies bumped: transformers 4.57.6 → 5.9.0 (major; the
+  whisperx 3.8 Wav2Vec2 align path was runtime-validated against
+  transformers 5.9.0 — import surface plus model load / forward /
+  CTC decode), argon2-cffi 23.1.0 → 25.1.0 (PasswordHasher defaults
+  unchanged: time_cost=3, memory_cost=65536, parallelism=4),
+  fastapi[standard] → 0.136.3, numpy → 2.4.6, fakeredis[lua] →
+  2.35.1.
+
+### Fixed
+
+- SRT / VTT export now collapses embedded newlines in cue text, so a
+  line break inside a segment (which the optional LLM correction
+  stage can emit) can no longer split or truncate a subtitle cue.
+- YouTube download stage pins `allowed_extractors=["youtube"]` as
+  defense in depth on top of the existing URL whitelist, so yt-dlp
+  can never fall back to the generic extractor.
+
+### Security
+
+- `starlette` bumped to 1.1.0 to remediate PYSEC-2026-161.
 
 ### Deploy notes
 
@@ -72,6 +94,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   values, URL paths, htmx polling structure, and theme strings
   are all preserved. See evaluation report §6 for the full
   "do-not-touch" list.
+- **Worker images now build on transformers 5.9.0.** Rebuild the
+  worker image (`docker compose --profile gpu|cpu build`) when
+  upgrading. The transformers 5 align path was validated at the API
+  level, not via a full GPU end-to-end run, so a one-off
+  Chinese-audio align smoke test after deploy is recommended.
 
 ## [2.2.0] - 2026-05-22
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.2.0"
+version = "2.3.0"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3807,7 +3807,7 @@ wheels = [
 
 [[package]]
 name = "whisper-ui"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Why
自 `v2.2.0`（2026-05-22）以來，main 已累積大量未發布變更，但 `:latest` 與版本化 Docker image 仍停在 v2.2.0（`docker-publish.yaml` 只在 push `v*` tag 時更新 `:latest` / `:{version}`）。本 PR 備妥 v2.3.0 release，合併後 tag 即可把這些變更帶進可部署的版本化 image。

## What
- `pyproject.toml` 版本 2.2.0 → 2.3.0，`uv.lock` 同步（`uv lock`，無 transitive churn）。
- CHANGELOG：`[Unreleased]` 內容定版為 `[2.3.0] - 2026-05-24`，並補上原先漏記的項目。

### 本版涵蓋（自 v2.2.0）
- **Added**：v2 UI 全面改版（Dashboard / Upload / Jobs / Viewer / Login）、`POST /jobs/bulk/{action}`、dashboard sparkline、upload toast 持久化。
- **Fixed**：SRT/VTT cue 文字換行收斂；yt-dlp 限定 `allowed_extractors=["youtube"]`（PR #70）。
- **Security**：`starlette` → 1.1.0（PYSEC-2026-161）。
- **Dependencies**：transformers 4.57.6 → **5.9.0**（major，align 路徑已 runtime 驗證）、argon2-cffi 23 → 25.1.0（預設參數未變）、fastapi[standard] → 0.136.3、numpy → 2.4.6、fakeredis[lua] → 2.35.1。

## SemVer
MINOR（2.3.0）：有新功能 + 顯著依賴變動，但未破壞本專案自身的 API / 行為契約（form 欄位、status enum、URL、htmx 結構、theme 字串皆保留）。transformers major 為內部依賴變更。

## 合併後的後續步驟（待你決定）
1. push `v2.3.0` tag → 觸發 `docker-publish.yaml` 發布 `:2.3.0` / `:2.3` 並更新 `:latest`。
2. （可選）建立對應 GitHub Release —— 註：`v2.1.0` / `v2.2.0` 目前有 git tag 但無 GitHub Release，可一併決定是否補建。
3. **transformers 5 注意**：worker image 需重建；建議部署後跑一次中文音檔 align smoke test（API 層已驗證，未做完整 GPU 端到端）。