### PR TITLE
fix: render viewer transcript text server-side

### DIFF
--- a/src/whisper_ui/web/templates/viewer.html
+++ b/src/whisper_ui/web/templates/viewer.html
@@ -180,9 +180,13 @@
         {% endif %}
         {#- Text renders server-side so it survives Alpine/JS failure; x-html
             re-renders it (with search highlighting) only when Alpine is alive.
-            Reading from data-raw avoids tojson's quotes breaking the attribute. -#}
-        <span data-raw="{{ seg.text|e }}"
-              x-html="window.whisperHighlight($el.dataset.raw, search)">{{ seg.text }}</span>
+            Gated on the same search_disabled flag as the row above (line ~168):
+            a huge transcript has search turned off for performance, so there is
+            nothing to highlight and the per-segment data-raw copy + x-html eval
+            would be wasted work. Reading from data-raw also avoids tojson's
+            quotes breaking the attribute. -#}
+        <span {% if not search_disabled %}data-raw="{{ seg.text|e }}"
+              x-html="window.whisperHighlight($el.dataset.raw, search)"{% endif %}>{{ seg.text }}</span>
       </div>
       <button class="btn btn-ghost btn-xs opacity-60 hover:opacity-100 focus:opacity-100 focus-visible:opacity-100 transition-opacity flex-shrink-0"
               type="button"

--- a/src/whisper_ui/web/templates/viewer.html
+++ b/src/whisper_ui/web/templates/viewer.html
@@ -178,7 +178,11 @@
           [{{ seg.speaker }}]
         </strong>
         {% endif %}
-        <span x-html="window.whisperHighlight({{ seg.text|tojson }}, search)"></span>
+        {#- Text renders server-side so it survives Alpine/JS failure; x-html
+            re-renders it (with search highlighting) only when Alpine is alive.
+            Reading from data-raw avoids tojson's quotes breaking the attribute. -#}
+        <span data-raw="{{ seg.text|e }}"
+              x-html="window.whisperHighlight($el.dataset.raw, search)">{{ seg.text }}</span>
       </div>
       <button class="btn btn-ghost btn-xs opacity-60 hover:opacity-100 focus:opacity-100 focus-visible:opacity-100 transition-opacity flex-shrink-0"
               type="button"

--- a/tests/unit/test_web_routes.py
+++ b/tests/unit/test_web_routes.py
@@ -582,6 +582,31 @@ class TestViewerRoutes:
         assert resp.status_code == 200
         assert "下載影片" not in resp.text
 
+    def test_viewer_renders_segment_text_server_side(self, client, db, filestore):
+        """Regression: transcript text must render as server-side element content,
+        not only inside a client-side ``x-html`` attribute.
+
+        v2.3.0 rendered text via ``x-html="whisperHighlight({{ seg.text|tojson }},
+        ...)"``. ``tojson`` emits a double-quoted JSON string, which closed the
+        double-quoted attribute early and left the expression malformed, so the
+        text never rendered whenever Alpine evaluated it. The text must appear as
+        visible element body, independent of JS."""
+        marker = "逐字稿可見內容XYZ"
+        result = TranscriptResult(
+            segments=[Segment(start=0.0, end=1.0, text=marker, speaker="SPEAKER_00")],
+            language="zh",
+            duration=1.0,
+        )
+        job = Job(filename="render.mp3", status=JobStatus.COMPLETED, language="zh")
+        result_path = filestore.save_result(job.id, result)
+        job.result_path = str(result_path)
+        db.insert_job(job)
+
+        resp = client.get(f"/viewer/{job.id}")
+
+        assert resp.status_code == 200
+        assert f">{marker}</span>" in resp.text
+
     def test_viewer_segment_copy_button_is_keyboard_reachable(self, client, db, filestore):
         """Regression for WCAG 2.1.1 + 1.4.13 (plan §4 P0): the per-segment
         copy button must be visible without hover and expose an aria-label."""

--- a/tests/unit/test_web_routes.py
+++ b/tests/unit/test_web_routes.py
@@ -530,6 +530,11 @@ class TestViewerRoutes:
         assert resp.status_code == 200
         assert "已停用即時搜尋" in resp.text
         assert 'placeholder="輸入關鍵字篩選' not in resp.text
+        # Search is disabled for performance, so the per-segment data-raw copy
+        # and x-html highlight eval must be skipped — but the text still renders
+        # server-side so it stays visible.
+        assert "data-raw=" not in resp.text
+        assert ">seg0</span>" in resp.text
 
     def test_viewer_keeps_search_under_limit(self, client, db, filestore):
         from whisper_ui.core.constants import VIEWER_SEARCH_SEGMENT_LIMIT
@@ -606,6 +611,8 @@ class TestViewerRoutes:
 
         assert resp.status_code == 200
         assert f">{marker}</span>" in resp.text
+        # Search is enabled under the limit, so the highlight path is wired up.
+        assert "data-raw=" in resp.text
 
     def test_viewer_segment_copy_button_is_keyboard_reachable(self, client, db, filestore):
         """Regression for WCAG 2.1.1 + 1.4.13 (plan §4 P0): the per-segment


### PR DESCRIPTION
## Why（Bug）
v2.3.0 起，viewer 的逐字稿**文字整段消失**（時間戳與語者標籤仍正常顯示）。資料完整無損，純顯示問題。

**根因**：`templates/viewer.html` 的逐字稿文字改用 Alpine `x-html` 渲染：
```
<span x-html="window.whisperHighlight({{ seg.text|tojson }}, search)"></span>
```
`tojson` 產生的字串外層帶**原始雙引號**（如 `"你..."`），被放在**雙引號的 `x-html` 屬性**裡時，瀏覽器會在第一個內層 `"` 提前關閉屬性，Alpine 取得殘缺運算式 `window.whisperHighlight(` → 求值失敗 → 文字永遠渲染不出來。時間戳/語者因為是 server 端渲染所以不受影響，造成「只有文字消失」。此為**普遍性 bug，與 CDN/Alpine 是否載入無關**。

對照：v2.2.0 是 `<span>{{ seg.text }}</span>`（server 端渲染），v2.3.0 改成 client-side x-html 才引入此問題。

## How（Fix）
- 逐字稿文字改回 **server 端渲染**為 span 內容（漸進增強）：即使 Alpine/JS 失效也一定看得到。
- 搜尋 highlight 仍由 `x-html` 處理，但改從 `data-raw`（`{{ seg.text|e }}`，屬性安全跳脫）讀取原文，**徹底避開 tojson 雙引號破壞屬性**的問題。
- Alpine 正常時 x-html 覆寫 fallback（含 `<mark>` highlight）；失效時保留 server 文字。

## Tests
新增 `test_viewer_renders_segment_text_server_side`：斷言逐字稿文字以可見元素內容（`>...</span>`）渲染，而非僅存在於 x-html 屬性——可擋住此 regression。全套 688 unit tests 通過、ruff 乾淨。

## 後續
這是 v2.3.0 的 viewer regression。合併後建議發 **v2.3.1** 並重新部署兩台（本機 + 211.72.5.3），逐字稿即恢復顯示（無需重跑任何 job，資料本就完整）。