### PR TITLE
chore: release v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-05-25
+
 ### Added
 
 - Visual-contrast regression tests (`tests/visual`, `pytest -m visual`, new

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.4.0"
+version = "2.5.0"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3895,7 +3895,7 @@ wheels = [
 
 [[package]]
 name = "whisper-ui"
-version = "2.4.0"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Release v2.5.0

Minor release bundling the work merged since v2.4.0 (PRs #76–#79). Backward-compatible — new features + internal changes + fixes, no breaking API changes.

Bumps `pyproject.toml` 2.4.0 → 2.5.0, promotes `CHANGELOG [Unreleased]` to `[2.5.0]`, and refreshes `uv.lock`.

### Highlights
- **Added**: Playwright visual-contrast regression tests (`tests/visual`, `visual-tests` CI job).
- **Changed**: dark-theme card borders visible again via a dedicated `--color-line` token defined in the daisyUI theme blocks (tracks prefers-dark + nested themes); admin pages aligned to v2 (sticky filter, owner badges, bulk delete/retry/export, reset-password modal); upload result toasts moved to a server-side session flash.
- **Fixed**: bulk-select store initializes on hx-boosted nav + search re-applies after list swaps; `volume-init` sidecar re-owns `app-data`/`model-cache` to uid 1000 (fixes upgrade-path permission noise).

See CHANGELOG.md for the full list.

After merge: tag `v2.5.0` → `docker-publish` builds and pushes the frontend / worker / worker-cpu images (`:2.5.0`, `:2.5`, `:latest`) to GHCR.