### PR TITLE
feat: server-side session flash for upload result toasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- Upload result toasts ("已提交 N 個任務" …) now use a server-side session
+  flash instead of redirect query params persisted to `localStorage`. The
+  upload handlers stash the message in the session and redirect to a clean
+  `/jobs` (no `?submitted=&failed=…`); `base.html` consumes and renders it
+  once per genuine full-page load (htmx partial fetches and hx-boosted swaps
+  are skipped, so a poll never pops a pending flash). The flash is now truly
+  one-shot — a page reload no longer re-shows a stale toast, dropping the
+  previous 60-second `localStorage` recovery hack.
+
 ### Fixed
 
 - Named volumes no longer keep `root:root` ownership inherited from an

--- a/src/whisper_ui/web/deps.py
+++ b/src/whisper_ui/web/deps.py
@@ -13,6 +13,7 @@ from whisper_ui.core.config import Settings
 from whisper_ui.core.constants import JOB_ID_DISPLAY_LENGTH, MAX_BATCH_SIZE, TIMESTAMP_DISPLAY_LENGTH
 from whisper_ui.storage.database import JobDatabase
 from whisper_ui.storage.filestore import FileStore
+from whisper_ui.web.flash import consume_flash
 
 _WEB_DIR = Path(__file__).parent
 
@@ -71,6 +72,8 @@ templates.env.filters["relative_time"] = _format_relative_time
 templates.env.globals["JOB_ID_DISPLAY_LENGTH"] = JOB_ID_DISPLAY_LENGTH
 templates.env.globals["TIMESTAMP_DISPLAY_LENGTH"] = TIMESTAMP_DISPLAY_LENGTH
 templates.env.globals["MAX_BATCH_SIZE"] = MAX_BATCH_SIZE
+# base.html consumes queued flash messages on full-page renders (see flash.py).
+templates.env.globals["consume_flash"] = consume_flash
 
 
 def get_settings(request: Request) -> Settings:

