### PR TITLE
fix: visible dark-theme card borders + visual contrast tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,6 +100,8 @@ jobs:
         run: uv python install 3.13
       - name: Install dependencies
         run: uv sync --extra dev --frozen --python 3.13
+      - name: Install Node deps (Tailwind/daisyUI for the CSS build)
+        run: npm ci
       - name: Build CSS
         run: mise run css
       - name: Install Playwright Chromium

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,3 +87,22 @@ jobs:
           push: false
           cache-from: type=gha,scope=${{ matrix.dockerfile }}
           cache-to: type=gha,mode=max,scope=${{ matrix.dockerfile }}
+  # Browser-rendered theme/contrast checks (tests/visual). Single Python slot —
+  # rendering is interpreter-independent. Needs the compiled stylesheet (built
+  # here, since style.css is gitignored) and a headless Chromium.
+  visual-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install mise
+        uses: jdx/mise-action@v4
+      - name: Install Python 3.13
+        run: uv python install 3.13
+      - name: Install dependencies
+        run: uv sync --extra dev --frozen --python 3.13
+      - name: Build CSS
+        run: mise run css
+      - name: Install Playwright Chromium
+        run: uv run playwright install --with-deps chromium
+      - name: Visual tests
+        run: uv run pytest -m visual --tb=short -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   in dark mode, so the outline all but disappeared. Borders now use a dedicated
   `--color-line` token (decoupled from `base-300`, which still backs surface
   fills like `bg-base-300` hovers/badges), tuned for a clearly perceptible
-  outline in both themes (measured ≈1.7:1 light, ≈2.2:1 dark). The border (and
-  the page loader / speaker colors) now also follow `prefers-color-scheme: dark`
-  before a `data-theme` is set, so nothing flashes a light value on a dark
-  surface before Alpine hydrates (or when JS is unavailable).
+  outline in both themes (measured ≈1.7:1 light, ≈2.2:1 dark). This border, the
+  page loader, and the speaker colors are defined inside the daisyUI theme
+  blocks, so they track the theme exactly like the base palette — including
+  `prefers-color-scheme: dark` before a `data-theme` is set (no light flash on a
+  dark surface pre-hydration / with JS off) and inside a nested
+  `data-theme="whisper-light"` subtree.
 
 - Admin pages aligned with the v2 design language. `/admin/jobs` now reuses the
   user-facing job list (`_job_list.html`/`_job_card.html`) with a sticky filter,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Visual-contrast regression tests (`tests/visual`, `pytest -m visual`, new
+  `visual-tests` CI job). A headless Chromium renders the compiled stylesheet
+  and reads computed colors to assert the card border stays perceptibly
+  distinct from the card surface in both themes — guarding against the dark
+  border regressing to invisible again. Requires `playwright install chromium`.
+
 ### Changed
+
+- Dark-theme card borders are visible again. They previously used
+  `border-base-300`, whose lightness sits ~3% from the `base-200` card surface
+  in dark mode, so the outline all but disappeared. Borders now use a dedicated
+  `--color-line` token (decoupled from `base-300`, which still backs surface
+  fills like `bg-base-300` hovers/badges), tuned for a clearly perceptible
+  outline in both themes (measured ≈1.7:1 light, ≈2.2:1 dark).
 
 - Admin pages aligned with the v2 design language. `/admin/jobs` now reuses the
   user-facing job list (`_job_list.html`/`_job_card.html`) with a sticky filter,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   in dark mode, so the outline all but disappeared. Borders now use a dedicated
   `--color-line` token (decoupled from `base-300`, which still backs surface
   fills like `bg-base-300` hovers/badges), tuned for a clearly perceptible
-  outline in both themes (measured ≈1.7:1 light, ≈2.2:1 dark).
+  outline in both themes (measured ≈1.7:1 light, ≈2.2:1 dark). The border (and
+  the page loader / speaker colors) now also follow `prefers-color-scheme: dark`
+  before a `data-theme` is set, so nothing flashes a light value on a dark
+  surface before Alpine hydrates (or when JS is unavailable).
 
 - Admin pages aligned with the v2 design language. `/admin/jobs` now reuses the
   user-facing job list (`_job_list.html`/`_job_card.html`) with a sticky filter,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,11 @@ dev = [
   # atomic max-write script (see whisper_ui/worker/progress.py) can be
   # exercised under fakeredis without a real Redis server.
   "fakeredis[lua]>=2.35.1,<3",
+  # Visual/contrast regression tests (tests/visual, `pytest -m visual`).
+  # Renders the compiled stylesheet in a headless Chromium and reads computed
+  # colors to guard theme contrast (issue #61). Browser binary is installed
+  # separately via `playwright install chromium` (not a Python dependency).
+  "pytest-playwright>=0.5,<1",
 ]
 
 [build-system]
@@ -102,5 +107,9 @@ pythonpath = ["src"]
 # `pytest -m integration` (in CI's integration stage, for example).
 markers = [
   "integration: end-to-end tests that exercise real I/O boundaries (ffmpeg, sqlite, filestore, fakeredis)",
+  "visual: browser-rendered checks (Playwright + Chromium) on the compiled stylesheet; run with `pytest -m visual`",
 ]
-addopts = "-m 'not integration'"
+# Both integration and visual tests need extra setup (ffmpeg / a Chromium
+# browser), so the default run stays fast and pure-Python; trigger each
+# explicitly with `pytest -m integration` / `pytest -m visual`.
+addopts = "-m 'not integration and not visual'"

--- a/src/whisper_ui/web/static/css/input.css
+++ b/src/whisper_ui/web/static/css/input.css
@@ -80,6 +80,24 @@
   --font-sans: "Noto Sans TC", system-ui, -apple-system, "Segoe UI", sans-serif;
 }
 
+/* Dedicated card/divider border color, decoupled from base-300.
+   base-300 doubles as a surface fill (bg-base-300 hover/badge), so it cannot
+   also be tuned for a visible border: in dark mode its L15 sits ~3% from the
+   L18 card surface and the border all but disappears (issue #61). `--color-line`
+   is owned solely by borders. The `@theme inline` form makes the generated
+   border-line utility reference the variable directly, so the per-theme
+   override below cascades. Exact values are tuned against the contrast check
+   in tests/visual (OKLCH lightness is not WCAG luminance). */
+:root {
+  --whisper-line: oklch(80% 0.01 260);
+}
+[data-theme="whisper-dark"] {
+  --whisper-line: oklch(42% 0.02 260);
+}
+@theme inline {
+  --color-line: var(--whisper-line);
+}
+
 /* htmx transition classes */
 .htmx-settling {
   opacity: 1;

--- a/src/whisper_ui/web/static/css/input.css
+++ b/src/whisper_ui/web/static/css/input.css
@@ -38,6 +38,21 @@
   --border: 1px;
   --depth: 1;
   --noise: 0;
+  /* Custom tokens — defined inside the theme so daisyUI emits them across all
+     of its selectors (:root default, [data-theme], theme-controller, and the
+     prefers-dark `:root:not([data-theme])` media block). That makes them track
+     the theme exactly like the base colors, including before Alpine sets
+     data-theme and inside a nested [data-theme="whisper-light"] subtree. */
+  --whisper-line: oklch(80% 0.01 260); /* card/divider border; see border-line */
+  --whisper-loader: oklch(52% 0.13 168); /* #page-loader progress bar */
+  --speaker-1: oklch(55% 0.2 240);
+  --speaker-2: oklch(55% 0.2 25);
+  --speaker-3: oklch(55% 0.2 168);
+  --speaker-4: oklch(55% 0.2 310);
+  --speaker-5: oklch(55% 0.2 80);
+  --speaker-6: oklch(55% 0.2 130);
+  --speaker-7: oklch(55% 0.2 200);
+  --speaker-8: oklch(55% 0.2 55);
 }
 
 /* Custom dark theme */
