### PR TITLE
chore: release v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-06-01
+
 ### Fixed
 
 - Batch task groups no longer auto-collapse (or refuse to collapse) while the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.5.0"
+version = "2.6.0"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3895,7 +3895,7 @@ wheels = [
 
 [[package]]
 name = "whisper-ui"
-version = "2.5.0"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Release v2.6.0

Cuts the v2.6.0 release: bumps the version (`pyproject.toml` + `uv.lock`) and
stamps the `[2.6.0]` CHANGELOG section from `[Unreleased]`.

Headline of this release: **AMD GPU (ROCm) support** — a `rocm` compose
profile with a whisper.cpp (HIP) transcription backend, alongside the
accumulated fixes/additions already under `[Unreleased]`.

Merging this PR and pushing the `v2.6.0` tag triggers Docker Publish,
including the new release-tag-only `build-and-push-rocm` job.
