### PR TITLE
feat: AMD GPU (ROCm) support via whisper.cpp transcription backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,25 @@ DEVICE=cuda
 # BATCH_SIZE: use 4 as default, reduce to 2 for 8GB VRAM GPUs, increase to 8+ for 16GB+ VRAM
 BATCH_SIZE=4
 
+# Transcription backend
+# TRANSCRIBE_BACKEND: "whisperx" (faster-whisper / CTranslate2, CUDA + CPU;
+# default) or "whispercpp" (whisper.cpp HIP CLI). The rocm compose profile
+# sets this to whispercpp automatically because CTranslate2 has no ROCm backend.
+# TRANSCRIBE_BACKEND=whisperx
+# WHISPERCPP_THREADS: CPU threads for whisper.cpp (0 = its own default).
+# WHISPERCPP_THREADS=0
+
+# AMD GPU / ROCm (docker compose --profile rocm)
+# The rocm worker forces DEVICE=rocm + TRANSCRIBE_BACKEND=whispercpp itself.
+# AMDGPU_TARGETS: GPU arch whisper.cpp is compiled for (gfx1151 = Strix Halo).
+# AMDGPU_TARGETS=gfx1151
+# VIDEO_GID / RENDER_GID: host group IDs for /dev/dri passthrough. Find them
+# with `getent group video render`. Defaults (44 / 993) suit a Strix Halo box.
+# VIDEO_GID=44
+# RENDER_GID=993
+# WORKER_ROCM_QUEUES: queues the rocm worker listens on.
+# WORKER_ROCM_QUEUES=whisper:gpu whisper:io whisper:cpu default
+
 # Language
 LANGUAGE=zh
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,6 +98,18 @@ jobs:
           push: false
           cache-from: type=gha,scope=${{ matrix.dockerfile }}
           cache-to: type=gha,mode=max,scope=${{ matrix.dockerfile }}
+  # The ROCm worker image (~38 GB ROCm-complete base) is too large to fully
+  # build on a stock PR runner, so instead of build-push-action we run
+  # BuildKit's --check (Dockerfile lint / best-practice + base metadata only,
+  # a few seconds) to catch regressions cheaply. The real build runs in Docker
+  # Publish on release tags.
+  rocm-dockerfile-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - name: Dockerfile check (no build)
+        run: docker buildx build --check --file docker/Dockerfile.worker.rocm .
   # Browser-rendered theme/contrast checks (tests/visual). Single Python slot —
   # rendering is interpreter-independent. Needs the compiled stylesheet (built
   # here, since style.css is gitignored) and a headless Chromium.

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -51,3 +51,50 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:buildcache,mode=max
+  # The ROCm worker image is ~38 GB (ROCm-complete base + torch-ROCm +
+  # compiled whisper.cpp), so it is published only on release tags — not on
+  # every main push like the others — and the runner frees disk before the
+  # build. Until a release exists, `docker compose --profile rocm` falls back
+  # to a local build.
+  build-and-push-rocm:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Free disk space for the large ROCm build
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune -af || true
+          df -h /
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/whisper-ui-worker-rocm
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile.worker.rocm
+          push: true
+          build-args: |
+            AMDGPU_TARGETS=gfx1151
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/whisper-ui-worker-rocm:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/whisper-ui-worker-rocm:buildcache,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- AMD GPU (ROCm) support via a new `rocm` compose profile and
+  `docker/Dockerfile.worker.rocm`. Transcription runs on the whisper.cpp HIP
+  backend — CTranslate2 (whisperx / faster-whisper) has no ROCm backend —
+  selected by a new `TRANSCRIBE_BACKEND=whispercpp` setting, while alignment
+  and speaker diarization run on PyTorch-ROCm. A `rocm` device label maps to
+  torch's `cuda` namespace, and the worker disables the MIOpen backend on
+  gfx1151 (native HIP kernels) to avoid a `miopenStatusUnknownError` in
+  pyannote. Tested on a Radeon 8060S (Strix Halo, gfx1151), ROCm 7.2.
 - `ALLOW_REGISTRATION` setting (default `true`): when `false`, self-service
   `/register` is closed after the bootstrap admin exists so only an admin can
   create accounts.

--- a/README.md
+++ b/README.md
@@ -111,12 +111,16 @@ Open <http://localhost:8080> in your browser.
 Pre-built Docker images are published to GHCR on each release.
 `docker compose up` pulls them automatically; if unavailable, it falls back to a local build.
 
-| Image                                     | Description           |
-| ----------------------------------------- | --------------------- |
-| `ghcr.io/fdff87554/whisper-ui-frontend`   | FastAPI web interface |
-| `ghcr.io/fdff87554/whisper-ui-worker`      | GPU worker (CUDA)      |
-| `ghcr.io/fdff87554/whisper-ui-worker-cpu`  | CPU worker             |
-| `ghcr.io/fdff87554/whisper-ui-worker-rocm` | AMD GPU worker (ROCm)  |
+| Image                                      | Description           |
+| ------------------------------------------ | --------------------- |
+| `ghcr.io/fdff87554/whisper-ui-frontend`    | FastAPI web interface |
+| `ghcr.io/fdff87554/whisper-ui-worker`      | GPU worker (CUDA)     |
+| `ghcr.io/fdff87554/whisper-ui-worker-cpu`  | CPU worker            |
+| `ghcr.io/fdff87554/whisper-ui-worker-rocm` | AMD GPU worker (ROCm) |
+
+> The ROCm worker image (~38 GB) is published only on **release tags**, not on
+> every `main` push. Until a release exists, `docker compose --profile rocm up`
+> falls back to building it locally.
 
 **Pin a specific version** by setting `WHISPER_UI_VERSION` in your `.env` file:
 
@@ -134,17 +138,17 @@ docker compose --profile gpu build
 
 All settings are configured via environment variables (`.env` file):
 
-| Variable             | Default                             | Description                                                       |
-| -------------------- | ----------------------------------- | ----------------------------------------------------------------- |
-| `WHISPER_MODEL`      | `large-v3`                          | Whisper model variant (see model list below)                      |
-| `COMPUTE_TYPE`       | `int8_float16` (GPU) / `int8` (CPU) | CTranslate2 compute type                                          |
-| `DEVICE`             | `auto`                              | Inference device; compose profiles set `cuda` (GPU) / `rocm` (AMD) / `cpu` (CPU) |
+| Variable             | Default                             | Description                                                                                   |
+| -------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------- |
+| `WHISPER_MODEL`      | `large-v3`                          | Whisper model variant (see model list below)                                                  |
+| `COMPUTE_TYPE`       | `int8_float16` (GPU) / `int8` (CPU) | CTranslate2 compute type                                                                      |
+| `DEVICE`             | `auto`                              | Inference device; compose profiles set `cuda` (GPU) / `rocm` (AMD) / `cpu` (CPU)              |
 | `TRANSCRIBE_BACKEND` | `whisperx`                          | `whisperx` (CTranslate2, CUDA/CPU) or `whispercpp` (whisper.cpp HIP; set by the rocm profile) |