@@ -74,35 +89,30 @@
   --border: 1px;
   --depth: 1;
   --noise: 0;
+  /* Dark counterparts of the custom tokens (see the light theme block). */
+  --whisper-line: oklch(42% 0.02 260);
+  --whisper-loader: oklch(65% 0.14 168);
+  --speaker-1: oklch(75% 0.15 240);
+  --speaker-2: oklch(75% 0.15 25);
+  --speaker-3: oklch(75% 0.15 168);
+  --speaker-4: oklch(75% 0.15 310);
+  --speaker-5: oklch(75% 0.15 80);
+  --speaker-6: oklch(75% 0.15 130);
+  --speaker-7: oklch(75% 0.15 200);
+  --speaker-8: oklch(75% 0.15 55);
 }
 
 @theme {
   --font-sans: "Noto Sans TC", system-ui, -apple-system, "Segoe UI", sans-serif;
 }
 
-/* Dedicated card/divider border color, decoupled from base-300.
-   base-300 doubles as a surface fill (bg-base-300 hover/badge), so it cannot
-   also be tuned for a visible border: in dark mode its L15 sits ~3% from the
-   L18 card surface and the border all but disappears (issue #61). `--color-line`
-   is owned solely by borders. The `@theme inline` form makes the generated
-   border-line utility reference the variable directly, so the per-theme
-   override below cascades. Exact values are tuned against the contrast check
-   in tests/visual (OKLCH lightness is not WCAG luminance). */
-:root {
-  --whisper-line: oklch(80% 0.01 260);
-}
-[data-theme="whisper-dark"] {
-  --whisper-line: oklch(42% 0.02 260);
-}
-/* Before Alpine sets data-theme (or with JS disabled) daisyUI already serves
-   its dark surfaces under prefers-dark via :root:not([data-theme]); mirror
-   that here so the border doesn't stay bright on a dark surface. Explicit
-   data-theme (either value) still takes over once present. */
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme]) {
-    --whisper-line: oklch(42% 0.02 260);
-  }
-}
+/* Expose the themed --whisper-line (defined in the daisyUI theme blocks above)
+   as a Tailwind color so `border-line` utilities exist. `inline` keeps the
+   utility referencing the variable, so it tracks the active theme. The border
+   is decoupled from base-300, which doubles as a surface fill (bg-base-300
+   hover/badge) and so can't also serve as a visible border in dark mode where
+   its L15 sits ~3% from the L18 card surface (issue #61). Values tuned against
+   tests/visual (OKLCH lightness is not WCAG luminance). */
 @theme inline {
   --color-line: var(--whisper-line);
 }
@@ -122,18 +132,10 @@
   top: 0;
   left: 0;
   height: 3px;
-  background: oklch(52% 0.13 168);
+  background: var(--whisper-loader);
   z-index: 9999;
   transition: width 0.3s ease;
   width: 0;
-}
-[data-theme="whisper-dark"] #page-loader {
-  background: oklch(65% 0.14 168);
-}
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme]) #page-loader {
-    background: oklch(65% 0.14 168);
-  }
 }
 
 /* Status accent border colors for job cards */
@@ -169,36 +171,17 @@
   .status-pulse { animation: none; opacity: 0.8; }
 }
 
-/* Speaker colors for viewer */
-.speaker-1 { color: oklch(55% 0.2 240); }
-.speaker-2 { color: oklch(55% 0.2 25); }
-.speaker-3 { color: oklch(55% 0.2 168); }
-.speaker-4 { color: oklch(55% 0.2 310); }
-.speaker-5 { color: oklch(55% 0.2 80); }
-.speaker-6 { color: oklch(55% 0.2 130); }
-.speaker-7 { color: oklch(55% 0.2 200); }
-.speaker-8 { color: oklch(55% 0.2 55); }
-
-[data-theme="whisper-dark"] .speaker-1 { color: oklch(75% 0.15 240); }
-[data-theme="whisper-dark"] .speaker-2 { color: oklch(75% 0.15 25); }
-[data-theme="whisper-dark"] .speaker-3 { color: oklch(75% 0.15 168); }
-[data-theme="whisper-dark"] .speaker-4 { color: oklch(75% 0.15 310); }
-[data-theme="whisper-dark"] .speaker-5 { color: oklch(75% 0.15 80); }
-[data-theme="whisper-dark"] .speaker-6 { color: oklch(75% 0.15 130); }
-[data-theme="whisper-dark"] .speaker-7 { color: oklch(75% 0.15 200); }
-[data-theme="whisper-dark"] .speaker-8 { color: oklch(75% 0.15 55); }
-
-/* prefers-dark fallback (before data-theme is set), mirroring daisyUI. */
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme]) .speaker-1 { color: oklch(75% 0.15 240); }
-  :root:not([data-theme]) .speaker-2 { color: oklch(75% 0.15 25); }
-  :root:not([data-theme]) .speaker-3 { color: oklch(75% 0.15 168); }
-  :root:not([data-theme]) .speaker-4 { color: oklch(75% 0.15 310); }
-  :root:not([data-theme]) .speaker-5 { color: oklch(75% 0.15 80); }
-  :root:not([data-theme]) .speaker-6 { color: oklch(75% 0.15 130); }
-  :root:not([data-theme]) .speaker-7 { color: oklch(75% 0.15 200); }
-  :root:not([data-theme]) .speaker-8 { color: oklch(75% 0.15 55); }
-}
+/* Speaker colors for viewer. Values live in the daisyUI theme blocks
+   (--speaker-N) so they track the theme — including prefers-dark before
+   data-theme is set, and nested [data-theme] subtrees — automatically. */
+.speaker-1 { color: var(--speaker-1); }
+.speaker-2 { color: var(--speaker-2); }
+.speaker-3 { color: var(--speaker-3); }
+.speaker-4 { color: var(--speaker-4); }
+.speaker-5 { color: var(--speaker-5); }
+.speaker-6 { color: var(--speaker-6); }
+.speaker-7 { color: var(--speaker-7); }
+.speaker-8 { color: var(--speaker-8); }
 
 /* Transcript reading experience */
 .transcript-container {

--- a/src/whisper_ui/web/static/css/input.css
+++ b/src/whisper_ui/web/static/css/input.css
@@ -94,6 +94,15 @@
 [data-theme="whisper-dark"] {
   --whisper-line: oklch(42% 0.02 260);
 }
+/* Before Alpine sets data-theme (or with JS disabled) daisyUI already serves
+   its dark surfaces under prefers-dark via :root:not([data-theme]); mirror
+   that here so the border doesn't stay bright on a dark surface. Explicit
+   data-theme (either value) still takes over once present. */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --whisper-line: oklch(42% 0.02 260);
+  }
+}
 @theme inline {
   --color-line: var(--whisper-line);
 }
