### PR TITLE
chore: release v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.3.1] - 2026-05-24
+
+### Fixed
+
+- Viewer transcript text no longer disappears. v2.3.0 rendered each
+  segment's text client-side via
+  `x-html="window.whisperHighlight({{ seg.text|tojson }}, search)"`;
+  `tojson` emits a double-quoted JSON string, which closed the
+  double-quoted attribute early and left the expression malformed, so
+  the text never rendered while timestamps and speaker labels (rendered
+  server-side) stayed visible. Text now renders server-side as element
+  content — visible even if Alpine/JS fails — and `x-html` only
+  re-renders it (with `<mark>` search highlighting) when Alpine is alive.
+
+### Changed
+
+- Viewer skips the per-segment `data-raw` copy and `x-html` highlight
+  markup for search-disabled large transcripts (> `VIEWER_SEARCH_SEGMENT_LIMIT`
+  segments), where search — and therefore highlighting — is already off,
+  avoiding redundant client-side work and a duplicate copy of each segment's
+  text.
+
 ## [2.3.0] - 2026-05-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.3.0"
+version = "2.3.1"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3807,7 +3807,7 @@ wheels = [
 
 [[package]]
 name = "whisper-ui"
-version = "2.3.0"
+version = "2.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Why
v2.3.1 patch release：發佈 PR #72 的 viewer 逐字稿顯示修復，讓兩台部署能透過版本化 image / `:latest` 取得修正。

## What
- `pyproject.toml` 2.3.0 → 2.3.1，`uv.lock` 同步（`uv lock`，無 transitive churn）。
- CHANGELOG 新增 `[2.3.1] - 2026-05-24`。

### 本版內容（PATCH）
- **Fixed**: viewer 逐字稿文字消失——`tojson` 的雙引號破壞 `x-html` 雙引號屬性導致 Alpine 求值失敗；改為 server 端渲染（JS 失效也看得到），search highlight 仍由 Alpine 處理。
- **Changed**: search-disabled 大型逐字稿（> VIEWER_SEARCH_SEGMENT_LIMIT）跳過 per-segment `data-raw`/`x-html`，省去冗餘 client-side 工作（採納 reviewer finding）。

## SemVer
PATCH（2.3.0 → 2.3.1）：純 bug fix + 內部渲染最佳化，無新功能、無破壞性變更。

## 合併後
push `v2.3.1` tag → 觸發 docker-publish 發佈 `:2.3.1`/`:2.3`/`:latest` → 重新部署兩台（本機 gpu+io、211.72.5.3 cpu）→ 逐字稿恢復顯示（資料本就完整、無需重跑 job）。