### PR TITLE
chore: default LLM correction model to gemma4:e4b

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,7 +92,7 @@ HF_TOKEN=
 #        OLLAMA_BASE_URL=http://192.168.1.20:11434
 #      You're responsible for having the model pulled on that server.
 # OLLAMA_BASE_URL=
-# OLLAMA_MODEL=gemma4:e2b
+# OLLAMA_MODEL=gemma4:e4b
 # OLLAMA_KEEP_ALIVE=30m
 # OLLAMA_REQUEST_TIMEOUT=120
 # LLM_CHUNK_SIZE=8

--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,8 @@ HF_TOKEN=
 #        OLLAMA_BASE_URL=http://192.168.1.20:11434
 #      You're responsible for having the model pulled on that server.
 # OLLAMA_BASE_URL=
+# gemma4:e4b (~9.6 GB) wants a 10 GB+ GPU; on 8 GB / shared GPUs use
+# gemma4:e2b (~7.2 GB) or an external Ollama server.
 # OLLAMA_MODEL=gemma4:e4b
 # OLLAMA_KEEP_ALIVE=30m
 # OLLAMA_REQUEST_TIMEOUT=120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- Default LLM correction model (`OLLAMA_MODEL`) is now `gemma4:e4b` instead of
+  `gemma4:e2b`, trading a larger VRAM/disk footprint (~9.6 GB pull) for better
+  correction accuracy. Set `OLLAMA_MODEL=gemma4:e2b` to keep the previous
+  default.
+
 ## [2.6.0] - 2026-06-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and Docker deployment (GPU / CPU).
 - Upload audio/video files for transcription
 - Batch upload with automatic filtering of unsupported files
 - Speaker diarization with pyannote speaker-diarization-3.1 (optional)
-- Optional LLM text correction via Ollama (small Gemma model, per-job toggle)
+- Optional LLM text correction via Ollama (a Gemma model, per-job toggle)
 - Real-time progress tracking via Redis
 - Export to SRT, VTT, TXT, JSON, DOCX
 - Batch download of results as ZIP
@@ -362,12 +362,17 @@ Override either variable in `.env` if your topology differs.
 >   held by another container), set `WORKER_GPU_DEVICE_ID` in your `.env`
 >   to restore the intended placement.
 
+**Model size vs VRAM:** the default `gemma4:e4b` is ~9.6 GB and wants a 10 GB+
+GPU to stay resident. On an 8 GB or shared GPU (e.g. running Whisper on the same
+card), use `gemma4:e2b` (~7.2 GB), point `OLLAMA_BASE_URL` at an external Ollama
+server, or split Whisper and Ollama onto separate GPUs as above.
+
 **Tuning (all optional):**
 
 | Variable                 | Default      | Description                                                                            |
 | ------------------------ | ------------ | -------------------------------------------------------------------------------------- |
 | `OLLAMA_BASE_URL`        | (empty)      | Empty disables the feature globally. Set to reach a bundled or external Ollama server. |
-| `OLLAMA_MODEL`           | `gemma4:e4b` | Any Ollama-compatible chat model. Larger = better accuracy but more VRAM.              |
+| `OLLAMA_MODEL`           | `gemma4:e4b` | Any Ollama-compatible chat model. Bigger = better accuracy, more VRAM (see note).      |
 | `OLLAMA_KEEP_ALIVE`      | `30m`        | How long Ollama keeps the model loaded in VRAM between requests.                       |
 | `OLLAMA_REQUEST_TIMEOUT` | `120`        | Per-request timeout in seconds.                                                        |
 | `LLM_CHUNK_SIZE`         | `8`          | Segments corrected per Ollama request. Larger reduces HTTP overhead.                   |

--- a/README.md
+++ b/README.md
@@ -321,13 +321,13 @@ timestamps / speaker labels. The feature is:
 ```bash
 # .env
 OLLAMA_BASE_URL=http://ollama:11434
-OLLAMA_MODEL=gemma4:e2b
+OLLAMA_MODEL=gemma4:e4b
 
 docker compose --profile gpu --profile llm up -d
 ```
 
 The `ollama-pull` init sidecar will wait until Ollama is healthy and then