-| `BATCH_SIZE`         | `4`                                 | Transcription batch size (whisperx backend only)                  |
-| `LANGUAGE`           | `zh`                                | Default language code                                             |
-| `HF_TOKEN`           | (empty)                             | HuggingFace token for speaker diarization                         |
-| `PIP_INDEX_URL`      | (empty)                             | Custom PyPI mirror for Docker builds                              |
-| `WHISPER_UI_VERSION` | `latest`                            | Docker image version tag to pull                                  |
+| `BATCH_SIZE`         | `4`                                 | Transcription batch size (whisperx backend only)                                              |
+| `LANGUAGE`           | `zh`                                | Default language code                                                                         |
+| `HF_TOKEN`           | (empty)                             | HuggingFace token for speaker diarization                                                     |
+| `PIP_INDEX_URL`      | (empty)                             | Custom PyPI mirror for Docker builds                                                          |
+| `WHISPER_UI_VERSION` | `latest`                            | Docker image version tag to pull                                                              |
 
 **Whisper models:** `tiny`, `tiny.en`, `base`, `base.en`, `small`, `small.en`, `medium`, `medium.en`, `large-v1`, `large-v2`, `large-v3`, `large-v3-turbo`
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ and Docker deployment (GPU / CPU).
 - NVIDIA GPU with 8GB+ VRAM
 - [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
 
+**For AMD GPU deployment (ROCm):**
+
+- AMD GPU with ROCm support (tested on Radeon 8060S / gfx1151, ROCm 7.2)
+- ROCm on the host: the worker image bundles the ROCm 7.2 runtime, but the
+  host must provide the `amdgpu` kernel driver and expose `/dev/kfd` + `/dev/dri`
+
 **Optional (for speaker diarization):**
 
 - HuggingFace token ([get one here](https://huggingface.co/settings/tokens))
@@ -70,6 +76,28 @@ cp .env.example .env
 docker compose --profile cpu up -d
 ```
 
+### AMD GPU Deployment (ROCm)
+
+Transcription runs on whisper.cpp (HIP); alignment and speaker diarization run
+on PyTorch-ROCm. CTranslate2 / faster-whisper has no ROCm backend, so the
+`whisperx` transcription path cannot drive an AMD GPU — the `rocm` profile uses
+whisper.cpp instead and selects it automatically (`TRANSCRIBE_BACKEND=whispercpp`).
+
+```bash
+cp .env.example .env
+# Set HF_TOKEN if you need speaker diarization.
+# Match the device-passthrough groups to your host: getent group video render
+#   VIDEO_GID / RENDER_GID  (defaults 44 / 993 suit a Strix Halo box)
+# For a non-gfx1151 GPU, build whisper.cpp for it: AMDGPU_TARGETS=gfx1100
+
+docker compose --profile rocm up -d
+```
+
+The first run compiles whisper.cpp for the target GPU arch and downloads the
+GGML model (`ggml-large-v3.bin`), so allow extra time. On gfx1151 the worker
+disables the MIOpen backend (falls back to native HIP kernels) to avoid a known
+`miopenStatusUnknownError` in pyannote's segmentation model.
+
 Open <http://localhost:8080> in your browser.
 
 > **Production note:** the bundled Redis starts without authentication
@@ -86,8 +114,9 @@ Pre-built Docker images are published to GHCR on each release.
 | Image                                     | Description           |
 | ----------------------------------------- | --------------------- |
 | `ghcr.io/fdff87554/whisper-ui-frontend`   | FastAPI web interface |
-| `ghcr.io/fdff87554/whisper-ui-worker`     | GPU worker (CUDA)     |
-| `ghcr.io/fdff87554/whisper-ui-worker-cpu` | CPU worker            |
+| `ghcr.io/fdff87554/whisper-ui-worker`      | GPU worker (CUDA)      |
+| `ghcr.io/fdff87554/whisper-ui-worker-cpu`  | CPU worker             |
+| `ghcr.io/fdff87554/whisper-ui-worker-rocm` | AMD GPU worker (ROCm)  |
 
 **Pin a specific version** by setting `WHISPER_UI_VERSION` in your `.env` file:
 
@@ -109,8 +138,9 @@ All settings are configured via environment variables (`.env` file):
 | -------------------- | ----------------------------------- | ----------------------------------------------------------------- |
 | `WHISPER_MODEL`      | `large-v3`                          | Whisper model variant (see model list below)                      |
 | `COMPUTE_TYPE`       | `int8_float16` (GPU) / `int8` (CPU) | CTranslate2 compute type                                          |
-| `DEVICE`             | `auto`                              | Inference device; compose profiles set `cuda` (GPU) / `cpu` (CPU) |
-| `BATCH_SIZE`         | `4`                                 | Transcription batch size                                          |
+| `DEVICE`             | `auto`                              | Inference device; compose profiles set `cuda` (GPU) / `rocm` (AMD) / `cpu` (CPU) |
+| `TRANSCRIBE_BACKEND` | `whisperx`                          | `whisperx` (CTranslate2, CUDA/CPU) or `whispercpp` (whisper.cpp HIP; set by the rocm profile) |
+| `BATCH_SIZE`         | `4`                                 | Transcription batch size (whisperx backend only)                  |
 | `LANGUAGE`           | `zh`                                | Default language code                                             |
 | `HF_TOKEN`           | (empty)                             | HuggingFace token for speaker diarization                         |
 | `PIP_INDEX_URL`      | (empty)                             | Custom PyPI mirror for Docker builds                              |

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -31,3 +31,7 @@ services:
     volumes:
       - ./src:/app/src
       - ./data:/app/data
+  worker-rocm:
+    volumes:
+      - ./src:/app/src
+      - ./data:/app/data

--- a/compose.yml
+++ b/compose.yml
@@ -223,6 +223,71 @@ services:
       options:
         max-size: "20m"
         max-file: "5"
+  # AMD / ROCm worker. Transcription runs on whisper.cpp (HIP); alignment and
+  # diarization run on PyTorch-ROCm. Enable with:
+  #   docker compose --profile rocm up -d
+  # AMD GPUs are passed through via /dev/kfd + /dev/dri and the host's
+  # video/render group GIDs — set VIDEO_GID / RENDER_GID to match
+  # `getent group video render` on your host (defaults suit a Strix Halo box).
+  worker-rocm:
+    profiles: [rocm]
+    image: ghcr.io/fdff87554/whisper-ui-worker-rocm:${WHISPER_UI_VERSION:-latest}
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.worker.rocm
+      args:
+        PIP_INDEX_URL: ${PIP_INDEX_URL:-}
+        AMDGPU_TARGETS: ${AMDGPU_TARGETS:-gfx1151}
+    environment:
+      - WORKER_QUEUES=${WORKER_ROCM_QUEUES:-whisper:gpu whisper:io whisper:cpu default}
+      - REDIS_URL=redis://:${REDIS_PASSWORD:-}@redis:6379/0
+      - DATABASE_PATH=/app/data/db/whisper_ui.db
+      - UPLOAD_DIR=/app/data/uploads
+      - OUTPUT_DIR=/app/data/outputs
+      - WHISPER_MODEL=${WHISPER_MODEL:-large-v3}
+      - DEVICE=rocm
+      # CTranslate2 has no ROCm backend; transcribe via whisper.cpp (HIP).
+      - TRANSCRIBE_BACKEND=whispercpp
+      - WHISPERCPP_THREADS=${WHISPERCPP_THREADS:-0}
+      - LANGUAGE=${LANGUAGE:-zh}
+      - HF_TOKEN=${HF_TOKEN:-}
+      - YOUTUBE_MAX_DURATION=${YOUTUBE_MAX_DURATION:-14400}
+      # Queue / job timeouts — see README "Queue / Timeout tuning".
+      - JOB_TIMEOUT_DEFAULT=${JOB_TIMEOUT_DEFAULT:-7200}
+      - JOB_TIMEOUT_FLOOR=${JOB_TIMEOUT_FLOOR:-1800}
+      - JOB_TIMEOUT_AUDIO_MULTIPLIER=${JOB_TIMEOUT_AUDIO_MULTIPLIER:-3.0}
+      - JOB_TIMEOUT_MAX=${JOB_TIMEOUT_MAX:-28800}
+      - STALE_JOB_BUFFER=${STALE_JOB_BUFFER:-1800}
+      - REDIS_PROCESSING_EXPIRY=${REDIS_PROCESSING_EXPIRY:-30600}
+      - DIARIZE_HEARTBEAT_INTERVAL=${DIARIZE_HEARTBEAT_INTERVAL:-30}
+      # Optional LLM text correction (Ollama).
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-}
+      - OLLAMA_MODEL=${OLLAMA_MODEL:-gemma4:e2b}
+      - OLLAMA_KEEP_ALIVE=${OLLAMA_KEEP_ALIVE:-30m}
+      - OLLAMA_REQUEST_TIMEOUT=${OLLAMA_REQUEST_TIMEOUT:-120}
+      - LLM_CHUNK_SIZE=${LLM_CHUNK_SIZE:-8}
+      - LLM_CHUNK_CONTEXT=${LLM_CHUNK_CONTEXT:-2}
+      - LLM_TEMPERATURE=${LLM_TEMPERATURE:-0.1}
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    group_add:
+      - "${VIDEO_GID:-44}"
+      - "${RENDER_GID:-993}"
+    volumes:
+      - app-data:/app/data
+      - model-cache:/cache/huggingface
+    depends_on:
+      redis:
+        condition: service_healthy
+      volume-init:
+        condition: service_completed_successfully
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "5"
   # Optional IO-dedicated worker for multi-worker topologies. Use it when
   # you want the GPU worker(s) to stay focused on whisper:gpu while a
   # lightweight CPU container handles download / preprocess / llm_correction.

--- a/docker/Dockerfile.worker.rocm
+++ b/docker/Dockerfile.worker.rocm
@@ -1,0 +1,92 @@
+# AMD / ROCm worker image.
+#
+# Transcription runs on whisper.cpp's HIP (ggml) backend because CTranslate2
+# (whisperx / faster-whisper) has no ROCm backend. Alignment (wav2vec2) and
+# speaker diarization (pyannote) run on PyTorch-ROCm. Both halves need a real
+# ROCm runtime present, so this image is based on an official ROCm image
+# rather than python-slim (the repo.radeon.com torch wheels are not
+# self-contained — they dlopen libroctx64 / librocblas from /opt/rocm).
+#
+# Stage 1 compiles whisper-cli with -DGGML_HIP=ON for the target gfx arch;
+# stage 2 is the runtime worker. The ROCm base tag and GPU target are build
+# args so the image tracks the host's ROCm version / GPU.
+
+ARG ROCM_BASE_IMAGE=rocm/dev-ubuntu-24.04:7.2.1-complete
+ARG AMDGPU_TARGETS=gfx1151
+ARG WHISPER_CPP_REF=v1.8.0
+
+# --- Stage 1: build whisper.cpp (HIP) ---
+FROM ${ROCM_BASE_IMAGE} AS whispercpp-build
+ARG AMDGPU_TARGETS
+ARG WHISPER_CPP_REF
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git cmake ninja-build ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+RUN git clone --depth 1 --branch "${WHISPER_CPP_REF}" https://github.com/ggml-org/whisper.cpp.git /src/whisper.cpp
+WORKDIR /src/whisper.cpp
+RUN cmake -S . -B build -G Ninja \
+    -DGGML_HIP=ON \
+    -DGPU_TARGETS="${AMDGPU_TARGETS}" \
+    -DAMDGPU_TARGETS="${AMDGPU_TARGETS}" \
+    -DCMAKE_C_COMPILER=/opt/rocm/bin/amdclang \
+    -DCMAKE_CXX_COMPILER=/opt/rocm/bin/amdclang++ \
+    -DCMAKE_PREFIX_PATH=/opt/rocm \
+    -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build -j"$(nproc)"
+# Gather the CLI and every produced shared lib (libwhisper, libggml*, the HIP
+# backend) into one dir, preserving SONAME symlinks, for a clean COPY.
+RUN mkdir -p /artifacts/lib && \
+    cp build/bin/whisper-cli /artifacts/ && \
+    find build -name "*.so*" -exec cp -P {} /artifacts/lib/ \;
+
+# --- Stage 2: runtime worker ---
+FROM ${ROCM_BASE_IMAGE} AS runtime
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ffmpeg nodejs python3 python3-pip python-is-python3 && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY pyproject.toml ./
+COPY src/ ./src/
+COPY docker/entrypoint-worker.sh ./entrypoint-worker.sh
+RUN chmod +x ./entrypoint-worker.sh
+
+ARG PIP_INDEX_URL=
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
+# AMD's manylinux wheel index. torch 2.10.0+rocm7.2.0 matches the cuda
+# worker's torch 2.10.0 and the ROCm 7.2 runtime in the base image; it pins
+# triton==3.6.0+rocm7.2.0 (hosted here, not on PyPI), hence --find-links.
+ARG ROCM_WHEEL_INDEX=https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2
+RUN pip install --no-cache-dir --break-system-packages --find-links "${ROCM_WHEEL_INDEX}/" \
+    "${ROCM_WHEEL_INDEX}/torch-2.10.0%2Brocm7.2.0.lw.gitb6ee5fde-cp312-cp312-linux_x86_64.whl" \
+    "${ROCM_WHEEL_INDEX}/torchaudio-2.10.0%2Brocm7.2.0.git5047768f-cp312-cp312-linux_x86_64.whl" \
+    "${ROCM_WHEEL_INDEX}/triton-3.6.0%2Brocm7.2.0.gitba5c1517-cp312-cp312-linux_x86_64.whl" && \
+    pip install --no-cache-dir --break-system-packages --no-deps "whisperx>=3.8,<3.9" && \
+    pip install --no-cache-dir --break-system-packages ".[worker,worker-llm]"
+
+# whisper.cpp HIP binary + its shared libs from the build stage.
+COPY --from=whispercpp-build /artifacts/whisper-cli /usr/local/bin/whisper-cli
+COPY --from=whispercpp-build /artifacts/lib/ /usr/local/lib/whispercpp/
+RUN echo "/usr/local/lib/whispercpp" > /etc/ld.so.conf.d/whispercpp.conf && ldconfig
+
+RUN useradd --uid 1000 --create-home appuser 2>/dev/null || true \
+    && mkdir -p /app/data/db /app/data/uploads /app/data/outputs /cache/huggingface \
+    && chown -R 1000 /app/data /cache/huggingface
+USER 1000
+
+ENV HF_HOME=/cache/huggingface
+ENV PYTHONUNBUFFERED=1
+# Defaults baked in so the rocm worker uses the whisper.cpp backend even if an
+# operator forgets to set them in compose. compose still overrides them.
+ENV DEVICE=rocm
+ENV TRANSCRIBE_BACKEND=whispercpp
+
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 \
+    CMD python -c "from redis import Redis; import os; r=Redis.from_url(os.environ.get('REDIS_URL','redis://redis:6379/0')); r.ping()" || exit 1
+
+ENTRYPOINT ["./entrypoint-worker.sh"]

--- a/docker/entrypoint-worker.sh
+++ b/docker/entrypoint-worker.sh
@@ -5,8 +5,11 @@ echo "=== Whisper UI Worker ==="
 
 # Log GPU availability (device detection handled in Python)
 if command -v nvidia-smi &>/dev/null && nvidia-smi &>/dev/null; then
-	echo "GPU detected:"
+	echo "NVIDIA GPU detected:"
 	nvidia-smi --query-gpu=name,memory.total --format=csv,noheader
+elif command -v rocm-smi &>/dev/null && rocm-smi &>/dev/null; then
+	echo "AMD GPU detected:"
+	rocm-smi --showproductname 2>/dev/null | grep -Ei "Card Series|GFX Version" || true
 else
 	echo "No GPU detected."
 fi

--- a/src/whisper_ui/core/config.py
+++ b/src/whisper_ui/core/config.py
@@ -147,11 +147,16 @@ class Settings(BaseSettings):
     @field_validator("transcribe_backend")
     @classmethod
     def _validate_transcribe_backend(cls, v: str) -> str:
-        """Reject unknown transcription backends at startup (fail fast)."""
+        """Normalize to lowercase and reject unknown backends (fail fast).
+
+        Returning the lowercased value keeps downstream ``== "whispercpp"``
+        comparisons robust against case in the .env (e.g. ``WHISPERCPP``).
+        """
+        v_lower = v.lower()
         allowed = {"whisperx", "whispercpp"}
-        if v not in allowed:
+        if v_lower not in allowed:
             raise ValueError(f"transcribe_backend must be one of {sorted(allowed)}, got {v!r}")
-        return v
+        return v_lower
 
     @field_validator("ollama_base_url", mode="before")
     @classmethod

--- a/src/whisper_ui/core/config.py
+++ b/src/whisper_ui/core/config.py
@@ -38,6 +38,17 @@ class Settings(BaseSettings):
     device: str = "auto"
     batch_size: int = 4
 
+    # Transcription backend:
+    #   "whisperx"  -> faster-whisper / CTranslate2 (CUDA + CPU; the default).
+    #   "whispercpp" -> whisper.cpp HIP CLI, used by the rocm worker because
+    #                   CTranslate2 has no ROCm backend. align/diarize still
+    #                   run on torch-ROCm regardless of this setting.
+    transcribe_backend: str = "whisperx"
+    # whisper.cpp CLI settings (only consulted when transcribe_backend ==
+    # "whispercpp"). The GGML model is fetched lazily as ggml-<whisper_model>.bin.
+    whispercpp_binary: str = "whisper-cli"
+    whispercpp_threads: int = 0  # 0 -> whisper.cpp's own default
+
     # Language
     language: str = "zh"
 
@@ -132,6 +143,15 @@ class Settings(BaseSettings):
     llm_chunk_size: int = 8
     llm_chunk_context: int = 2
     llm_temperature: float = 0.1
+
+    @field_validator("transcribe_backend")
+    @classmethod
+    def _validate_transcribe_backend(cls, v: str) -> str:
+        """Reject unknown transcription backends at startup (fail fast)."""
+        allowed = {"whisperx", "whispercpp"}
+        if v not in allowed:
+            raise ValueError(f"transcribe_backend must be one of {sorted(allowed)}, got {v!r}")
+        return v
 
     @field_validator("ollama_base_url", mode="before")
     @classmethod

--- a/src/whisper_ui/core/device.py
+++ b/src/whisper_ui/core/device.py
@@ -4,30 +4,42 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-_SUPPORTED_DEVICES = {"cuda", "cpu"}
+_SUPPORTED_DEVICES = {"cuda", "rocm", "cpu"}
 _CPU_INCOMPATIBLE_COMPUTE_TYPES = {"float16", "int8_float16"}
 
 
 def detect_device(preferred: str = "auto") -> str:
     """Detect the best available compute device.
 
-    Priority: user preference > CUDA > CPU.
+    Priority: user preference > CUDA > ROCm > CPU.
+    ``"rocm"`` selects an AMD GPU through PyTorch's HIP build, which still
+    exposes the ``torch.cuda.*`` API. Translate it to the string PyTorch and
+    whisperx actually expect when placing tensors with :func:`torch_device_for`.
     If *preferred* is not ``"auto"``, validate availability and fall back if needed.
     """
     if preferred == "cpu":
         return "cpu"
 
-    cuda_available = _cuda_available()
-
     if preferred == "auto":
-        device = "cuda" if cuda_available else "cpu"
+        if _cuda_available():
+            device = "cuda"
+        elif _rocm_available():
+            device = "rocm"
+        else:
+            device = "cpu"
         logger.info("Auto-detected device: %s", device)
         return device
 
     if preferred == "cuda":
-        if cuda_available:
+        if _cuda_available():
             return "cuda"
         logger.warning("CUDA requested but not available. Falling back to CPU.")
+        return "cpu"
+
+    if preferred == "rocm":
+        if _rocm_available():
+            return "rocm"
+        logger.warning("ROCm requested but not available. Falling back to CPU.")
         return "cpu"
 
     # Unsupported device value
@@ -38,7 +50,10 @@ def detect_device(preferred: str = "auto") -> str:
 def validate_compute_type(device: str, compute_type: str) -> str:
     """Validate compute_type compatibility with the device.
 
-    CPU does not support float16 or int8_float16; downgrade to int8.
+    CPU does not support float16 or int8_float16; downgrade to int8. GPU
+    devices (cuda / rocm) keep the requested type. Note the rocm worker
+    transcribes via whisper.cpp, where ``compute_type`` is unused — it is kept
+    here for API symmetry and the whisperx/CTranslate2 path on cuda.
     """
     if device == "cpu" and compute_type in _CPU_INCOMPATIBLE_COMPUTE_TYPES:
         logger.warning(
@@ -49,8 +64,41 @@ def validate_compute_type(device: str, compute_type: str) -> str:
     return compute_type
 
 
+def torch_device_for(device: str) -> str:
+    """Map a logical device label to the string PyTorch / whisperx expect.
+
+    PyTorch's ROCm build has no ``"rocm"`` device — AMD GPUs are addressed
+    through the ``"cuda"`` namespace (HIP masquerades as CUDA) — so ``"rocm"``
+    maps to ``"cuda"``. Anything other than a GPU label maps to ``"cpu"``.
+    """
+    if device in ("cuda", "rocm"):
+        return "cuda"
+    return "cpu"
+
+
+def configure_torch_for_rocm() -> None:
+    """Disable the MIOpen (cuDNN-equivalent) backend for ROCm workers.
+
+    gfx1151 lacks working MIOpen kernels for some ops the pipeline relies on
+    (e.g. pyannote SincNet's InstanceNorm raises ``miopenStatusUnknownError``).
+    Turning the cuDNN backend off makes PyTorch fall back to native HIP
+    kernels, which run correctly at a small performance cost. Idempotent and a
+    no-op when torch is absent.
+    """
+    try:
+        import torch
+
+        torch.backends.cudnn.enabled = False
+    except ImportError:
+        pass
+
+
 def release_gpu_memory() -> None:
-    """Release GPU memory. Currently supports CUDA only."""
+    """Release cached GPU memory.
+
+    Works for both CUDA and ROCm: PyTorch's HIP build exposes the same
+    ``torch.cuda`` API, so ``torch.cuda.empty_cache()`` frees the AMD GPU too.
+    """
     try:
         import torch
 
@@ -61,9 +109,24 @@ def release_gpu_memory() -> None:
 
 
 def _cuda_available() -> bool:
+    """True only for a real NVIDIA CUDA build.
+
+    A ROCm/HIP build also reports ``torch.cuda.is_available()`` True but sets
+    ``torch.version.hip``; exclude it here so ``rocm`` is detected separately.
+    """
     try:
         import torch
 
-        return torch.cuda.is_available()
+        return torch.cuda.is_available() and getattr(torch.version, "hip", None) is None
+    except ImportError:
+        return False
+
+
+def _rocm_available() -> bool:
+    """True when PyTorch is a ROCm/HIP build exposing a usable GPU."""
+    try:
+        import torch
+
+        return torch.cuda.is_available() and getattr(torch.version, "hip", None) is not None
     except ImportError:
         return False

--- a/src/whisper_ui/pipeline/whispercpp_transcribe.py
+++ b/src/whisper_ui/pipeline/whispercpp_transcribe.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from rq.timeouts import BaseTimeoutException
+
+from whisper_ui.core.exceptions import TranscriptionError
+from whisper_ui.core.languages import DEFAULT_WHISPER_MODEL
+from whisper_ui.core.messages import TRANSCRIBE_DONE, TRANSCRIBE_LOADING, TRANSCRIBE_RUNNING
+
+if TYPE_CHECKING:
+    from whisper_ui.pipeline.base import ProgressCallback
+
+logger = logging.getLogger(__name__)
+
+# whisper.cpp publishes GGML weights on the Hugging Face hub here, named
+# ``ggml-<model>.bin`` (e.g. ggml-large-v3.bin). Downloaded lazily and cached
+# under HF_HOME (the worker mounts that on the model-cache volume).
+_GGML_HF_REPO = "ggerganov/whisper.cpp"
+
+# Local progress band for the CLI run. We cannot stream whisper.cpp progress
+# without parsing stderr, so we report load -> running -> done coarsely; the
+# 0.0-0.1 slice covers model resolution to match the whisperx stage's feel.
+_RUN_PROGRESS_START = 0.1
+
+
+class WhisperCppTranscribeStage:
+    """Transcribe via the whisper.cpp HIP CLI — the AMD/ROCm transcription path.
+
+    CTranslate2 (which faster-whisper / whisperx use) has no ROCm backend, so
+    the whisperx transcription path cannot drive an AMD GPU. whisper.cpp's HIP
+    (ggml) backend runs natively on gfx1151. This stage shells out to the
+    ``whisper-cli`` binary, parses its ``-oj`` JSON, and emits the *same*
+    context keys the whisperx :class:`~whisper_ui.pipeline.transcribe.TranscribeStage`
+    does (``transcription_result`` + ``whisperx_audio``) so the downstream
+    AlignStage and DiarizeStage run unchanged.
+    """
+
+    def __init__(
+        self,
+        model_name: str = DEFAULT_WHISPER_MODEL,
+        *,
+        binary: str = "whisper-cli",
+        model_dir: str | Path | None = None,
+        threads: int = 0,
+        device: str = "rocm",
+    ) -> None:
+        # ``device`` is accepted for interface symmetry with TranscribeStage;
+        # whisper.cpp selects the GPU itself (HIP_VISIBLE_DEVICES env), so it is
+        # not passed to the CLI.
+        self._model_name = model_name
+        self._binary = binary
+        self._model_dir = Path(model_dir) if model_dir else None
+        self._threads = threads
+        self._device = device
+
+    @property
+    def name(self) -> str:
+        return "transcribe"
+
+    def execute(self, context: dict[str, Any], on_progress: ProgressCallback | None = None) -> dict[str, Any]:
+        audio_path = context["audio_path"]
+        language = context.get("language", "zh")
+
+        if on_progress:
+            on_progress(0.0, TRANSCRIBE_LOADING)
+
+        try:
+            model_path = self._resolve_model_path()
+
+            if on_progress:
+                on_progress(_RUN_PROGRESS_START, TRANSCRIBE_RUNNING)
+
+            data = self._run_whisper_cli(model_path, audio_path, language)
+            transcription = self._to_whisperx_result(data)
+
+            # AlignStage consumes ``whisperx_audio`` (the decoded 16 kHz array);
+            # load it the same way the whisperx path does so the contract is
+            # byte-for-byte identical regardless of transcription backend.
+            import whisperx
+
+            context["transcription_result"] = transcription
+            context["whisperx_audio"] = whisperx.load_audio(audio_path)
+
+            if on_progress:
+                on_progress(1.0, TRANSCRIBE_DONE)
+            return context
+
+        except BaseTimeoutException:
+            # Let RQ's death penalty propagate so the task is classified as a
+            # timeout, not a stage-level transcription failure.
+            raise
+        except TranscriptionError:
+            raise
+        except FileNotFoundError as err:
+            raise TranscriptionError(
+                f"whisper.cpp binary '{self._binary}' not found. It must be built into the rocm worker image."
+            ) from err
+        except ImportError as err:
+            raise TranscriptionError("whisperx is not installed (needed to load audio for alignment).") from err
+        except Exception as e:
+            raise TranscriptionError(f"Transcription failed: {e}") from e
+
+    def cleanup(self) -> None:
+        # The CLI subprocess has already exited and released the GPU; there is
+        # no in-process model handle to free.
+        return None
+
+    def _resolve_model_path(self) -> str:
+        """Return a path to the GGML model file, downloading it if needed.
+
+        A pre-baked file under ``model_dir`` wins (offline images); otherwise
+        fetch ``ggml-<model>.bin`` from the Hugging Face hub, cached under
+        HF_HOME so repeat runs do not re-download.
+        """
+        filename = f"ggml-{self._model_name}.bin"
+        if self._model_dir is not None:
+            candidate = self._model_dir / filename
+            if candidate.exists():
+                return str(candidate)
+        from huggingface_hub import hf_hub_download
+
+        return hf_hub_download(repo_id=_GGML_HF_REPO, filename=filename)
+
+    def _run_whisper_cli(self, model_path: str, audio_path: str, language: str) -> dict[str, Any]:
+        """Run whisper-cli with JSON output and return the parsed document."""
+        with tempfile.TemporaryDirectory() as tmp:
+            out_prefix = str(Path(tmp) / "out")
+            cmd = [
+                self._binary,
+                "-m",
+                model_path,
+                "-f",
+                str(audio_path),
+                "-l",
+                language,
+                "-oj",
+                "-of",
+                out_prefix,
+            ]
+            if self._threads and self._threads > 0:
+                cmd += ["-t", str(self._threads)]
+
+            proc = subprocess.run(cmd, capture_output=True, text=True)
+            if proc.returncode != 0:
+                raise TranscriptionError(f"whisper-cli failed (exit {proc.returncode}): {proc.stderr.strip()[:500]}")
+
+            json_path = Path(f"{out_prefix}.json")
+            if not json_path.exists():
+                raise TranscriptionError("whisper-cli produced no JSON output")
+            return json.loads(json_path.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _to_whisperx_result(data: dict[str, Any]) -> dict[str, Any]:
+        """Adapt whisper.cpp ``-oj`` JSON to the whisperx transcription contract.
+
+        whisper.cpp emits ``result.language`` and a ``transcription`` array of
+        segments with millisecond ``offsets`` and ``text``; AlignStage expects
+        ``{"language", "segments": [{"start", "end", "text"}]}`` with seconds.
+        """
+        language = (data.get("result") or {}).get("language") or "unknown"
+        segments: list[dict[str, Any]] = []
+        for seg in data.get("transcription") or []:
+            offsets = seg.get("offsets") or {}
+            segments.append(
+                {
+                    "start": offsets.get("from", 0) / 1000.0,
+                    "end": offsets.get("to", 0) / 1000.0,
+                    "text": (seg.get("text") or "").strip(),
+                }
+            )
+        return {"language": language, "segments": segments}

--- a/src/whisper_ui/pipeline/whispercpp_transcribe.py
+++ b/src/whisper_ui/pipeline/whispercpp_transcribe.py
@@ -81,8 +81,14 @@ class WhisperCppTranscribeStage:
 
             # AlignStage consumes ``whisperx_audio`` (the decoded 16 kHz array);
             # load it the same way the whisperx path does so the contract is
-            # byte-for-byte identical regardless of transcription backend.
-            import whisperx
+            # byte-for-byte identical regardless of transcription backend. The
+            # import is localized so a genuinely missing whisperx is reported
+            # accurately, while unrelated ImportErrors (e.g. huggingface_hub
+            # raised during model resolution above) are not misattributed to it.
+            try:
+                import whisperx
+            except ImportError as err:
+                raise TranscriptionError("whisperx is not installed (needed to load audio for alignment).") from err
 
             context["transcription_result"] = transcription
             context["whisperx_audio"] = whisperx.load_audio(audio_path)
@@ -101,8 +107,6 @@ class WhisperCppTranscribeStage:
             raise TranscriptionError(
                 f"whisper.cpp binary '{self._binary}' not found. It must be built into the rocm worker image."
             ) from err
-        except ImportError as err:
-            raise TranscriptionError("whisperx is not installed (needed to load audio for alignment).") from err
         except Exception as e:
             raise TranscriptionError(f"Transcription failed: {e}") from e
 
@@ -146,9 +150,13 @@ class WhisperCppTranscribeStage:
             if self._threads and self._threads > 0:
                 cmd += ["-t", str(self._threads)]
 
-            proc = subprocess.run(cmd, capture_output=True, text=True)
+            # encoding/errors (not text=True) so non-ASCII output — e.g. zh
+            # transcripts or file names — cannot raise UnicodeDecodeError.
+            proc = subprocess.run(cmd, capture_output=True, encoding="utf-8", errors="replace")
             if proc.returncode != 0:
-                raise TranscriptionError(f"whisper-cli failed (exit {proc.returncode}): {proc.stderr.strip()[:500]}")
+                # Some builds emit diagnostics on stdout; fall back to it.
+                detail = proc.stderr.strip() or proc.stdout.strip()
+                raise TranscriptionError(f"whisper-cli failed (exit {proc.returncode}): {detail[:500]}")
 
             json_path = Path(f"{out_prefix}.json")
             if not json_path.exists():
@@ -163,14 +171,20 @@ class WhisperCppTranscribeStage:
         segments with millisecond ``offsets`` and ``text``; AlignStage expects
         ``{"language", "segments": [{"start", "end", "text"}]}`` with seconds.
         """
-        language = (data.get("result") or {}).get("language") or "unknown"
+        if not isinstance(data, dict):
+            return {"language": "unknown", "segments": []}
+        result = data.get("result")
+        language = (result.get("language") if isinstance(result, dict) else None) or "unknown"
         segments: list[dict[str, Any]] = []
         for seg in data.get("transcription") or []:
-            offsets = seg.get("offsets") or {}
+            if not isinstance(seg, dict):
+                continue
+            offsets = seg.get("offsets") if isinstance(seg.get("offsets"), dict) else {}
+            # ``or 0`` guards an explicit ``null`` offset (None / 1000.0 -> TypeError).
             segments.append(
                 {
-                    "start": offsets.get("from", 0) / 1000.0,
-                    "end": offsets.get("to", 0) / 1000.0,
+                    "start": (offsets.get("from") or 0) / 1000.0,
+                    "end": (offsets.get("to") or 0) / 1000.0,
                     "text": (seg.get("text") or "").strip(),
                 }
             )

--- a/src/whisper_ui/worker/runtime.py
+++ b/src/whisper_ui/worker/runtime.py
@@ -71,6 +71,12 @@ def build_worker_runtime(job_id: str, *, generation: int | None = None) -> Itera
     skips generation gating and falls back to plain max-write semantics.
     """
     settings = get_settings()
+    if settings.device == "rocm":
+        # gfx1151 MIOpen lacks kernels for some ops (pyannote InstanceNorm);
+        # fall back to native HIP kernels for every GPU task in this worker.
+        from whisper_ui.core.device import configure_torch_for_rocm
+
+        configure_torch_for_rocm()
     redis = Redis.from_url(settings.redis_url)
     reporter = RedisProgressReporter(
         redis,

--- a/src/whisper_ui/worker/stage_tasks.py
+++ b/src/whisper_ui/worker/stage_tasks.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 from rq.timeouts import BaseTimeoutException
 
+from whisper_ui.core.device import torch_device_for
 from whisper_ui.core.exceptions import PipelineError
 from whisper_ui.core.models import JobStatus
 from whisper_ui.pipeline.align import AlignStage
@@ -356,12 +357,15 @@ def run_transcribe_align(parent_job_id: str) -> str:
         throttled = make_throttled_progress_reporter(runtime.reporter, runtime.db, job)
         weights = pick_stage_weights(job, runtime)
 
+        # On ROCm the logical device label is "rocm"; PyTorch/whisperx address
+        # the AMD GPU through the "cuda" namespace, so translate before use.
+        torch_device = torch_device_for(runtime.settings.device)
         transcribe = TranscribeStage(
             model_name=job.model_name,
             compute_type=runtime.settings.compute_type,
-            device=runtime.settings.device,
+            device=torch_device,
         )
-        align = AlignStage(device=runtime.settings.device)
+        align = AlignStage(device=torch_device)
 
         transcribe_progress = _banded_progress(throttled, weights.get("transcribe", (0.0, 1.0)))
         align_progress = _banded_progress(throttled, weights.get("align", (0.0, 1.0)))
@@ -395,7 +399,7 @@ def run_diarize(parent_job_id: str) -> str:
         stage_name="diarize",
         build_stage=lambda job, runtime: DiarizeStage(
             hf_token=runtime.settings.hf_token,
-            device=runtime.settings.device,
+            device=torch_device_for(runtime.settings.device),
             enabled=job.enable_diarization,
             heartbeat_interval=runtime.settings.diarize_heartbeat_interval,
         ),

--- a/src/whisper_ui/worker/stage_tasks.py
+++ b/src/whisper_ui/worker/stage_tasks.py
@@ -35,6 +35,7 @@ from whisper_ui.pipeline.progress_bands import (
     build_stage_weights,
 )
 from whisper_ui.pipeline.transcribe import TranscribeStage
+from whisper_ui.pipeline.whispercpp_transcribe import WhisperCppTranscribeStage
 from whisper_ui.worker.context_store import PipelineContextStore
 from whisper_ui.worker.runtime import (
     WorkerRuntime,
@@ -66,6 +67,28 @@ def _load_job(runtime: WorkerRuntime, parent_job_id: str) -> Job:
     if job is None:
         raise PipelineError(f"Job {parent_job_id} not found while running stage task")
     return job
+
+
+def _build_transcribe_stage(job: Job, runtime: WorkerRuntime, torch_device: str) -> PipelineStage:
+    """Select the transcription engine for this worker.
+
+    AMD/ROCm workers set ``transcribe_backend=whispercpp`` because CTranslate2
+    (whisperx / faster-whisper) has no ROCm backend; every other worker keeps
+    the whisperx path. Both backends emit the same ``transcription_result`` /
+    ``whisperx_audio`` context keys, so align/diarize stay backend-agnostic.
+    """
+    if runtime.settings.transcribe_backend == "whispercpp":
+        return WhisperCppTranscribeStage(
+            model_name=job.model_name,
+            binary=runtime.settings.whispercpp_binary,
+            threads=runtime.settings.whispercpp_threads,
+            device=runtime.settings.device,
+        )
+    return TranscribeStage(
+        model_name=job.model_name,
+        compute_type=runtime.settings.compute_type,
+        device=torch_device,
+    )
 
 
 def _mark_processing_if_queued(runtime: WorkerRuntime, job: Job) -> None:
@@ -360,11 +383,7 @@ def run_transcribe_align(parent_job_id: str) -> str:
         # On ROCm the logical device label is "rocm"; PyTorch/whisperx address
         # the AMD GPU through the "cuda" namespace, so translate before use.
         torch_device = torch_device_for(runtime.settings.device)
-        transcribe = TranscribeStage(
-            model_name=job.model_name,
-            compute_type=runtime.settings.compute_type,
-            device=torch_device,
-        )
+        transcribe = _build_transcribe_stage(job, runtime, torch_device)
         align = AlignStage(device=torch_device)
 
         transcribe_progress = _banded_progress(throttled, weights.get("transcribe", (0.0, 1.0)))

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 import logging
 from unittest.mock import MagicMock, patch
 
-from whisper_ui.core.device import detect_device, release_gpu_memory, validate_compute_type
+from whisper_ui.core.device import (
+    _cuda_available,
+    _rocm_available,
+    configure_torch_for_rocm,
+    detect_device,
+    release_gpu_memory,
+    torch_device_for,
+    validate_compute_type,
+)
 
 
 class TestDetectDevice:
@@ -37,6 +45,84 @@ class TestDetectDevice:
             result = detect_device("mps")
         assert result == "cpu"
         assert "Unsupported device" in caplog.text
+
+    def test_auto_with_rocm(self):
+        with (
+            patch("whisper_ui.core.device._cuda_available", return_value=False),
+            patch("whisper_ui.core.device._rocm_available", return_value=True),
+        ):
+            assert detect_device("auto") == "rocm"
+
+    def test_auto_prefers_cuda_over_rocm(self):
+        with (
+            patch("whisper_ui.core.device._cuda_available", return_value=True),
+            patch("whisper_ui.core.device._rocm_available", return_value=True),
+        ):
+            assert detect_device("auto") == "cuda"
+
+    def test_explicit_rocm_available(self):
+        with patch("whisper_ui.core.device._rocm_available", return_value=True):
+            assert detect_device("rocm") == "rocm"
+
+    def test_explicit_rocm_unavailable(self, caplog):
+        with (
+            patch("whisper_ui.core.device._rocm_available", return_value=False),
+            caplog.at_level(logging.WARNING),
+        ):
+            result = detect_device("rocm")
+        assert result == "cpu"
+        assert "ROCm requested but not available" in caplog.text
+
+
+class TestTorchDeviceFor:
+    def test_cuda_maps_to_cuda(self):
+        assert torch_device_for("cuda") == "cuda"
+
+    def test_rocm_maps_to_cuda(self):
+        assert torch_device_for("rocm") == "cuda"
+
+    def test_cpu_maps_to_cpu(self):
+        assert torch_device_for("cpu") == "cpu"
+
+    def test_unknown_maps_to_cpu(self):
+        assert torch_device_for("mps") == "cpu"
+
+
+class TestConfigureTorchForRocm:
+    def test_disables_cudnn_backend(self):
+        mock_torch = MagicMock()
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            configure_torch_for_rocm()
+        assert mock_torch.backends.cudnn.enabled is False
+
+    def test_no_torch(self):
+        with patch.dict("sys.modules", {"torch": None}):
+            # Should not raise when torch is unavailable.
+            configure_torch_for_rocm()
+
+
+class TestAvailabilityProbes:
+    @staticmethod
+    def _torch(*, available: bool, hip: str | None) -> MagicMock:
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = available
+        mock_torch.version.hip = hip
+        return mock_torch
+
+    def test_real_cuda_is_cuda_not_rocm(self):
+        with patch.dict("sys.modules", {"torch": self._torch(available=True, hip=None)}):
+            assert _cuda_available() is True
+            assert _rocm_available() is False
+
+    def test_hip_build_is_rocm_not_cuda(self):
+        with patch.dict("sys.modules", {"torch": self._torch(available=True, hip="7.2.0")}):
+            assert _cuda_available() is False
+            assert _rocm_available() is True
+
+    def test_neither_when_gpu_unavailable(self):
+        with patch.dict("sys.modules", {"torch": self._torch(available=False, hip=None)}):
+            assert _cuda_available() is False
+            assert _rocm_available() is False
 
 
 class TestValidateComputeType:

--- a/tests/unit/test_whispercpp_transcribe.py
+++ b/tests/unit/test_whispercpp_transcribe.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from whisper_ui.core.exceptions import TranscriptionError
+from whisper_ui.pipeline.transcribe import TranscribeStage
+from whisper_ui.pipeline.whispercpp_transcribe import WhisperCppTranscribeStage
+from whisper_ui.worker.stage_tasks import _build_transcribe_stage
+
+_MODULE = "whisper_ui.pipeline.whispercpp_transcribe"
+
+
+def _fake_cli_writer(payload: dict):
+    """Return a subprocess.run stand-in that writes ``payload`` to <-of>.json."""
+
+    def _run(cmd, capture_output, text):
+        out_prefix = cmd[cmd.index("-of") + 1]
+        Path(f"{out_prefix}.json").write_text(json.dumps(payload), encoding="utf-8")
+        return MagicMock(returncode=0, stderr="")
+
+    return _run
+
+
+class TestAdapter:
+    def test_converts_ms_to_seconds_and_strips_text(self):
+        data = {
+            "result": {"language": "zh"},
+            "transcription": [{"offsets": {"from": 1200, "to": 2500}, "text": "  hi  "}],
+        }
+        assert WhisperCppTranscribeStage._to_whisperx_result(data) == {
+            "language": "zh",
+            "segments": [{"start": 1.2, "end": 2.5, "text": "hi"}],
+        }
+
+    def test_handles_missing_fields(self):
+        assert WhisperCppTranscribeStage._to_whisperx_result({}) == {"language": "unknown", "segments": []}
+
+
+class TestExecute:
+    def test_parses_json_and_sets_context_keys(self):
+        stage = WhisperCppTranscribeStage(model_name="large-v3")
+        payload = {
+            "result": {"language": "en"},
+            "transcription": [
+                {"offsets": {"from": 0, "to": 3000}, "text": " Hello world"},
+                {"offsets": {"from": 3000, "to": 6000}, "text": "second"},
+            ],
+        }
+        mock_whisperx = MagicMock()
+        mock_whisperx.load_audio.return_value = "AUDIO_ARRAY"
+        with (
+            patch.object(WhisperCppTranscribeStage, "_resolve_model_path", return_value="/m/ggml-large-v3.bin"),
+            patch(f"{_MODULE}.subprocess.run", side_effect=_fake_cli_writer(payload)),
+            patch.dict("sys.modules", {"whisperx": mock_whisperx}),
+        ):
+            ctx = stage.execute({"audio_path": "/tmp/a.16k.wav", "language": "en"})
+
+        assert ctx["transcription_result"]["language"] == "en"
+        assert ctx["transcription_result"]["segments"] == [
+            {"start": 0.0, "end": 3.0, "text": "Hello world"},
+            {"start": 3.0, "end": 6.0, "text": "second"},
+        ]
+        assert ctx["whisperx_audio"] == "AUDIO_ARRAY"
+
+    def test_progress_callback_brackets_run(self):
+        stage = WhisperCppTranscribeStage()
+        payload = {"result": {"language": "en"}, "transcription": []}
+        progress: list[tuple[float, str]] = []
+        mock_whisperx = MagicMock()
+        with (
+            patch.object(WhisperCppTranscribeStage, "_resolve_model_path", return_value="/m.bin"),
+            patch(f"{_MODULE}.subprocess.run", side_effect=_fake_cli_writer(payload)),
+            patch.dict("sys.modules", {"whisperx": mock_whisperx}),
+        ):
+            stage.execute({"audio_path": "/tmp/a.wav"}, on_progress=lambda p, m: progress.append((p, m)))
+
+        assert progress[0][0] == 0.0
+        assert progress[-1][0] == 1.0
+
+    def test_nonzero_exit_raises(self):
+        stage = WhisperCppTranscribeStage()
+        with (
+            patch.object(WhisperCppTranscribeStage, "_resolve_model_path", return_value="/m.bin"),
+            patch(f"{_MODULE}.subprocess.run", return_value=MagicMock(returncode=2, stderr="boom")),
+            pytest.raises(TranscriptionError, match="exit 2"),
+        ):
+            stage.execute({"audio_path": "/tmp/a.wav"})
+
+    def test_missing_json_raises(self):
+        stage = WhisperCppTranscribeStage()
+        with (
+            patch.object(WhisperCppTranscribeStage, "_resolve_model_path", return_value="/m.bin"),
+            patch(f"{_MODULE}.subprocess.run", return_value=MagicMock(returncode=0, stderr="")),
+            pytest.raises(TranscriptionError, match="no JSON"),
+        ):
+            stage.execute({"audio_path": "/tmp/a.wav"})
+
+    def test_binary_not_found_raises(self):
+        stage = WhisperCppTranscribeStage(binary="whisper-cli")
+        with (
+            patch.object(WhisperCppTranscribeStage, "_resolve_model_path", return_value="/m.bin"),
+            patch(f"{_MODULE}.subprocess.run", side_effect=FileNotFoundError()),
+            pytest.raises(TranscriptionError, match="whisper-cli"),
+        ):
+            stage.execute({"audio_path": "/tmp/a.wav"})
+
+
+class TestModelResolution:
+    def test_prefers_existing_local_model(self, tmp_path):
+        model = tmp_path / "ggml-large-v3.bin"
+        model.write_bytes(b"x")
+        stage = WhisperCppTranscribeStage(model_name="large-v3", model_dir=tmp_path)
+        assert stage._resolve_model_path() == str(model)
+
+    def test_downloads_when_absent(self, tmp_path):
+        stage = WhisperCppTranscribeStage(model_name="large-v3", model_dir=tmp_path)
+        mock_hf = MagicMock()
+        mock_hf.hf_hub_download.return_value = "/cache/ggml-large-v3.bin"
+        with patch.dict("sys.modules", {"huggingface_hub": mock_hf}):
+            assert stage._resolve_model_path() == "/cache/ggml-large-v3.bin"
+        mock_hf.hf_hub_download.assert_called_once_with(repo_id="ggerganov/whisper.cpp", filename="ggml-large-v3.bin")
+
+
+class TestBackendSelection:
+    @staticmethod
+    def _runtime(backend: str) -> MagicMock:
+        runtime = MagicMock()
+        runtime.settings.transcribe_backend = backend
+        runtime.settings.whispercpp_binary = "whisper-cli"
+        runtime.settings.whispercpp_threads = 0
+        runtime.settings.compute_type = "int8_float16"
+        runtime.settings.device = "rocm"
+        return runtime
+
+    def test_selects_whispercpp_backend(self):
+        job = MagicMock()
+        job.model_name = "large-v3"
+        stage = _build_transcribe_stage(job, self._runtime("whispercpp"), "cuda")
+        assert isinstance(stage, WhisperCppTranscribeStage)
+
+    def test_defaults_to_whisperx_backend(self):
+        job = MagicMock()
+        job.model_name = "large-v3"
+        stage = _build_transcribe_stage(job, self._runtime("whisperx"), "cuda")
+        assert isinstance(stage, TranscribeStage)

--- a/tests/unit/test_whispercpp_transcribe.py
+++ b/tests/unit/test_whispercpp_transcribe.py
@@ -5,7 +5,9 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
+from whisper_ui.core.config import Settings
 from whisper_ui.core.exceptions import TranscriptionError
 from whisper_ui.pipeline.transcribe import TranscribeStage
 from whisper_ui.pipeline.whispercpp_transcribe import WhisperCppTranscribeStage
@@ -17,10 +19,10 @@ _MODULE = "whisper_ui.pipeline.whispercpp_transcribe"
 def _fake_cli_writer(payload: dict):
     """Return a subprocess.run stand-in that writes ``payload`` to <-of>.json."""
 
-    def _run(cmd, capture_output, text):
+    def _run(cmd, *args, **kwargs):  # resilient to subprocess.run kwargs (encoding/errors/etc.)
         out_prefix = cmd[cmd.index("-of") + 1]
         Path(f"{out_prefix}.json").write_text(json.dumps(payload), encoding="utf-8")
-        return MagicMock(returncode=0, stderr="")
+        return MagicMock(returncode=0, stderr="", stdout="")
 
     return _run
 
@@ -38,6 +40,15 @@ class TestAdapter:
 
     def test_handles_missing_fields(self):
         assert WhisperCppTranscribeStage._to_whisperx_result({}) == {"language": "unknown", "segments": []}
+
+    def test_null_offsets_do_not_crash(self):
+        # An explicit JSON null offset must not raise (None / 1000.0 -> TypeError).
+        data = {"transcription": [{"offsets": {"from": None, "to": None}, "text": "x"}]}
+        out = WhisperCppTranscribeStage._to_whisperx_result(data)
+        assert out == {"language": "unknown", "segments": [{"start": 0.0, "end": 0.0, "text": "x"}]}
+
+    def test_non_dict_payload_is_safe(self):
+        assert WhisperCppTranscribeStage._to_whisperx_result([1, 2, 3]) == {"language": "unknown", "segments": []}
 
 
 class TestExecute:
@@ -147,3 +158,13 @@ class TestBackendSelection:
         job.model_name = "large-v3"
         stage = _build_transcribe_stage(job, self._runtime("whisperx"), "cuda")
         assert isinstance(stage, TranscribeStage)
+
+
+class TestTranscribeBackendConfig:
+    # _env_file=None isolates the validator test from a developer's local .env.
+    def test_normalizes_case(self):
+        assert Settings(transcribe_backend="WhisperCPP", _env_file=None).transcribe_backend == "whispercpp"
+
+    def test_rejects_unknown_backend(self):
+        with pytest.raises(ValidationError):
+            Settings(transcribe_backend="bogus", _env_file=None)


### PR DESCRIPTION
## Summary

Adds **AMD GPU (ROCm) support** so the worker can run on AMD hardware (developed and validated on a Radeon 8060S / Strix Halo, gfx1151, ROCm 7.2). Transcription runs on the **whisper.cpp HIP** backend because CTranslate2 (whisperx / faster-whisper) has no ROCm backend; alignment (wav2vec2) and speaker diarization (pyannote) run on PyTorch-ROCm. Existing `cuda` / `cpu` profiles are unchanged.

## Commits (atomic)

1. **`feat: recognise rocm device and map to torch cuda backend`** — `core/device.py` adds a `rocm` device (detected via `torch.version.hip`), `torch_device_for()` (rocm→cuda, since PyTorch-ROCm addresses the GPU through the cuda namespace), and `configure_torch_for_rocm()` (disables MIOpen → native HIP kernels, applied per task in `build_worker_runtime`). `stage_tasks` maps the align/diarize device accordingly. + tests.
2. **`feat: add whisper.cpp transcription backend`** — a `TRANSCRIBE_BACKEND` setting plus `WhisperCppTranscribeStage`, which shells out to `whisper-cli`, parses its `-oj` JSON, and emits the same `transcription_result` / `whisperx_audio` context keys the whisperx stage does, so align/diarize are unchanged. The GGML model is fetched lazily from the Hugging Face hub. + tests.
3. **`build: add rocm worker image and compose profile`** — multi-stage `docker/Dockerfile.worker.rocm` (builds whisper.cpp with `-DGGML_HIP=ON` then runs it alongside PyTorch-ROCm `torch 2.10.0+rocm7.2.0` on a ROCm 7.2 base), a `worker-rocm` compose profile (`/dev/kfd` + `/dev/dri` passthrough, video/render `group_add`, `DEVICE=rocm` + `TRANSCRIBE_BACKEND=whispercpp`), entrypoint AMD-GPU detection, and `.env.example` entries.
4. **`docs: document AMD/ROCm whisper.cpp support`** — README deployment section + CHANGELOG.

## Why whisper.cpp (not torch-native or a CT2 fork)

On-box PoC measured `large-v3` real-time factors: **whisper.cpp HIP ~0.13**, torch-native HF transformers ~0.34, CPU CT2 int8 ~0.48. The CTranslate2-rocm fork builds for gfx1151 but cannot run Whisper (`Conv1D on GPU requires cuDNN`, no MIOpen integration), so it was ruled out.

## Verification

- **Unit tests: 787 passed** (`pytest`); `ruff check` + `ruff format` clean.
- `docker compose --profile rocm config` valid; `Dockerfile --check` clean; base image tag confirmed.
- **rocm worker image builds successfully** — whisper.cpp HIP compiled in-image (`whisper-cli` + `libggml-hip.so`). In-container GPU smoke test: `whisper-cli` runs, `torch 2.10.0+rocm7.2.0` sees "Radeon 8060S Graphics", GPU matmul works, package imports, and the backend selector picks `WhisperCppTranscribeStage`.
- **End-to-end** (transcribe→align→diarize on a real 2-speaker clip, in the built image on the GPU): **in progress at the time this PR was opened** — will be updated with the transcript + speaker results. The individual stages were each proven on this GPU during the PoC (whisper.cpp transcription, pyannote diarization with MIOpen disabled).

## Caveats / notes

- `VIDEO_GID` / `RENDER_GID` default to `44` / `993` (this host); other hosts set them from `getent group video render`.
- The rocm worker sets `torch.backends.cudnn.enabled = False` on gfx1151 to avoid a `miopenStatusUnknownError` in pyannote's SincNet (`InstanceNorm`); native HIP kernels are used at a small perf cost.
- Two pre-existing `test_pipeline_dag_parallelism` failures seen in the dev venv are an RQ-2.9.0 + fakeredis `KeyError: 'addr'` quirk that reproduces on `main` (unrelated to this PR; the project's `uv.lock` pins a working RQ).
- This PR is larger than the 400-line guideline (kept as a single PR per request); it is split into 4 atomic commits for review.
