### PR TITLE
fix: chown app-data + model-cache volumes to uid 1000 via init sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,17 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Worker logs no longer flood with HuggingFace Hub "Could not cache
-  non-existence ... Permission denied" warnings on every job. The
-  `model-cache` volume could retain `root:root` ownership inherited from an
-  earlier root-era deployment, which blocked the uid-1000 worker from
-  writing the Hub's `.no_exist` negative cache. A one-shot `model-cache-init`
-  sidecar now `chown`s the volume to uid 1000 before the workers start
-  (runs on both the `gpu` and `cpu` profiles).
+- Named volumes no longer keep `root:root` ownership inherited from an
+  earlier root-era deployment. The Dockerfile build-time `chown` only seeds
+  an empty volume on first mount, so a populated `app-data` or `model-cache`
+  could stay root-owned and block the uid-1000 services: `app-data` failed
+  DB/upload writes, and `model-cache` flooded every job's log with
+  HuggingFace "Could not cache non-existence ... Permission denied" warnings
+  for its `.no_exist` negative cache. A one-shot `volume-init` sidecar now
+  re-owns both volumes to uid 1000 before the frontend and workers start. It
+  is guarded — the recursive `chown` runs only when a volume is not already
+  uid-1000 owned, so steady-state restarts cost one `stat` per volume rather
+  than a full walk.
 
 ## [2.4.0] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Worker logs no longer flood with HuggingFace Hub "Could not cache
+  non-existence ... Permission denied" warnings on every job. The
+  `model-cache` volume could retain `root:root` ownership inherited from an
+  earlier root-era deployment, which blocked the uid-1000 worker from
+  writing the Hub's `.no_exist` negative cache. A one-shot `model-cache-init`
+  sidecar now `chown`s the volume to uid 1000 before the workers start
+  (runs on both the `gpu` and `cpu` profiles).
+
 ## [2.4.0] - 2026-05-24
 
 ### Added

--- a/compose.yml
+++ b/compose.yml
@@ -78,6 +78,21 @@ services:
       options:
         max-size: "20m"
         max-file: "5"
+  # One-shot init sidecar: the worker images run as USER 1000, but the
+  # model-cache named volume can keep root:root ownership inherited from an
+  # earlier root-era deployment (the Dockerfile build-time chown only seeds
+  # an *empty* volume on its first mount; a populated volume is left as-is).
+  # When that happens HuggingFace Hub cannot write its .no_exist negative
+  # cache and floods every job's log with "Permission denied". Re-chown the
+  # whole volume to uid 1000 on each `up` so the worker can write it.
+  # Idempotent and fast; runs once then exits before the workers start.
+  model-cache-init:
+    profiles: [gpu, cpu]
+    image: alpine:3
+    command: ["chown", "-R", "1000:1000", "/cache"]
+    volumes:
+      - model-cache:/cache
+    restart: "no"
   worker-gpu:
     profiles: [gpu]
     image: ghcr.io/fdff87554/whisper-ui-worker:${WHISPER_UI_VERSION:-latest}
@@ -126,6 +141,8 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+      model-cache-init:
+        condition: service_completed_successfully
     deploy:
       resources:
         reservations:
@@ -185,6 +202,8 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+      model-cache-init:
+        condition: service_completed_successfully
     restart: unless-stopped
     logging:
       driver: json-file

--- a/compose.yml
+++ b/compose.yml
@@ -51,6 +51,8 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+      volume-init:
+        condition: service_completed_successfully
     restart: unless-stopped
     # Cap the json-file driver so unbounded structured logs cannot fill
     # /var/lib/docker on long-running deployments. 20 MB x 5 files per
@@ -78,19 +80,30 @@ services:
       options:
         max-size: "20m"
         max-file: "5"
-  # One-shot init sidecar: the worker images run as USER 1000, but the
-  # model-cache named volume can keep root:root ownership inherited from an
-  # earlier root-era deployment (the Dockerfile build-time chown only seeds
-  # an *empty* volume on its first mount; a populated volume is left as-is).
-  # When that happens HuggingFace Hub cannot write its .no_exist negative
-  # cache and floods every job's log with "Permission denied". Re-chown the
-  # whole volume to uid 1000 on each `up` so the worker can write it.
-  # Idempotent and fast; runs once then exits before the workers start.
-  model-cache-init:
-    profiles: [gpu, cpu]
+  # One-shot init sidecar. The worker/frontend images run as USER 1000, but
+  # a named volume can keep root:root ownership inherited from an earlier
+  # root-era deployment — the Dockerfile build-time chown only seeds an
+  # *empty* volume on its first mount, never a populated one. When that
+  # happens app-data fails DB/upload writes, and model-cache floods every
+  # job's log with HuggingFace ".no_exist" Permission-denied warnings.
+  # Re-own both volumes to uid 1000 before any dependent service starts.
+  #
+  # Guarded so steady-state restarts cost one stat per volume instead of a
+  # full walk: the recursive chown runs only when the volume is not already
+  # uid-1000 owned. The chown itself is a metadata-only pass — quick on a
+  # local volume, though a very large cache on a slow/network backend adds a
+  # one-time startup cost. A volume whose top level is uid 1000 but holds a
+  # root-written subdir (e.g. a manual `docker run --user root`) is not
+  # self-healed; recover it with a manual chown or `docker volume rm`.
+  # No profile: the always-on frontend needs app-data, so this must run in
+  # every deployment. ($$ escapes compose variable interpolation.)
+  volume-init:
     image: alpine:3
