### PR TITLE
chore: release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-05-24
+
+### Added
+
+- Re-transcribe a completed job's audio with different parameters
+  (model, language, speaker diarization, traditional-Chinese conversion,
+  LLM correction) **without re-uploading**. Each run creates a new
+  transcript version and preserves the original so versions can be
+  compared. The job card gains a "重新轉換" modal pre-filled from the
+  source job, and re-transcribe versions are tagged with a "重新轉換版本"
+  badge; a `source_job_id` column links a version chain back to its root
+  job. The source audio is copied into the new job's own directory, so
+  each version is independent for viewing, export, and deletion.
+
+### Changed
+
+- The diarization and LLM-correction opt-in flags are now clamped to what
+  the deployment can actually run (`HF_TOKEN` for diarization,
+  `OLLAMA_BASE_URL` for LLM correction) when a job is created from upload,
+  URL, or re-transcribe. This keeps the persisted flag honest and avoids
+  enqueueing a diarize sub-job that the stage would only skip. The upload
+  "job inserted" log now records the clamped flags rather than the raw
+  request flags.
+
+### Fixed
+
+- Async request handlers no longer block the event loop on slow filesystem
+  or subprocess work: the ffprobe duration probe, batch ZIP creation,
+  transcript result loading, and job-directory deletion are now offloaded
+  to worker threads.
+
 ## [2.3.1] - 2026-05-24
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.3.1"
+version = "2.4.0"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3807,7 +3807,7 @@ wheels = [
 
 [[package]]
 name = "whisper-ui"
-version = "2.3.1"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Release v2.4.0

Minor release: re-transcribe feature (PR #74) plus its review-round fixes. Backward-compatible, no API breaking changes.

### Added
- Re-transcribe a completed job with different parameters without re-uploading; creates a new version and preserves the original. New "重新轉換" modal + version badge; `source_job_id` links versions.

### Changed
- Diarization / LLM-correction flags clamped to deployment availability (`HF_TOKEN` / `OLLAMA_BASE_URL`) at job creation; honest persisted flags, no no-op diarize sub-job. Upload log records clamped flags.

### Fixed
- ffprobe probe, batch ZIP, result load, and job-dir delete offloaded to threads so async handlers no longer block the event loop.

Bumps `pyproject.toml` / `uv.lock` to 2.4.0 and updates `CHANGELOG.md`. Tagging `v2.4.0` after merge will publish the GHCR images.