--- a/src/whisper_ui/web/flash.py
+++ b/src/whisper_ui/web/flash.py
@@ -1,0 +1,31 @@
+"""Server-side flash messages backed by the Starlette session.
+
+A flash is a one-shot user-facing message that survives a POST-redirect-GET:
+``set_flash`` stashes it in ``request.session``; the next full-page render
+calls ``consume_flash`` to pop and display it. This replaces the earlier
+client-side localStorage stopgap so the redirect URL stays clean and the
+message's lifecycle is owned by the server.
+
+Each entry is ``{"message": str, "type": str}`` where ``type`` is a toast
+category (``success`` / ``warning`` / ``error`` / ``info``) consumed by the
+Alpine toast store in ``base.html``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+
+FLASH_SESSION_KEY = "_flash"
+
+
+def set_flash(request: Request, message: str, category: str = "info") -> None:
+    """Queue a flash message for the next full-page render."""
+    request.session.setdefault(FLASH_SESSION_KEY, []).append({"message": message, "type": category})
+
+
+def consume_flash(request: Request) -> list[dict[str, str]]:
+    """Return and clear all queued flash messages (empty list if none)."""
+    return request.session.pop(FLASH_SESSION_KEY, [])

--- a/src/whisper_ui/web/flash.py
+++ b/src/whisper_ui/web/flash.py
@@ -23,7 +23,9 @@ FLASH_SESSION_KEY = "_flash"
 
 def set_flash(request: Request, message: str, category: str = "info") -> None:
     """Queue a flash message for the next full-page render."""
-    request.session.setdefault(FLASH_SESSION_KEY, []).append({"message": message, "type": category})
+    messages = request.session.get(FLASH_SESSION_KEY, [])
+    messages.append({"message": message, "type": category})
+    request.session[FLASH_SESSION_KEY] = messages
 
 
 def consume_flash(request: Request) -> list[dict[str, str]]:

--- a/src/whisper_ui/web/routes/jobs.py
+++ b/src/whisper_ui/web/routes/jobs.py
@@ -106,7 +106,6 @@ async def jobs_page(
     filestore: FileStoreDep,
     settings: SettingsDep,
     user: CurrentUserDep,
-    submitted: int | None = None,
     status: str = "",
     page: int = 0,
 ):
@@ -115,7 +114,6 @@ async def jobs_page(
     owner_id = owner_filter(user)
     ctx = _build_list_context(db, redis, filestore, status, page, owner_id)
     ctx["active_page"] = "jobs"
-    ctx["submitted"] = submitted
     ctx["status_counts"] = db.get_status_counts(owner_id=owner_id)
     # The re-transcribe modal (full page only, not the /jobs/list fragment)
     # reuses the upload form's option choices.

--- a/src/whisper_ui/web/routes/upload.py
+++ b/src/whisper_ui/web/routes/upload.py
@@ -18,6 +18,7 @@ from whisper_ui.pipeline.audio_probe import get_audio_duration_seconds
 from whisper_ui.pipeline.preprocess import SUPPORTED_EXTENSIONS
 from whisper_ui.ui import labels as ui_labels
 from whisper_ui.web.deps import CurrentUserDep, DbDep, FileStoreDep, RedisDep, SettingsDep, templates
+from whisper_ui.web.flash import set_flash
 from whisper_ui.web.url_validation import PlaylistURLError, YouTubeURLError, validate_youtube_url
 from whisper_ui.worker.pipeline_dispatcher import enqueue_pipeline
 
@@ -25,6 +26,24 @@ _READ_CHUNK_SIZE = 1024 * 1024  # 1 MB
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+def _build_upload_toast(submitted: int, failed: int = 0, skipped: int = 0, deduped: int = 0) -> tuple[str, str]:
+    """Compose the post-upload toast message and category.
+
+    Mirrors the label concatenation the client used to do from query params:
+    a success base line plus optional failed / skipped / deduped clauses. The
+    category is ``warning`` whenever anything was failed or skipped.
+    """
+    message = ui_labels.TOAST_UPLOAD_SUCCESS.replace("{count}", str(submitted))
+    if failed:
+        message += ui_labels.TOAST_UPLOAD_FAILED.replace("{count}", str(failed))
+    if skipped:
+        message += ui_labels.TOAST_URL_SKIPPED.replace("{count}", str(skipped))
+    if deduped:
+        message += ui_labels.TOAST_URL_DEDUPED.replace("{count}", str(deduped))
+    category = "warning" if (failed or skipped) else "success"
+    return message, category
 
 
 def _format_size(size_bytes: int) -> str:
@@ -213,12 +232,11 @@ async def upload_submit(
         batch_id or "-",
     )
 
-    redirect_url = f"/jobs?submitted={submitted_count}"
-    if failed_count:
-        redirect_url += f"&failed={failed_count}"
+    message, category = _build_upload_toast(submitted_count, failed=failed_count)
+    set_flash(request, message, category)
     if htmx:
-        return Response(status_code=204, headers={"HX-Redirect": redirect_url})
-    return RedirectResponse(redirect_url, status_code=303)
+        return Response(status_code=204, headers={"HX-Redirect": "/jobs"})
+    return RedirectResponse("/jobs", status_code=303)
 
 
 @router.post("/upload/url")
@@ -348,16 +366,13 @@ async def upload_url_submit(
     # Queue itself could not be constructed — that happens before any job is
     # persisted, so there is nothing to show on /jobs.
 
-    # Build redirect URL with toast info
-    parts = [f"/jobs?submitted={submitted_count}"]
-    if failed_count:
-        parts.append(f"failed={failed_count}")
-    if invalid_line_nums:
-        parts.append(f"skipped={len(invalid_line_nums)}")
-    if duplicates_removed > 0:
-        parts.append(f"deduped={duplicates_removed}")
-    redirect_url = "&".join(parts)
-
+    message, category = _build_upload_toast(
+        submitted_count,
+        failed=failed_count,
+        skipped=len(invalid_line_nums),
+        deduped=duplicates_removed,
+    )
+    set_flash(request, message, category)
     if htmx:
-        return Response(status_code=204, headers={"HX-Redirect": redirect_url})
-    return RedirectResponse(redirect_url, status_code=303)
+        return Response(status_code=204, headers={"HX-Redirect": "/jobs"})
+    return RedirectResponse("/jobs", status_code=303)

--- a/src/whisper_ui/web/templates/base.html
+++ b/src/whisper_ui/web/templates/base.html
@@ -87,86 +87,16 @@
   {# Toast notifications #}
   {% include "_toast.html" %}
 
-  {# Toast from URL params (for post-redirect scenarios), persisted to
-     localStorage so a single reload can recover it. The flash entry
-     expires after 60 seconds to avoid stale toasts on long-idle reloads. #}
-  <div x-data x-init="
-    const FLASH_KEY = 'whisper-ui-upload-flash';
-    const FLASH_TTL_MS = 60000;
-    const buildSubmittedMessage = (n, failed, skipped, deduped) => {
-      let msg = '{{ labels.TOAST_UPLOAD_SUCCESS }}'.replace('{count}', n);
-      if (failed > 0) msg += '{{ labels.TOAST_UPLOAD_FAILED }}'.replace('{count}', failed);
-      if (skipped > 0) msg += '{{ labels.TOAST_URL_SKIPPED }}'.replace('{count}', skipped);
-      if (deduped > 0) msg += '{{ labels.TOAST_URL_DEDUPED }}'.replace('{count}', deduped);
-      const toastType = failed > 0 ? 'warning' : (skipped > 0 ? 'warning' : 'success');
-      return { message: msg, type: toastType };
-    };
-    const readFlash = () => {
-      try {
-        const raw = localStorage.getItem(FLASH_KEY);
-        if (!raw) return null;
-        const data = JSON.parse(raw);
-        if (!data.savedAt || Date.now() - data.savedAt > FLASH_TTL_MS) {
-          localStorage.removeItem(FLASH_KEY);
-          return null;
-        }
-        return data;
-      } catch { return null; }
-    };
-    const writeFlash = (toast) => {
-      try { localStorage.setItem(FLASH_KEY, JSON.stringify({ toast, savedAt: Date.now() })); } catch {}
-    };
-    const clearFlash = () => {
-      try { localStorage.removeItem(FLASH_KEY); } catch {}
-    };
-
-    const params = new URLSearchParams(window.location.search);
-    let toastShown = false;
-    let dirty = false;
-
-    const toast = params.get('toast');
-    const message = params.get('message');
-    if (toast && message) {
-      const payload = { message: decodeURIComponent(message), type: toast };
-      $store.toasts.add(payload);
-      writeFlash(payload);
-      toastShown = true;
-      params.delete('toast');
-      params.delete('message');
-      dirty = true;
-    }
-
-    const submitted = params.get('submitted');
-    if (submitted) {
-      const n = parseInt(submitted, 10);
-      const failed = parseInt(params.get('failed') || '0', 10);
-      const skipped = parseInt(params.get('skipped') || '0', 10);
-      const deduped = parseInt(params.get('deduped') || '0', 10);
-      const payload = buildSubmittedMessage(n, failed, skipped, deduped);
-      $store.toasts.add(payload);
-      writeFlash(payload);
-      toastShown = true;
-      params.delete('submitted');
-      params.delete('failed');
-      params.delete('skipped');
-      params.delete('deduped');
-      dirty = true;
-    }
-
-    if (dirty) {
-      const url = new URL(window.location);
-      url.search = params.toString();
-      history.replaceState({}, '', url);
-    }
-
-    if (!toastShown) {
-      const recovered = readFlash();
-      if (recovered && recovered.toast) {
-        $store.toasts.add(recovered.toast);
-        clearFlash();
-      }
-    }
-  "></div>
+  {# Server-side flash messages. Consumed once per full-page load (htmx
+     partial fetches and hx-boosted swaps send HX-Request and are skipped, so
+     a poll or fragment never pops a pending flash). The payload rides in a
+     JSON <script> element rather than the x-init attribute to avoid the
+     tojson-in-double-quoted-attribute breakage hit in v2.3.1. #}
+  {% set flashes = consume_flash(request) if not request.headers.get('hx-request') else [] %}
+  {% if flashes %}
+  <script id="flash-data" type="application/json">{{ flashes|tojson }}</script>
+  <div x-data x-init="JSON.parse(document.getElementById('flash-data').textContent).forEach(f => $store.toasts.add(f))"></div>
+  {% endif %}
 
   {# htmx event listeners for page loader and toasts #}
   <script>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+import re
 from typing import TYPE_CHECKING
 
 import pytest
@@ -22,6 +23,18 @@ if TYPE_CHECKING:
 # sign manufactured session cookies in the helpers below, so it must match
 # the SESSION_SECRET env var that `_test_session_secret` injects.
 TEST_SESSION_SECRET = "test-session-secret-not-real-do-not-reuse"
+
+_FLASH_ISLAND_RE = re.compile(r'<script id="flash-data" type="application/json">(.*?)</script>', re.S)
+
+
+def flash_messages(html: str) -> list[str]:
+    """Extract the flash messages base.html renders into its JSON island.
+
+    Jinja's ``tojson`` escapes non-ASCII (e.g. Chinese → ``\\uXXXX``), so the
+    raw HTML is not a reliable substring target; parse the JSON instead.
+    """
+    match = _FLASH_ISLAND_RE.search(html)
+    return [entry["message"] for entry in json.loads(match.group(1))] if match else []
 
 
 @pytest.fixture

--- a/tests/integration/test_e2e_golden_path.py
+++ b/tests/integration/test_e2e_golden_path.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from tests.conftest import flash_messages
 from whisper_ui.core.config import Settings
 from whisper_ui.core.constants import (
     WORKER_QUEUE_CPU,
@@ -35,6 +36,7 @@ from whisper_ui.pipeline.align import AlignStage
 from whisper_ui.pipeline.transcribe import TranscribeStage
 from whisper_ui.storage.database import JobDatabase
 from whisper_ui.storage.filestore import FileStore
+from whisper_ui.ui import labels as ui_labels
 from whisper_ui.web.app import create_app
 from whisper_ui.worker.runtime import WorkerRuntime
 
@@ -279,7 +281,12 @@ def test_upload_to_export_golden_path(
             follow_redirects=False,
         )
     assert resp.status_code == 303, resp.text
-    assert "submitted=1" in resp.headers["location"]
+    assert resp.headers["location"] == "/jobs"
+    # The success toast is delivered as a server-side session flash, shown
+    # once on the next full-page load rather than via query params. Verifying
+    # it here exercises the flash round-trip through the real SessionMiddleware.
+    page = integration_client.get("/jobs")
+    assert flash_messages(page.text) == [ui_labels.TOAST_UPLOAD_SUCCESS.replace("{count}", "1")]
 
     jobs = db.list_jobs()
     assert len(jobs) == 1

--- a/tests/unit/test_flash.py
+++ b/tests/unit/test_flash.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from whisper_ui.web.flash import FLASH_SESSION_KEY, consume_flash, set_flash
+
+
+def _request(session: dict | None = None) -> SimpleNamespace:
+    """A stand-in exposing just the ``.session`` attribute the helpers touch."""
+    return SimpleNamespace(session=session if session is not None else {})
+
+
+def test_consume_flash_with_no_messages_returns_empty_list():
+    assert consume_flash(_request()) == []
+
+
+def test_set_then_consume_returns_message_and_clears_session():
+    request = _request()
+    set_flash(request, "已提交 1 個任務", "success")
+    assert consume_flash(request) == [{"message": "已提交 1 個任務", "type": "success"}]
+    assert consume_flash(request) == []
+    assert FLASH_SESSION_KEY not in request.session
+
+
+def test_set_flash_accumulates_messages_in_order():
+    request = _request()
+    set_flash(request, "first")
+    set_flash(request, "second", "warning")
+    assert consume_flash(request) == [
+        {"message": "first", "type": "info"},
+        {"message": "second", "type": "warning"},
+    ]
+
+
+def test_set_flash_defaults_category_to_info():
+    request = _request()
+    set_flash(request, "plain")
+    assert consume_flash(request)[0]["type"] == "info"

--- a/tests/unit/test_web_routes.py
+++ b/tests/unit/test_web_routes.py
@@ -1,28 +1,14 @@
 from __future__ import annotations
 
-import json
-import re
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tests.conftest import authed_test_client
+from tests.conftest import authed_test_client, flash_messages
 from whisper_ui.core.models import Job, JobStatus, Segment, TranscriptResult
 from whisper_ui.ui import labels as ui_labels
 from whisper_ui.web.app import create_app
 from whisper_ui.web.deps import _format_relative_time, _format_time, make_content_disposition
-
-_FLASH_RE = re.compile(r'<script id="flash-data" type="application/json">(.*?)</script>', re.S)
-
-
-def _flash_messages(html: str) -> list[str]:
-    """Extract the messages from the rendered flash-data JSON island.
-
-    Jinja's ``tojson`` escapes non-ASCII (e.g. Chinese → ``\\uXXXX``), so the
-    raw HTML is not a reliable substring target; parse the JSON instead.
-    """
-    match = _FLASH_RE.search(html)
-    return [entry["message"] for entry in json.loads(match.group(1))] if match else []
 
 
 @pytest.fixture
@@ -943,7 +929,7 @@ class TestUploadPost:
         # The success toast rides in the session flash, rendered on the next
         # full-page load rather than via query params.
         page = client.get("/jobs")
-        assert _flash_messages(page.text) == [ui_labels.TOAST_UPLOAD_SUCCESS.replace("{count}", "1")]
+        assert flash_messages(page.text) == [ui_labels.TOAST_UPLOAD_SUCCESS.replace("{count}", "1")]
 
     def test_upload_flash_is_consumed_after_one_render(self, client, app):
         with patch("whisper_ui.web.routes.upload.enqueue_pipeline"):
@@ -1124,7 +1110,7 @@ class TestUploadPost:
         expected = ui_labels.TOAST_UPLOAD_SUCCESS.replace("{count}", "1") + ui_labels.TOAST_UPLOAD_FAILED.replace(
             "{count}", "1"
         )
-        assert _flash_messages(page.text) == [expected]
+        assert flash_messages(page.text) == [expected]
         statuses = sorted(j.status for j in db.list_jobs())
         assert statuses == sorted([JobStatus.QUEUED, JobStatus.FAILED])
 
@@ -1158,7 +1144,7 @@ class TestUploadURLPost:
         assert resp.status_code == 303
         assert resp.headers["location"] == "/jobs"
         page = client.get("/jobs")
-        assert _flash_messages(page.text) == [ui_labels.TOAST_UPLOAD_SUCCESS.replace("{count}", "1")]
+        assert flash_messages(page.text) == [ui_labels.TOAST_UPLOAD_SUCCESS.replace("{count}", "1")]
 
     def test_upload_url_creates_job_with_source_url(self, client, app, db):
         with patch("whisper_ui.web.routes.upload.enqueue_pipeline"):
@@ -1226,7 +1212,7 @@ class TestUploadURLPost:
         assert resp.status_code == 303
         assert resp.headers["location"] == "/jobs"
         page = client.get("/jobs")
-        assert _flash_messages(page.text) == [
+        assert flash_messages(page.text) == [
             ui_labels.TOAST_UPLOAD_SUCCESS.replace("{count}", "0")
             + ui_labels.TOAST_UPLOAD_FAILED.replace("{count}", "1")
         ]

--- a/tests/unit/test_web_routes.py
+++ b/tests/unit/test_web_routes.py
@@ -1,13 +1,28 @@
 from __future__ import annotations
 
+import json
+import re
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from tests.conftest import authed_test_client
 from whisper_ui.core.models import Job, JobStatus, Segment, TranscriptResult
+from whisper_ui.ui import labels as ui_labels
 from whisper_ui.web.app import create_app
 from whisper_ui.web.deps import _format_relative_time, _format_time, make_content_disposition
+
+_FLASH_RE = re.compile(r'<script id="flash-data" type="application/json">(.*?)</script>', re.S)
+
+
+def _flash_messages(html: str) -> list[str]:
+    """Extract the messages from the rendered flash-data JSON island.
+
+    Jinja's ``tojson`` escapes non-ASCII (e.g. Chinese → ``\\uXXXX``), so the
+    raw HTML is not a reliable substring target; parse the JSON instead.
+    """
+    match = _FLASH_RE.search(html)
+    return [entry["message"] for entry in json.loads(match.group(1))] if match else []
 
 
 @pytest.fixture
@@ -162,10 +177,21 @@ class TestJobsRoutes:
         assert resp.status_code == 200
         assert "任務列表" in resp.text
 
-    def test_jobs_page_with_submitted(self, client):
-        resp = client.get("/jobs?submitted=3")
-        assert resp.status_code == 200
-        assert "3" in resp.text
+    def test_jobs_page_htmx_request_does_not_consume_flash(self, client):
+        # Queue a flash via an upload, then fetch /jobs as an htmx request:
+        # partial/boosted fetches must not pop a pending flash.
+        with patch("whisper_ui.web.routes.upload.enqueue_pipeline"):
+            client.post(
+                "/upload",
+                data={"language": "zh", "model_name": "large-v3", "num_speakers": "0"},
+                files=[("files", ("test.mp3", b"fake audio data", "audio/mpeg"))],
+                follow_redirects=False,
+            )
+        htmx_resp = client.get("/jobs", headers={"HX-Request": "true"})
+        assert 'id="flash-data"' not in htmx_resp.text
+        # The flash survives and shows on the next genuine full-page load.
+        full_resp = client.get("/jobs")
+        assert 'id="flash-data"' in full_resp.text
 
     def test_jobs_list_fragment(self, client):
         resp = client.get("/jobs/list")
@@ -909,11 +935,24 @@ class TestUploadPost:
         file_list = files or [("files", ("test.mp3", b"fake audio data", "audio/mpeg"))]
         return client.post("/upload", data=data, files=file_list, follow_redirects=False)
 
-    def test_upload_post_submits_job(self, client, app):
+    def test_upload_post_redirects_to_clean_jobs_and_flashes(self, client, app):
         with patch("whisper_ui.web.routes.upload.enqueue_pipeline"):
             resp = self._upload(client)
         assert resp.status_code == 303
-        assert "/jobs?submitted=" in resp.headers["location"]
+        assert resp.headers["location"] == "/jobs"
+        # The success toast rides in the session flash, rendered on the next
+        # full-page load rather than via query params.
+        page = client.get("/jobs")
+        assert _flash_messages(page.text) == [ui_labels.TOAST_UPLOAD_SUCCESS.replace("{count}", "1")]
+
+    def test_upload_flash_is_consumed_after_one_render(self, client, app):
+        with patch("whisper_ui.web.routes.upload.enqueue_pipeline"):
+            self._upload(client)
+        first = client.get("/jobs")
+        assert 'id="flash-data"' in first.text
+        # Flash is one-shot: a reload no longer re-shows the toast.
+        second = client.get("/jobs")
+        assert 'id="flash-data"' not in second.text
 
     def test_upload_clamps_diarization_and_llm_when_unavailable(self, client, db, app):
         # Force neither hf_token nor ollama_base_url, so both opt-in flags must
@@ -1080,9 +1119,12 @@ class TestUploadPost:
         ):
             resp = self._upload(client, files=files)
         assert resp.status_code == 303
-        location = resp.headers["location"]
-        assert "submitted=1" in location
-        assert "failed=1" in location
+        assert resp.headers["location"] == "/jobs"
+        page = client.get("/jobs")
+        expected = ui_labels.TOAST_UPLOAD_SUCCESS.replace("{count}", "1") + ui_labels.TOAST_UPLOAD_FAILED.replace(
+            "{count}", "1"
+        )
+        assert _flash_messages(page.text) == [expected]
         statuses = sorted(j.status for j in db.list_jobs())
         assert statuses == sorted([JobStatus.QUEUED, JobStatus.FAILED])
 
@@ -1114,7 +1156,9 @@ class TestUploadURLPost:
         with patch("whisper_ui.web.routes.upload.enqueue_pipeline"):
             resp = self._post_url(client)
         assert resp.status_code == 303
-        assert "/jobs?submitted=1" in resp.headers["location"]
+        assert resp.headers["location"] == "/jobs"
+        page = client.get("/jobs")
+        assert _flash_messages(page.text) == [ui_labels.TOAST_UPLOAD_SUCCESS.replace("{count}", "1")]
 
     def test_upload_url_creates_job_with_source_url(self, client, app, db):
         with patch("whisper_ui.web.routes.upload.enqueue_pipeline"):
@@ -1156,7 +1200,7 @@ class TestUploadURLPost:
                 follow_redirects=False,
             )
         assert resp.status_code == 204
-        assert resp.headers.get("HX-Redirect") == "/jobs?submitted=1"
+        assert resp.headers.get("HX-Redirect") == "/jobs"
 
     def test_upload_url_passes_job_without_probed_duration(self, client, app, db):
         with patch("whisper_ui.web.routes.upload.enqueue_pipeline") as mock_enqueue:
@@ -1180,10 +1224,12 @@ class TestUploadURLPost:
         ):
             resp = self._post_url(client)
         assert resp.status_code == 303
-        location = resp.headers["location"]
-        assert "/jobs?submitted=0" in location
-        assert "failed=1" in location
-        assert "error=queue" not in location
+        assert resp.headers["location"] == "/jobs"
+        page = client.get("/jobs")
+        assert _flash_messages(page.text) == [
+            ui_labels.TOAST_UPLOAD_SUCCESS.replace("{count}", "0")
+            + ui_labels.TOAST_UPLOAD_FAILED.replace("{count}", "1")
+        ]
         jobs = db.list_jobs()
         assert len(jobs) == 1
         assert jobs[0].status == JobStatus.FAILED
@@ -1208,9 +1254,7 @@ class TestUploadURLPost:
                 follow_redirects=False,
             )
         assert resp.status_code == 204
-        hx_redirect = resp.headers.get("HX-Redirect", "")
-        assert "/jobs?submitted=0" in hx_redirect
-        assert "failed=1" in hx_redirect
+        assert resp.headers.get("HX-Redirect") == "/jobs"
         jobs = db.list_jobs()
         assert len(jobs) == 1
         assert jobs[0].status == JobStatus.FAILED


### PR DESCRIPTION
## Why

Closes #62.

The post-upload result toast (已提交 N 個任務 / 失敗 / 略過 / 去重) was a stopgap: `upload.py` redirected to `/jobs?submitted=&failed=&skipped=&deduped=`, and `base.html` read those query params client-side, pushed a toast, and mirrored it into `localStorage` (60s TTL) so a single reload could recover it. `SessionMiddleware` was already in place but unused for messaging. This replaces the stopgap with a proper server-side flash so the URL stays clean and the message lifecycle is owned by the server.

## How

- New `src/whisper_ui/web/flash.py`: `set_flash(request, message, category)` / `consume_flash(request)` backed by `request.session["_flash"]` (a list of `{message, type}`).
- `routes/upload.py`: both handlers build the message server-side (`_build_upload_toast`, mirroring the old JS label concatenation and warning/success rule), `set_flash(...)`, and redirect to a clean `/jobs` (303, or 204 + `HX-Redirect: /jobs` for htmx). No more query strings.
- `routes/jobs.py`: dropped the now-unused `submitted` query param / context key.
- `templates/base.html`: replaced the localStorage + URL-param block with a guarded consume — `consume_flash(request)` runs only on genuine full-page loads (skipped when `HX-Request` is present), so htmx partial fetches (`/jobs/list`, the dashboard poll) and hx-boosted swaps never pop a pending flash. The payload rides in a `<script type=\"application/json\">` island parsed by a tiny `x-init`, **avoiding the tojson-in-double-quoted-attribute breakage fixed in v2.3.1**.
- `deps.py`: registered `consume_flash` as a Jinja global.

### Behaviour change (intentional)

The flash is now truly one-shot: after it shows on the post-redirect page, a reload no longer re-displays it. This drops the previous 60-second `localStorage` recovery hack and matches standard flash semantics.

### Out of scope (deliberately untouched)

The upload **validation** errors (`/upload?error=…`, shown inline on the upload form) and the `/jobs?status=`/`?page=` filter URLs are legitimate share-friendly state, not transient toasts — left as-is. No server code produced the generic `?toast=&message=` path (dead code), so it was removed along with the rest of the stopgap.

## Testing

- `pytest` full unit suite: 719 passed. `ruff check`/`format`: clean. `pre-commit`: clean.
- New `tests/unit/test_flash.py`: set/consume round-trip, clears session, accumulation order, default category.
- Updated route tests assert a clean `/jobs` redirect (no `?submitted=`) and that the toast appears in the rendered flash JSON on the next GET; new tests cover one-shot consumption and the htmx guard (an `HX-Request` GET does not pop the flash, the next full load does). Flash assertions parse the JSON island because Jinja's `tojson` unicode-escapes the Chinese message text.

### Manual

Upload a file → land on `/jobs` (clean URL) → success toast top-right; reload → no toast (one-shot). URL upload with invalid lines → warning toast incl. 略過/去重 counts.