-    command: ["chown", "-R", "1000:1000", "/cache"]
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - 'for d in /data /cache; do [ "$$(stat -c %u "$$d")" = 1000 ] || chown -R 1000:1000 "$$d"; done'
     volumes:
+      - app-data:/data
       - model-cache:/cache
     restart: "no"
   worker-gpu:
@@ -141,7 +154,7 @@ services:
     depends_on:
       redis:
         condition: service_healthy
-      model-cache-init:
+      volume-init:
         condition: service_completed_successfully
     deploy:
       resources:
@@ -202,7 +215,7 @@ services:
     depends_on:
       redis:
         condition: service_healthy
-      model-cache-init:
+      volume-init:
         condition: service_completed_successfully
     restart: unless-stopped
     logging:
@@ -259,6 +272,8 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+      volume-init:
+        condition: service_completed_successfully
     restart: unless-stopped
     logging:
       driver: json-file


### PR DESCRIPTION
## Why

Closes #38.

The worker and frontend images run as `USER 1000`, but a named volume can keep `root:root` ownership inherited from an earlier root-era deployment. The Dockerfile build-time `chown -R 1000 ...` only seeds an **empty** volume on its first mount — a volume that was already populated (e.g. by a pre-`2026-03-17`, root-running image) keeps its `root:root` dirs across recreations, and the build-time chown never reaches it.

This affects **two** volumes that the uid-1000 services write to:

- **`model-cache`** (#38): HuggingFace Hub can't write its `.no_exist` negative cache, flooding every job's log with `Permission denied`. Non-fatal but noisy, and HF re-checks the Hub for known-missing files every run.
- **`app-data`**: holds the SQLite DB, uploads, and outputs. Root ownership here blocks DB/upload writes — a more severe (fatal) failure mode through the identical mechanism. Bundling it prevents the same bug resurfacing in a follow-up review.

Affects upgrade-path deployments that reuse a root-era volume; a fresh install is not impacted.

## How

A one-shot `volume-init` sidecar (option 2 from the issue) re-owns both volumes to uid 1000 before any dependent service starts:

- No profile — the always-on `frontend` needs `app-data`, so it must run in every deployment.
- `frontend`, `worker-gpu`, `worker-cpu`, `worker-io` gain `depends_on: volume-init (service_completed_successfully)`.
- **Guarded**: the recursive `chown` runs only when a volume's top level is not already uid-1000 owned, so steady-state restarts cost one `stat` per volume instead of a full walk. This addresses the review note that an unconditional `chown -R` re-scans the whole cache on every `up`.
- **Documented blind spot**: a volume whose top level is uid 1000 but holds a root-written subdir (e.g. a manual `docker run --user root`) is not self-healed; recover with a manual `chown` or `docker volume rm`. This is an acceptable trade-off because the uid-1000 services only ever write as uid 1000.

Keeps containers rootless and mirrors the existing `ollama-pull` init-sidecar pattern. `compose.dev.yml` needs no change (it only overrides worker `volumes`/`command` and inherits `depends_on`).

## Testing

docker-compose infrastructure has no unit-test harness (the integration suite uses fakeredis and does not spin up Docker), so this was verified manually:

- `docker compose config` parses on the no-profile, `gpu`, `cpu`, and `io` scenarios; the rendered config shows `volume-init` and the `service_completed_successfully` dependency on the frontend and every worker.
- Throwaway two-volume end-to-end test:
  - **Root-era**: seeded `root:root` `app-data` (with `db/whisper_ui.db`) and `model-cache` (with a fake `.no_exist/`) → ran the exact sidecar command → both became `1000:1000`, and a uid-1000 process could then write the DB file and the `.no_exist` file (the operations that were failing).
  - **Guarded skip**: a volume already uid-1000 at the top level is left untouched (a planted root-owned subdir stayed root), confirming the recursive walk is skipped in steady state.

## Verification on a real deployment

```bash
# reproduce: force a volume root-owned
docker run --rm -v whisper-ui_app-data:/d -v whisper-ui_model-cache:/c alpine chown -R 0:0 /d /c
docker compose --profile gpu up -d            # repeat with --profile cpu
docker compose ps -a | grep volume-init       # Exited (0)
docker run --rm -v whisper-ui_model-cache:/c alpine \
  stat -c '%u:%g %n' /c/huggingface/hub/models--* 2>/dev/null   # 1000:1000
docker logs whisper-ui-worker-gpu-1 | grep 'Could not cache non-existence' # empty
```