-pull `OLLAMA_MODEL` on first start (~7 GB download for `gemma4:e2b`).
+pull `OLLAMA_MODEL` on first start (~9.6 GB download for `gemma4:e4b`).
 Check its exit status with `docker compose ps ollama-pull`; the model is
 cached in the `ollama-data` volume so restarts are instant.
 
@@ -336,11 +336,11 @@ cached in the `ollama-data` volume so restarts are instant.
 ```bash
 # .env
 OLLAMA_BASE_URL=http://192.168.1.20:11434
-OLLAMA_MODEL=gemma4:e2b
+OLLAMA_MODEL=gemma4:e4b
 
 docker compose --profile gpu up -d
 # Make sure the model is pulled on the external server yourself:
-#   ollama pull gemma4:e2b
+#   ollama pull gemma4:e4b
 ```
 
 **Dual-GPU hosts:** the `gpu` profile pins the Whisper worker to
@@ -367,7 +367,7 @@ Override either variable in `.env` if your topology differs.
 | Variable                 | Default      | Description                                                                            |
 | ------------------------ | ------------ | -------------------------------------------------------------------------------------- |
 | `OLLAMA_BASE_URL`        | (empty)      | Empty disables the feature globally. Set to reach a bundled or external Ollama server. |
-| `OLLAMA_MODEL`           | `gemma4:e2b` | Any Ollama-compatible chat model. Larger = better accuracy but more VRAM.              |
+| `OLLAMA_MODEL`           | `gemma4:e4b` | Any Ollama-compatible chat model. Larger = better accuracy but more VRAM.              |
 | `OLLAMA_KEEP_ALIVE`      | `30m`        | How long Ollama keeps the model loaded in VRAM between requests.                       |
 | `OLLAMA_REQUEST_TIMEOUT` | `120`        | Per-request timeout in seconds.                                                        |
 | `LLM_CHUNK_SIZE`         | `8`          | Segments corrected per Ollama request. Larger reduces HTTP overhead.                   |

--- a/compose.yml
+++ b/compose.yml
@@ -30,7 +30,7 @@ services:
       # Optional LLM text correction (Ollama). Empty string disables the
       # feature globally and greys out the upload-form toggle.
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-}
-      - OLLAMA_MODEL=${OLLAMA_MODEL:-gemma4:e2b}
+      - OLLAMA_MODEL=${OLLAMA_MODEL:-gemma4:e4b}
       # Optional upload retention. 0 (default) keeps every upload until the
       # job is explicitly deleted. >0 has the web app hourly reclaim the
       # upload directory of COMPLETED jobs older than that many days.
@@ -142,7 +142,7 @@ services:
       - DIARIZE_HEARTBEAT_INTERVAL=${DIARIZE_HEARTBEAT_INTERVAL:-30}
       # Optional LLM text correction (Ollama).
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-}
-      - OLLAMA_MODEL=${OLLAMA_MODEL:-gemma4:e2b}
+      - OLLAMA_MODEL=${OLLAMA_MODEL:-gemma4:e4b}
       - OLLAMA_KEEP_ALIVE=${OLLAMA_KEEP_ALIVE:-30m}
       - OLLAMA_REQUEST_TIMEOUT=${OLLAMA_REQUEST_TIMEOUT:-120}
       - LLM_CHUNK_SIZE=${LLM_CHUNK_SIZE:-8}
@@ -203,7 +203,7 @@ services:
       - DIARIZE_HEARTBEAT_INTERVAL=${DIARIZE_HEARTBEAT_INTERVAL:-30}
       # Optional LLM text correction (Ollama).
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-}
-      - OLLAMA_MODEL=${OLLAMA_MODEL:-gemma4:e2b}
+      - OLLAMA_MODEL=${OLLAMA_MODEL:-gemma4:e4b}
       - OLLAMA_KEEP_ALIVE=${OLLAMA_KEEP_ALIVE:-30m}
       - OLLAMA_REQUEST_TIMEOUT=${OLLAMA_REQUEST_TIMEOUT:-120}
       - LLM_CHUNK_SIZE=${LLM_CHUNK_SIZE:-8}