@@ -120,6 +129,11 @@
 }
 [data-theme="whisper-dark"] #page-loader {
   background: oklch(65% 0.14 168);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) #page-loader {
+    background: oklch(65% 0.14 168);
+  }
 }
 
 /* Status accent border colors for job cards */
@@ -173,6 +187,18 @@
 [data-theme="whisper-dark"] .speaker-6 { color: oklch(75% 0.15 130); }
 [data-theme="whisper-dark"] .speaker-7 { color: oklch(75% 0.15 200); }
 [data-theme="whisper-dark"] .speaker-8 { color: oklch(75% 0.15 55); }
+
+/* prefers-dark fallback (before data-theme is set), mirroring daisyUI. */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) .speaker-1 { color: oklch(75% 0.15 240); }
+  :root:not([data-theme]) .speaker-2 { color: oklch(75% 0.15 25); }
+  :root:not([data-theme]) .speaker-3 { color: oklch(75% 0.15 168); }
+  :root:not([data-theme]) .speaker-4 { color: oklch(75% 0.15 310); }
+  :root:not([data-theme]) .speaker-5 { color: oklch(75% 0.15 80); }
+  :root:not([data-theme]) .speaker-6 { color: oklch(75% 0.15 130); }
+  :root:not([data-theme]) .speaker-7 { color: oklch(75% 0.15 200); }
+  :root:not([data-theme]) .speaker-8 { color: oklch(75% 0.15 55); }
+}
 
 /* Transcript reading experience */
 .transcript-container {

--- a/src/whisper_ui/web/templates/_dashboard_active.html
+++ b/src/whisper_ui/web/templates/_dashboard_active.html
@@ -41,7 +41,7 @@
     {%- else %}{% set _stage = 'transcribe' %}{% endif -%}
     {%- set _stage_idx = _stage_keys.index(_stage) -%}
     <div id="dashboard-active-{{ job.id }}"
-         class="card bg-base-200 border border-base-300 mb-2"
+         class="card bg-base-200 border border-line mb-2"
          x-data="{
            createdAt: {{ (job.created_at or '')|tojson }},
            progress: {{ progress_val }},
@@ -76,7 +76,7 @@
           <span class="px-2 py-0.5 rounded-full
             {% if is_current %}bg-primary text-primary-content
             {% elif is_done %}bg-base-300 opacity-70
-            {% else %}border border-base-300 opacity-50{% endif %}">
+            {% else %}border border-line opacity-50{% endif %}">
             {{ _stage_labels[key] }}
           </span>
           {% if not loop.last %}<span class="opacity-30">›</span>{% endif %}

--- a/src/whisper_ui/web/templates/_job_card.html
+++ b/src/whisper_ui/web/templates/_job_card.html
@@ -55,7 +55,7 @@
     {# Inline export dropdown #}
     <div class="dropdown dropdown-end" x-data="{ open: false }" @click.away="open = false">
       <button class="btn btn-ghost btn-xs" @click="open = !open">{{ labels.JOBS_INLINE_EXPORT }}</button>
-      <ul class="dropdown-content menu bg-base-100 rounded-box shadow-lg z-10 w-36 p-1 border border-base-300" x-show="open" x-transition>
+      <ul class="dropdown-content menu bg-base-100 rounded-box shadow-lg z-10 w-36 p-1 border border-line" x-show="open" x-transition>
         {% for fmt in export_formats %}
         <li><a href="/viewer/{{ job.id }}/export/{{ fmt }}" download class="text-xs">{{ fmt|upper }}</a></li>
         {% endfor %}

--- a/src/whisper_ui/web/templates/_job_interactions.html
+++ b/src/whisper_ui/web/templates/_job_interactions.html
@@ -7,7 +7,7 @@
 {# Bulk action bar — sticky at the bottom when any rows are selected. #}
 <div class="fixed inset-x-0 bottom-0 md:left-14 lg:left-60 z-30 px-4 sm:px-6 lg:px-8 pb-4"
      x-data x-show="$store.jobSelection.size > 0" x-transition.opacity x-cloak>
-  <div class="card bg-base-200 border border-base-300 shadow-lg max-w-3xl mx-auto">
+  <div class="card bg-base-200 border border-line shadow-lg max-w-3xl mx-auto">
     <div class="card-body p-3 flex flex-row flex-wrap items-center gap-3">
       <span class="text-sm font-medium" x-text="`{{ labels.JOBS_BULK_SELECTED }}`.replace('{count}', $store.jobSelection.size)"></span>
       <div class="flex flex-wrap gap-2 ml-auto">

--- a/src/whisper_ui/web/templates/_job_list.html
+++ b/src/whisper_ui/web/templates/_job_list.html
@@ -28,7 +28,7 @@
   {% set bi = batch_info[group_key] %}
   {%- set _batch_search = (group_jobs|map(attribute='filename')|join(' ')) + ' ' + (group_jobs|map(attribute='source_url')|select|join(' ')) -%}
   <div id="job-group-{{ group_key }}"
-       class="collapse collapse-arrow bg-base-200 border border-base-300"
+       class="collapse collapse-arrow bg-base-200 border border-line"
        data-job-name="{{ group_jobs[0].filename if group_jobs else '' }}"
        data-job-search="{{ _batch_search }}"
        {% if not bi.all_done %}open{% endif %}>
@@ -87,7 +87,7 @@
   {# Single job #}
   {% set job = group_jobs[0] %}
   <div id="job-{{ job.id }}"
-       class="card bg-base-200 border border-base-300 border-l-3 border-status-{{ job.status.value }}"
+       class="card bg-base-200 border border-line border-l-3 border-status-{{ job.status.value }}"
        data-job-name="{{ job.filename }}"
        data-job-search="{{ job.filename }}{% if job.source_url %} {{ job.source_url }}{% endif %}">
     <div class="card-body p-4">

--- a/src/whisper_ui/web/templates/_sidebar.html
+++ b/src/whisper_ui/web/templates/_sidebar.html
@@ -2,7 +2,7 @@
 {# Desktop sidebar (>= lg) and tablet icon rail (md-lg) #}
 <div class="flex flex-col h-full bg-base-200">
   {# Logo: mark on rail; mark + wordmark on full sidebar #}
-  <div class="p-4 flex items-center gap-2 border-b border-base-300">
+  <div class="p-4 flex items-center gap-2 border-b border-line">
     <img src="{{ url_for('static', path='images/logo-mark.svg') }}"
          alt="Whisper UI" width="32" height="32"
          class="w-8 h-8 shrink-0" />
@@ -63,7 +63,7 @@
   </nav>
 
   {# Theme toggle #}
-  <div class="p-4 border-t border-base-300">
+  <div class="p-4 border-t border-line">
     <button class="btn btn-ghost btn-sm w-full justify-start gap-2"
             :aria-label="theme === 'whisper-light' ? '{{ labels.THEME_TOGGLE_DARK }}' : '{{ labels.THEME_TOGGLE_LIGHT }}'"
             @click="theme = theme === 'whisper-light' ? 'whisper-dark' : 'whisper-light'">
@@ -78,7 +78,7 @@
 
   {# Current user + logout — only rendered when a user is on request.state. #}
   {% if request.state and request.state.user %}
-  <div class="p-4 border-t border-base-300">
+  <div class="p-4 border-t border-line">
     <div class="hidden lg:block text-xs opacity-70 mb-2 truncate" title="{{ request.state.user.username }}">
       {{ labels.AUTH_SIGNED_IN_AS.format(username=request.state.user.username) }}
       {% if request.state.user.is_admin %}

--- a/src/whisper_ui/web/templates/admin_jobs.html
+++ b/src/whisper_ui/web/templates/admin_jobs.html
@@ -9,13 +9,13 @@
 {# Sticky filter+search header — same shape as /jobs, but the chips and the
    polled list fragment point at /admin/jobs/list so the admin (owner_id=None)
    scope and owner badges are preserved. #}
-<div class="sticky top-0 z-10 bg-base-100 pt-1 pb-3 mb-4 -mx-4 sm:-mx-6 lg:-mx-8 px-4 sm:px-6 lg:px-8 border-b border-base-300">
+<div class="sticky top-0 z-10 bg-base-100 pt-1 pb-3 mb-4 -mx-4 sm:-mx-6 lg:-mx-8 px-4 sm:px-6 lg:px-8 border-b border-line">
   <div class="flex flex-wrap gap-2 mb-3" x-data="{ activeFilter: {{ status|tojson }} }">
     {% set _all_count = status_counts.values()|sum %}
     {% for value, label in [('', labels.JOBS_FILTER_ALL)] + labels.STATUS_LABELS.items()|list %}
     {%- set _count = _all_count if value == '' else status_counts.get(value, 0) -%}
     <button class="btn btn-sm gap-1.5"
-            :class="activeFilter === '{{ value }}' ? 'btn-primary' : 'btn-ghost border border-base-300'"
+            :class="activeFilter === '{{ value }}' ? 'btn-primary' : 'btn-ghost border border-line'"
             hx-get="/admin/jobs/list?status={{ value }}" hx-target="#job-list-wrapper" hx-swap="outerHTML"
             @click="activeFilter = '{{ value }}'">
       <span>{{ label }}</span>

--- a/src/whisper_ui/web/templates/admin_users.html
+++ b/src/whisper_ui/web/templates/admin_users.html
@@ -23,7 +23,7 @@
       ('inactive', labels.ADMIN_USER_STATUS_INACTIVE),
     ] %}
     <button class="btn btn-sm"
-            :class="f === '{{ value }}' ? 'btn-primary' : 'btn-ghost border border-base-300'"
+            :class="f === '{{ value }}' ? 'btn-primary' : 'btn-ghost border border-line'"
             @click="f = '{{ value }}'">{{ label }}</button>
     {% endfor %}
   </div>
@@ -119,7 +119,7 @@
   </dialog>
 </div>
 
-<div class="card bg-base-200 border border-base-300">
+<div class="card bg-base-200 border border-line">
   <div class="card-body">
     <h2 class="card-title text-base">{{ labels.ADMIN_ADD_USER_HEADER }}</h2>
     <form method="post" action="/admin/users" class="grid grid-cols-1 sm:grid-cols-4 gap-3 items-end">

--- a/src/whisper_ui/web/templates/base.html
+++ b/src/whisper_ui/web/templates/base.html
@@ -68,7 +68,7 @@
   {# App shell: sidebar + main content #}
   <div class="flex min-h-screen">
     {# Sidebar — hidden on mobile, icon rail on tablet, full on desktop #}
-    <aside class="hidden md:flex md:w-14 lg:w-60 flex-col fixed inset-y-0 left-0 z-40 transition-colors duration-200 border-r border-base-300 bg-base-200">
+    <aside class="hidden md:flex md:w-14 lg:w-60 flex-col fixed inset-y-0 left-0 z-40 transition-colors duration-200 border-r border-line bg-base-200">
       {% include "_sidebar.html" %}
     </aside>
 

--- a/src/whisper_ui/web/templates/dashboard.html
+++ b/src/whisper_ui/web/templates/dashboard.html
@@ -30,7 +30,7 @@
    full-card click target (Fitts) leading to the matching upload tab. #}
 <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
   <a href="/upload?mode=files"
-     class="card bg-base-200 border border-base-300 hover:border-primary/40 hover:bg-base-300 focus-visible:border-primary transition-colors"
+     class="card bg-base-200 border border-line hover:border-primary/40 hover:bg-base-300 focus-visible:border-primary transition-colors"
      hx-boost="true" hx-target="#page-content" hx-select="#page-content" hx-swap="outerHTML transition:true">
     <div class="card-body p-4">
       <div class="flex items-center gap-3">
@@ -43,7 +43,7 @@
     </div>
   </a>
   <a href="/upload?mode=folder"
-     class="card bg-base-200 border border-base-300 hover:border-primary/40 hover:bg-base-300 focus-visible:border-primary transition-colors"
+     class="card bg-base-200 border border-line hover:border-primary/40 hover:bg-base-300 focus-visible:border-primary transition-colors"
      hx-boost="true" hx-target="#page-content" hx-select="#page-content" hx-swap="outerHTML transition:true">
     <div class="card-body p-4">
       <div class="flex items-center gap-3">
@@ -56,7 +56,7 @@
     </div>
   </a>
   <a href="/upload?mode=url"
-     class="card bg-base-200 border border-base-300 hover:border-primary/40 hover:bg-base-300 focus-visible:border-primary transition-colors"
+     class="card bg-base-200 border border-line hover:border-primary/40 hover:bg-base-300 focus-visible:border-primary transition-colors"
      hx-boost="true" hx-target="#page-content" hx-select="#page-content" hx-swap="outerHTML transition:true">
     <div class="card-body p-4">
       <div class="flex items-center gap-3">
@@ -114,7 +114,7 @@
   <h2 class="text-lg font-medium mb-3">{{ labels.DASHBOARD_RECENT_SECTION }}</h2>
   <div class="flex flex-col gap-2">
     {% for job in recent_completed %}
-    <a href="/viewer/{{ job.id }}" class="card bg-base-200 border border-base-300 hover:border-primary/30 transition-colors">
+    <a href="/viewer/{{ job.id }}" class="card bg-base-200 border border-line hover:border-primary/30 transition-colors">
       <div class="card-body p-4">
         <div class="flex items-center justify-between gap-4">
           <div class="flex-1 min-w-0">
@@ -138,7 +138,7 @@
 
 {# Onboarding — first-run guidance replaces the lonely empty-state glyph. #}
 {% if total_jobs == 0 %}
-<section class="card bg-base-200 border border-base-300 mb-8">
+<section class="card bg-base-200 border border-line mb-8">
   <div class="card-body p-6">
     <h2 class="text-lg font-medium mb-4">{{ labels.DASHBOARD_ONBOARDING_TITLE }}</h2>
     <ol class="space-y-3">

--- a/src/whisper_ui/web/templates/jobs.html
+++ b/src/whisper_ui/web/templates/jobs.html
@@ -7,7 +7,7 @@
    can scan workload at a glance without expanding the lists. The search
    input filters by filename AND source URL — useful for YouTube-heavy
    workflows where the filename is just the video id. #}
-<div class="sticky top-0 z-10 bg-base-100 pt-1 pb-3 mb-4 -mx-4 sm:-mx-6 lg:-mx-8 px-4 sm:px-6 lg:px-8 border-b border-base-300">
+<div class="sticky top-0 z-10 bg-base-100 pt-1 pb-3 mb-4 -mx-4 sm:-mx-6 lg:-mx-8 px-4 sm:px-6 lg:px-8 border-b border-line">
   <div class="flex flex-wrap gap-2 mb-3" x-data="{ activeFilter: {{ status|tojson }} }">
     {# total_count is filtered by the active status, so it can't stand in for
        the "全部" chip — sum the per-status counts for the true total. #}
@@ -15,7 +15,7 @@
     {% for value, label in [('', labels.JOBS_FILTER_ALL)] + labels.STATUS_LABELS.items()|list %}
     {%- set _count = _all_count if value == '' else status_counts.get(value, 0) -%}
     <button class="btn btn-sm gap-1.5"
-            :class="activeFilter === '{{ value }}' ? 'btn-primary' : 'btn-ghost border border-base-300'"
+            :class="activeFilter === '{{ value }}' ? 'btn-primary' : 'btn-ghost border border-line'"
             hx-get="/jobs/list?status={{ value }}" hx-target="#job-list-wrapper" hx-swap="outerHTML"
             @click="activeFilter = '{{ value }}'">
       <span>{{ label }}</span>

--- a/src/whisper_ui/web/templates/login.html
+++ b/src/whisper_ui/web/templates/login.html
@@ -18,7 +18,7 @@
           crossorigin="anonymous"></script>
 </head>
 <body class="min-h-screen bg-base-100 text-base-content flex items-center justify-center px-4">
-  <div class="card bg-base-200 border border-base-300 shadow-sm w-full max-w-md">
+  <div class="card bg-base-200 border border-line shadow-sm w-full max-w-md">
     <div class="card-body p-8">
       <h1 class="text-2xl font-medium mb-2">{{ labels.AUTH_LOGIN_HEADER }}</h1>
       <p class="text-sm opacity-60 mb-6">{{ labels.AUTH_LOGIN_DESCRIPTION }}</p>

--- a/src/whisper_ui/web/templates/register.html
+++ b/src/whisper_ui/web/templates/register.html
@@ -17,7 +17,7 @@
           crossorigin="anonymous"></script>
 </head>
 <body class="min-h-screen bg-base-100 text-base-content flex items-center justify-center px-4">
-  <div class="card bg-base-200 border border-base-300 shadow-sm w-full max-w-md">
+  <div class="card bg-base-200 border border-line shadow-sm w-full max-w-md">
     <div class="card-body p-8">
       {% if bootstrap %}
       <h1 class="text-2xl font-medium mb-2">{{ labels.AUTH_BOOTSTRAP_HEADER }}</h1>

--- a/src/whisper_ui/web/templates/upload.html
+++ b/src/whisper_ui/web/templates/upload.html
@@ -64,7 +64,7 @@
     <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
       <button type="button"
               class="card bg-base-200 border text-left transition-colors hover:bg-base-300 focus-visible:border-primary"
-              :class="activePreset === 'meeting' ? 'border-primary' : 'border-base-300'"
+              :class="activePreset === 'meeting' ? 'border-primary' : 'border-line'"
               :aria-pressed="(activePreset === 'meeting').toString()"
               @click="applyPreset('meeting')">
         <div class="card-body p-3">
@@ -74,7 +74,7 @@
       </button>
       <button type="button"
               class="card bg-base-200 border text-left transition-colors hover:bg-base-300 focus-visible:border-primary"
-              :class="activePreset === 'podcast' ? 'border-primary' : 'border-base-300'"
+              :class="activePreset === 'podcast' ? 'border-primary' : 'border-line'"
               :aria-pressed="(activePreset === 'podcast').toString()"
               @click="applyPreset('podcast')">
         <div class="card-body p-3">
@@ -84,7 +84,7 @@
       </button>
       <button type="button"
               class="card bg-base-200 border text-left transition-colors hover:bg-base-300 focus-visible:border-primary"
-              :class="activePreset === 'interview' ? 'border-primary' : 'border-base-300'"
+              :class="activePreset === 'interview' ? 'border-primary' : 'border-line'"
               :aria-pressed="(activePreset === 'interview').toString()"
               @click="applyPreset('interview')">
         <div class="card-body p-3">
@@ -94,7 +94,7 @@
       </button>
       <button type="button"
               class="card bg-base-200 border text-left transition-colors hover:bg-base-300 focus-visible:border-primary"
-              :class="activePreset === 'lecture' ? 'border-primary' : 'border-base-300'"
+              :class="activePreset === 'lecture' ? 'border-primary' : 'border-line'"
               :aria-pressed="(activePreset === 'lecture').toString()"
               @click="applyPreset('lecture')">
         <div class="card-body p-3">
@@ -108,7 +108,7 @@
   {# Upload progress overlay #}
   <template x-if="uploading">
     <div class="fixed inset-0 bg-base-100/80 z-50 flex items-center justify-center">
-      <div class="card bg-base-100 border border-base-300 shadow-lg w-80">
+      <div class="card bg-base-100 border border-line shadow-lg w-80">
         <div class="card-body items-center text-center p-6">
           <span class="loading loading-spinner loading-lg text-primary mb-2"></span>
           <progress class="progress progress-primary w-full" :value="progress" max="100"></progress>
@@ -145,7 +145,7 @@
 
   {# Files tab #}
   <div x-show="tab === 'files'" x-transition.opacity>
-    <div class="border-2 border-dashed border-base-300 rounded-box p-8 sm:p-12 text-center transition-colors"
+    <div class="border-2 border-dashed border-line rounded-box p-8 sm:p-12 text-center transition-colors"
          :class="{ 'border-primary bg-primary/5': dragging }"
          x-data="{ dragging: false }"
          @dragover.prevent="dragging = true"
@@ -201,7 +201,7 @@
 
   {# Settings #}
   {# Basic settings — always visible, the two controls every user adjusts. #}
-  <section class="mt-8 pt-6 border-t border-base-300">
+  <section class="mt-8 pt-6 border-t border-line">
     <h2 class="text-sm font-medium opacity-80 mb-3">{{ labels.UPLOAD_SECTION_BASIC }}</h2>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
       <fieldset class="fieldset w-full">
@@ -228,7 +228,7 @@
   {# Advanced settings — collapsed by default. The "已啟用 N 項" pill is a
      summary so users never have to expand the panel just to see whether
      diarization / 繁體 / LLM are on. #}
-  <section class="mt-6 pt-6 border-t border-base-300">
+  <section class="mt-6 pt-6 border-t border-line">
     <button type="button"
             class="w-full flex items-center justify-between gap-3 text-left focus-visible:outline-none"
             :aria-expanded="advancedOpen.toString()"
@@ -306,7 +306,7 @@
   {# Sticky submit footer — keeps the primary action close to the user's
      cursor regardless of how far they've scrolled (Fitts's Law). The status
      line previews how many files / URLs the current selection will submit. #}
-  <div class="sticky bottom-0 -mx-4 sm:-mx-6 lg:-mx-8 mt-8 bg-base-100/95 backdrop-blur border-t border-base-300 px-4 sm:px-6 lg:px-8 py-3 z-10">
+  <div class="sticky bottom-0 -mx-4 sm:-mx-6 lg:-mx-8 mt-8 bg-base-100/95 backdrop-blur border-t border-line px-4 sm:px-6 lg:px-8 py-3 z-10">
     <div class="flex items-center gap-3">
       <span class="text-sm opacity-70 flex-1 min-w-0 truncate" x-text="statusLine"></span>
       <button type="submit" class="btn btn-primary btn-lg gap-2" :disabled="uploading">

--- a/src/whisper_ui/web/templates/viewer.html
+++ b/src/whisper_ui/web/templates/viewer.html
@@ -93,7 +93,7 @@
   else if (!inField && ($event.key === 'c' || $event.key === 'C')) { copyActive(); }
 ">
   {# Sticky toolbar #}
-  <div class="sticky top-0 z-10 bg-base-100 border-b border-base-300 pb-3 mb-4 pt-2">
+  <div class="sticky top-0 z-10 bg-base-100 border-b border-line pb-3 mb-4 pt-2">
     {# Export buttons #}
     <div class="flex flex-wrap items-center gap-2 mb-3">
       <div class="flex flex-wrap gap-1">
@@ -209,7 +209,7 @@
 </div>
 {% else %}
 {# No segments: export-only toolbar #}
-<div class="sticky top-0 z-10 bg-base-100 border-b border-base-300 pb-3 mb-4 pt-2">
+<div class="sticky top-0 z-10 bg-base-100 border-b border-line pb-3 mb-4 pt-2">
   <div class="flex flex-wrap items-center gap-2">
     <div class="flex flex-wrap gap-1">
       {% for fmt in export_formats %}

--- a/tests/visual/harness.html
+++ b/tests/visual/harness.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<!--
+  Static visual-test harness for tests/visual/test_contrast.py.
+
+  Loads the COMPILED stylesheet (built by `mise run css`, gitignored) and
+  renders a representative card in each theme so a headless browser can read
+  the rendered colors. No app/redis needed — opened directly via file://.
+  Keep the card classes in sync with the real templates' card pattern
+  (`card bg-base-200 border border-line`).
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" href="../../src/whisper_ui/web/static/style.css" />
+  </head>
+  <body>
+    <section data-theme="whisper-light">
+      <div id="card-light" class="card bg-base-200 border border-line">
+        <div class="card-body">light card</div>
+      </div>
+    </section>
+    <section data-theme="whisper-dark">
+      <div id="card-dark" class="card bg-base-200 border border-line">
+        <div class="card-body">dark card</div>
+      </div>
+    </section>
+  </body>
+</html>

--- a/tests/visual/harness.html
+++ b/tests/visual/harness.html
@@ -23,11 +23,13 @@
       <div id="card-light" class="card bg-base-200 border border-line">
         <div class="card-body">light card</div>
       </div>
+      <span id="spk-light" class="speaker-1">speaker</span>
     </section>
     <section data-theme="whisper-dark">
       <div id="card-dark" class="card bg-base-200 border border-line">
         <div class="card-body">dark card</div>
       </div>
+      <span id="spk-dark" class="speaker-1">speaker</span>
     </section>
   </body>
 </html>

--- a/tests/visual/harness.html
+++ b/tests/visual/harness.html
@@ -14,6 +14,11 @@
     <link rel="stylesheet" href="../../src/whisper_ui/web/static/style.css" />
   </head>
   <body>
+    <!-- No data-theme wrapper: exercises the pre-hydration / JS-off state
+         where daisyUI + our fallbacks follow prefers-color-scheme. -->
+    <div id="card-auto" class="card bg-base-200 border border-line">
+      <div class="card-body">auto card</div>
+    </div>
     <section data-theme="whisper-light">
       <div id="card-light" class="card bg-base-200 border border-line">
         <div class="card-body">light card</div>

--- a/tests/visual/test_contrast.py
+++ b/tests/visual/test_contrast.py
@@ -68,3 +68,14 @@ def test_card_border_is_distinct_from_surface(page: Page, card_id: str) -> None:
     assert ratio >= _MIN_CONTRAST, (
         f"{card_id}: border {border} vs surface {surface} contrast {ratio:.2f} < required {_MIN_CONTRAST}"
     )
+
+
+def test_auto_theme_border_follows_prefers_dark(page: Page) -> None:
+    """With no data-theme set (pre-hydration / JS off) and the system preferring
+    dark, the border must use the dark value — not the bright light default.
+    Asserts the no-data-theme card matches the explicit dark card."""
+    page.emulate_media(color_scheme="dark")
+    page.goto(_HARNESS.resolve().as_uri())
+    auto = tuple(page.locator("#card-auto").evaluate(_TO_RGB, "borderTopColor"))
+    dark = tuple(page.locator("#card-dark").evaluate(_TO_RGB, "borderTopColor"))
+    assert auto == dark, f"auto-theme border {auto} != dark border {dark} (bright-border regression)"

--- a/tests/visual/test_contrast.py
+++ b/tests/visual/test_contrast.py
@@ -79,3 +79,26 @@ def test_auto_theme_border_follows_prefers_dark(page: Page) -> None:
     auto = tuple(page.locator("#card-auto").evaluate(_TO_RGB, "borderTopColor"))
     dark = tuple(page.locator("#card-dark").evaluate(_TO_RGB, "borderTopColor"))
     assert auto == dark, f"auto-theme border {auto} != dark border {dark} (bright-border regression)"
+
+
+def test_explicit_light_border_ignores_system_dark_preference(page: Page) -> None:
+    """A nested/explicit data-theme=whisper-light keeps the light border even
+    when the OS prefers dark — it must not inherit the root's dark fallback."""
+    page.emulate_media(color_scheme="light")
+    page.goto(_HARNESS.resolve().as_uri())
+    under_light = tuple(page.locator("#card-light").evaluate(_TO_RGB, "borderTopColor"))
+    page.emulate_media(color_scheme="dark")
+    page.goto(_HARNESS.resolve().as_uri())
+    under_dark = tuple(page.locator("#card-light").evaluate(_TO_RGB, "borderTopColor"))
+    dark_border = tuple(page.locator("#card-dark").evaluate(_TO_RGB, "borderTopColor"))
+    assert under_dark == under_light, f"explicit-light border drifted under dark pref: {under_dark} != {under_light}"
+    assert under_dark != dark_border, "explicit-light border matched the dark theme (regression)"
+
+
+def test_speaker_colors_switch_between_themes(page: Page) -> None:
+    """Guards the var-based speaker colors: the same .speaker-1 renders a
+    different color under whisper-light vs whisper-dark."""
+    page.goto(_HARNESS.resolve().as_uri())
+    light = tuple(page.locator("#spk-light").evaluate(_TO_RGB, "color"))
+    dark = tuple(page.locator("#spk-dark").evaluate(_TO_RGB, "color"))
+    assert light != dark, f"speaker color did not switch per theme: {light} == {dark}"

--- a/tests/visual/test_contrast.py
+++ b/tests/visual/test_contrast.py
@@ -1,0 +1,70 @@
+"""Visual-contrast regression for the dark/light themes (issue #61).
+
+Renders the compiled stylesheet in a headless browser and asserts the card
+border is perceptibly distinct from the card surface in both themes. This is
+the objective oracle for the `--color-line` values in input.css — OKLCH
+lightness is not WCAG luminance, so the only reliable check is to read the
+*rendered* sRGB colors and compute the real contrast ratio.
+
+Run with ``pytest -m visual`` (needs ``playwright install chromium``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+pytestmark = pytest.mark.visual
+
+_HARNESS = Path(__file__).parent / "harness.html"
+
+# Resolve a computed CSS color (which Chromium may report as oklch(...)) to
+# sRGB bytes by painting it on a canvas — robust across color spaces.
+_TO_RGB = """
+(el, prop) => {
+  const ctx = document.createElement('canvas').getContext('2d');
+  ctx.fillStyle = getComputedStyle(el)[prop];
+  ctx.fillRect(0, 0, 1, 1);
+  const d = ctx.getImageData(0, 0, 1, 1).data;
+  return [d[0], d[1], d[2]];
+}
+"""
+
+# Minimum border-vs-surface contrast we require. Not the WCAG 1.4.11 3:1 bar:
+# card borders are decorative (the card is identifiable by its fill/content),
+# and a strict 3:1 line on a near-white light card reads as a heavy outline.
+# This floor is well above the ~1.05:1 near-invisible status quo #61 reported,
+# so it guards against the border disappearing again while staying subtle.
+_MIN_CONTRAST = 1.5
+
+
+def _relative_luminance(rgb: tuple[int, int, int]) -> float:
+    def channel(c: int) -> float:
+        s = c / 255
+        return s / 12.92 if s <= 0.03928 else ((s + 0.055) / 1.055) ** 2.4
+
+    r, g, b = (channel(c) for c in rgb)
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _contrast(a: tuple[int, int, int], b: tuple[int, int, int]) -> float:
+    la, lb = _relative_luminance(a), _relative_luminance(b)
+    hi, lo = max(la, lb), min(la, lb)
+    return (hi + 0.05) / (lo + 0.05)
+
+
+@pytest.mark.parametrize("card_id", ["card-light", "card-dark"])
+def test_card_border_is_distinct_from_surface(page: Page, card_id: str) -> None:
+    page.goto(_HARNESS.resolve().as_uri())
+    card = page.locator(f"#{card_id}")
+    border = tuple(card.evaluate(_TO_RGB, "borderTopColor"))
+    surface = tuple(card.evaluate(_TO_RGB, "backgroundColor"))
+    ratio = _contrast(border, surface)
+    assert ratio >= _MIN_CONTRAST, (
+        f"{card_id}: border {border} vs surface {surface} contrast {ratio:.2f} < required {_MIN_CONTRAST}"
+    )

--- a/tests/visual/test_contrast.py
+++ b/tests/visual/test_contrast.py
@@ -31,9 +31,23 @@ _TO_RGB = """
   ctx.fillStyle = getComputedStyle(el)[prop];
   ctx.fillRect(0, 0, 1, 1);
   const d = ctx.getImageData(0, 0, 1, 1).data;
-  return [d[0], d[1], d[2]];
+  return [d[0], d[1], d[2], d[3]];
 }
 """
+
+
+def _opaque_rgb(locator, prop: str) -> tuple[int, int, int]:
+    """Read a computed color as sRGB, asserting it is opaque.
+
+    The contrast math below assumes opaque colors. A translucent value would
+    need compositing over its background before the ratio is meaningful, so we
+    fail loudly rather than compute a wrong number silently. All current theme
+    tokens are opaque OKLCH; this guard documents and enforces that.
+    """
+    r, g, b, a = locator.evaluate(_TO_RGB, prop)
+    assert a == 255, f"{prop} is not opaque (alpha={a}); composite over the background before measuring"
+    return (r, g, b)
+
 
 # Minimum border-vs-surface contrast we require. Not the WCAG 1.4.11 3:1 bar:
 # card borders are decorative (the card is identifiable by its fill/content),
@@ -62,8 +76,8 @@ def _contrast(a: tuple[int, int, int], b: tuple[int, int, int]) -> float:
 def test_card_border_is_distinct_from_surface(page: Page, card_id: str) -> None:
     page.goto(_HARNESS.resolve().as_uri())
     card = page.locator(f"#{card_id}")
-    border = tuple(card.evaluate(_TO_RGB, "borderTopColor"))
-    surface = tuple(card.evaluate(_TO_RGB, "backgroundColor"))
+    border = _opaque_rgb(card, "borderTopColor")
+    surface = _opaque_rgb(card, "backgroundColor")
     ratio = _contrast(border, surface)
     assert ratio >= _MIN_CONTRAST, (
         f"{card_id}: border {border} vs surface {surface} contrast {ratio:.2f} < required {_MIN_CONTRAST}"
@@ -76,8 +90,8 @@ def test_auto_theme_border_follows_prefers_dark(page: Page) -> None:
     Asserts the no-data-theme card matches the explicit dark card."""
     page.emulate_media(color_scheme="dark")
     page.goto(_HARNESS.resolve().as_uri())
-    auto = tuple(page.locator("#card-auto").evaluate(_TO_RGB, "borderTopColor"))
-    dark = tuple(page.locator("#card-dark").evaluate(_TO_RGB, "borderTopColor"))
+    auto = _opaque_rgb(page.locator("#card-auto"), "borderTopColor")
+    dark = _opaque_rgb(page.locator("#card-dark"), "borderTopColor")
     assert auto == dark, f"auto-theme border {auto} != dark border {dark} (bright-border regression)"
 
 
@@ -86,11 +100,11 @@ def test_explicit_light_border_ignores_system_dark_preference(page: Page) -> Non
     when the OS prefers dark — it must not inherit the root's dark fallback."""
     page.emulate_media(color_scheme="light")
     page.goto(_HARNESS.resolve().as_uri())
-    under_light = tuple(page.locator("#card-light").evaluate(_TO_RGB, "borderTopColor"))
+    under_light = _opaque_rgb(page.locator("#card-light"), "borderTopColor")
     page.emulate_media(color_scheme="dark")
     page.goto(_HARNESS.resolve().as_uri())
-    under_dark = tuple(page.locator("#card-light").evaluate(_TO_RGB, "borderTopColor"))
-    dark_border = tuple(page.locator("#card-dark").evaluate(_TO_RGB, "borderTopColor"))
+    under_dark = _opaque_rgb(page.locator("#card-light"), "borderTopColor")
+    dark_border = _opaque_rgb(page.locator("#card-dark"), "borderTopColor")
     assert under_dark == under_light, f"explicit-light border drifted under dark pref: {under_dark} != {under_light}"
     assert under_dark != dark_border, "explicit-light border matched the dark theme (regression)"
 
@@ -99,6 +113,6 @@ def test_speaker_colors_switch_between_themes(page: Page) -> None:
     """Guards the var-based speaker colors: the same .speaker-1 renders a
     different color under whisper-light vs whisper-dark."""
     page.goto(_HARNESS.resolve().as_uri())
-    light = tuple(page.locator("#spk-light").evaluate(_TO_RGB, "color"))
-    dark = tuple(page.locator("#spk-dark").evaluate(_TO_RGB, "color"))
+    light = _opaque_rgb(page.locator("#spk-light"), "color")
+    dark = _opaque_rgb(page.locator("#spk-dark"), "color")
     assert light != dark, f"speaker color did not switch per theme: {light} == {dark}"

--- a/uv.lock
+++ b/uv.lock
@@ -1046,7 +1046,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
     { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
     { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
     { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
     { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
     { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
     { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
@@ -1054,7 +1056,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
     { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
     { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
     { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
     { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
     { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
     { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
@@ -1062,7 +1066,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
     { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
     { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
     { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
     { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
     { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
     { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
@@ -1070,7 +1076,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
     { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
     { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
     { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
     { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
     { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
     { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
@@ -2348,6 +2356,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/f0/832bd9677194908da118064eef20082f2791e3d18215cc6d9391ee2c5a67/playwright-1.60.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:6a8cd0fec171fb3089e95e898c8bc8a6f35dea0b78b399e12fcc19427e91b1d7", size = 43474635, upload-time = "2026-05-18T12:00:31.969Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:39b5420ba6145045b69ced4c5c47d4d9fe5bddfc8ff816c518913afcb25ec7a5", size = 42261327, upload-time = "2026-05-18T12:00:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/bc/23de499ded6411c188a20c5a0dea6f0cd4ed5d2b3cc6042a5dbd3ed609aa/playwright-1.60.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:2581d0e6a3392c71f91b27460c7fd093356818dc430f48153896c8aeeaef7705", size = 43474636, upload-time = "2026-05-18T12:00:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7b/1d679f4fced4ea94efadd17103856d8c565384f68382a1681264e46f5925/playwright-1.60.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:1c2bfae7884fb3fb05b853290eab8f343d524e5016f2f1def702acbbdf14c93e", size = 47467220, upload-time = "2026-05-18T12:00:43.179Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c2/1528d267d4442bd2c6b8eaeab819dd52c2030bf80e89293f0ba1f687473b/playwright-1.60.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43e66564125ee31b07a58cefb21e256d62d67d8d1713e6858df7a3019d8ed353", size = 47154856, upload-time = "2026-05-18T12:00:46.715Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4e/b008b6440a7a1624378041da94829956d4b8f7ab9ef5aad22d0dc3f2e26d/playwright-1.60.0-py3-none-win32.whl", hash = "sha256:ec94e416ea320711e0ad4bf185dcbf41833672961e90773e1885255d7db7b7e7", size = 37902157, upload-time = "2026-05-18T12:00:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f0/0541524133104f9cc20bf900870ff4a736b76a23483f3a55295ddfa58409/playwright-1.60.0-py3-none-win_amd64.whl", hash = "sha256:9566821ce6030a1f9e7146a24e19355ab0d98805fd0f9be50bb3d8fef1750c02", size = 37902159, upload-time = "2026-05-18T12:00:53.728Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c8/210f282d278e4709cdd71b12a31af45a30a22ab3207b387e29b37e478713/playwright-1.60.0-py3-none-win_arm64.whl", hash = "sha256:6e4f6700a4c2250efff8e690a81d66e3855754fb587b6b87cf5c784014f91537", size = 34037981, upload-time = "2026-05-18T12:00:57.584Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2712,6 +2739,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2746,6 +2785,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-base-url"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/1a/b64ac368de6b993135cb70ca4e5d958a5c268094a3a2a4cac6f0021b6c4f/pytest_base_url-2.1.0.tar.gz", hash = "sha256:02748589a54f9e63fcbe62301d6b0496da0d10231b753e950c63e03aee745d45", size = 6702, upload-time = "2024-01-31T22:43:00.81Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl", hash = "sha256:3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6", size = 5302, upload-time = "2024-01-31T22:42:58.897Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2757,6 +2809,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-playwright"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "playwright" },
+    { name = "pytest" },
+    { name = "pytest-base-url" },
+    { name = "python-slugify" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/ef/172eb8e23c80491fc72f1401c72f9305663873649351306a38b18406b0c9/pytest_playwright-0.8.0.tar.gz", hash = "sha256:7888d4a2443160c82e0c506c437076679f86b36d1910427250d90fbf1843a981", size = 17132, upload-time = "2026-05-18T10:16:15.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/71/1c545fac6a9054b52b3771238fb2dc6e8f1d0ccec116e1c7786ec191887c/pytest_playwright-0.8.0-py3-none-any.whl", hash = "sha256:856aae6efd4bc055f2ef229c647768760bcaad5cd3a5983c314ac260a974a933", size = 17143, upload-time = "2026-05-18T10:16:18.226Z" },
 ]
 
 [[package]]
@@ -2800,6 +2867,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
 ]
 
 [[package]]
@@ -3351,6 +3430,15 @@ wheels = [
 ]
 
 [[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3825,6 +3913,7 @@ dev = [
     { name = "itsdangerous" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-playwright" },
     { name = "python-docx" },
 ]
 frontend = [
@@ -3869,6 +3958,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.0,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0,<10" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0,<8" },
+    { name = "pytest-playwright", marker = "extra == 'dev'", specifier = ">=0.5,<1" },
     { name = "python-docx", marker = "extra == 'frontend'", specifier = ">=1.0,<2" },
     { name = "redis", specifier = ">=5.0,<7" },
     { name = "rq", specifier = ">=2.0,<3" },


### PR DESCRIPTION
## Why

Closes #61.

In the dark theme, card borders used `border-base-300`, whose OKLCH lightness (L15) sits only ~3% from the `base-200` card surface (L18), so the outline was all but invisible. `base-300` can't simply be retuned because it doubles as a **surface** fill (`bg-base-300` powers card hovers, the "done" state, and number badges) — changing it would shift those, and raising it would even invert the base ladder.

## How

**#61 — decouple the border token (commit 1)**
- New dedicated `--color-line` border color in `input.css`, owned solely by borders, using the documented Tailwind v4 theming pattern: `@theme inline { --color-line: var(--whisper-line) }` with `--whisper-line` overridden per theme under `[data-theme="whisper-dark"]`.
- Replaced the 34 `border-base-300` usages with `border-line` across templates. `bg-base-300` (surface role) is untouched, so hovers/badges/ladder are unchanged.
- Values tuned against the contrast test (OKLCH L is not WCAG luminance): measured ≈**1.71:1** light, ≈**2.22:1** dark — both clearly perceptible, up from the ~1.05:1 near-invisible status quo.

**Visual contrast tests — Playwright Tier B (commit 2)**
- Added `pytest-playwright` (dev extra) + a `visual` marker (default-excluded, like `integration`).
- `tests/visual/harness.html` renders a representative card in each theme against the **compiled** stylesheet; `test_contrast.py` opens it headless via `file://` (no app/redis), reads the rendered colors (converted to sRGB via a canvas, since Chromium reports `oklch()`), computes the real WCAG contrast, and asserts ≥ a documented floor (1.5) in both themes.
- New `visual-tests` CI job (single 3.13 slot): `uv sync` → `mise run css` (style.css is gitignored) → `playwright install --with-deps chromium` → `pytest -m visual`.

## Scope / honesty notes

- The floor is **1.5:1, not WCAG 1.4.11 3:1**: card borders are decorative (the card is identifiable by its fill/content) and a strict 3:1 line reads as a heavy outline on near-white light cards. 1.5 is well above the broken state while staying subtle; it's a documented, tunable knob.
- Tier B covers **CSS/theme contrast only** — it deliberately does *not* drive the full app or test htmx/Alpine behaviour (that would be a heavier Tier A with a running app + redis). No golden-screenshot assertions (fragile cross-env; not built into Python pytest-playwright) — the deterministic computed-contrast check is the oracle.

## Testing

- `pytest -m visual`: 2 passed (both themes ≥1.5). `pytest`: 733 passed (the plugin needs no browser when visual is deselected). `pytest -m integration`: 1 passed (golden path — this PR is CSS/template/test-only, no backend change). `ruff`/`pre-commit` clean.

### Manual
Toggle light/dark: card borders are clearly visible; `bg-base-300` hovers/badges look unchanged.