@@ -262,7 +262,7 @@ services:
       - DIARIZE_HEARTBEAT_INTERVAL=${DIARIZE_HEARTBEAT_INTERVAL:-30}
       # Optional LLM text correction (Ollama).
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-}
-      - OLLAMA_MODEL=${OLLAMA_MODEL:-gemma4:e2b}
+      - OLLAMA_MODEL=${OLLAMA_MODEL:-gemma4:e4b}
       - OLLAMA_KEEP_ALIVE=${OLLAMA_KEEP_ALIVE:-30m}
       - OLLAMA_REQUEST_TIMEOUT=${OLLAMA_REQUEST_TIMEOUT:-120}
       - LLM_CHUNK_SIZE=${LLM_CHUNK_SIZE:-8}
@@ -326,7 +326,7 @@ services:
       - REDIS_PROCESSING_EXPIRY=${REDIS_PROCESSING_EXPIRY:-30600}
       # LLM correction runs here when enabled — no GPU required.
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-}
-      - OLLAMA_MODEL=${OLLAMA_MODEL:-gemma4:e2b}
+      - OLLAMA_MODEL=${OLLAMA_MODEL:-gemma4:e4b}
       - OLLAMA_KEEP_ALIVE=${OLLAMA_KEEP_ALIVE:-30m}
       - OLLAMA_REQUEST_TIMEOUT=${OLLAMA_REQUEST_TIMEOUT:-120}
       - LLM_CHUNK_SIZE=${LLM_CHUNK_SIZE:-8}
@@ -384,7 +384,7 @@ services:
     entrypoint: /bin/sh
     command:
       - -c
-      - 'OLLAMA_HOST=http://ollama:11434 ollama pull ${OLLAMA_MODEL:-gemma4:e2b}'
+      - 'OLLAMA_HOST=http://ollama:11434 ollama pull ${OLLAMA_MODEL:-gemma4:e4b}'
     depends_on:
       ollama:
         condition: service_healthy

--- a/src/whisper_ui/core/config.py
+++ b/src/whisper_ui/core/config.py
@@ -135,7 +135,7 @@ class Settings(BaseSettings):
     # to enable: "http://ollama:11434" for the bundled `llm` compose profile,
     # or any external Ollama server.
     ollama_base_url: str = ""
-    ollama_model: str = "gemma4:e2b"
+    ollama_model: str = "gemma4:e4b"
     # keep_alive format follows Ollama's duration string (e.g. "30m", "1h",
     # "-1" = forever). Longer values amortize model load cost across chunks.
     ollama_keep_alive: str = "30m"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -33,6 +33,7 @@ def test_default_settings(tmp_path, monkeypatch):
     assert s.device == "auto"
     assert s.language == "zh"
     assert s.batch_size == 4
+    assert s.ollama_model == "gemma4:e4b"
 
 
 def test_timeout_defaults_are_consistent(tmp_path):


### PR DESCRIPTION
## Why

The shipped default LLM correction model was `gemma4:e2b`. Bumping the default to
`gemma4:e4b` gives noticeably better correction accuracy out of the box. The
trade-off is a larger footprint (~9.6 GB pull, more VRAM); users on
constrained hardware can opt back to the smaller model.

## How

Change every place that carries the *default* model value:

- `src/whisper_ui/core/config.py` — `ollama_model` default
- `compose.yml` — `${OLLAMA_MODEL:-...}` defaults across frontend / worker-gpu /
  worker-cpu / worker-io / worker-rocm and the `ollama-pull` sidecar
- `.env.example` — commented default
- `README.md` — examples, the `ollama-pull` download-size note (~7 GB → ~9.6 GB),
  and the env-var table
- `CHANGELOG.md` — `Unreleased > Changed` entry

Tests under `tests/unit/test_llm_correction*.py` keep using `gemma4:e2b` as an
explicit fixture/literal; they assert request pass-through, not the config
default, so they are intentionally left untouched (no drive-by changes).

## Impact

Downstream deployments that do not set `OLLAMA_MODEL` will pull and run the
larger `gemma4:e4b` on next start. To keep the previous behaviour, set
`OLLAMA_MODEL=gemma4:e2b` in `.env`.