### PR TITLE
chore: hold fakeredis below 2.36.0 pending RQ addr fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,15 @@ updates:
           - "pytest*"
           - "fakeredis*"
           - "ruff*"
+    ignore:
+      # fakeredis 2.36.0 refactored CLIENT INFO so in-process connections stop
+      # exposing 'addr'; RQ's _set_ip_address reads client['addr'] without
+      # catching KeyError, breaking the SimpleWorker burst tests. Hold until
+      # upstream restores the field (or RQ guards the lookup), then drop this
+      # entry and the <2.36.0 cap in pyproject.toml.
+      - dependency-name: "fakeredis"
+        versions:
+          - ">=2.36.0"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,13 @@ dev = [
   # extra pulls in ``lupa`` so the RedisProgressReporter's EVAL-based
   # atomic max-write script (see whisper_ui/worker/progress.py) can be
   # exercised under fakeredis without a real Redis server.
-  "fakeredis[lua]>=2.35.1,<3",
+  #
+  # Held below 2.36.0: that release refactored CLIENT INFO so in-process
+  # connections stop exposing 'addr', and RQ's Worker._set_ip_address reads
+  # client['addr'] without catching KeyError, which breaks the SimpleWorker
+  # burst tests. Drop the <2.36.0 cap and the matching .github/dependabot.yml
+  # ignore once upstream restores the field (or RQ guards the lookup).
+  "fakeredis[lua]>=2.35.1,<2.36.0",
   # Visual/contrast regression tests (tests/visual, `pytest -m visual`).
   # Renders the compiled stylesheet in a headless Chromium and reads computed
   # colors to guard theme contrast (issue #61). Browser binary is installed

--- a/uv.lock
+++ b/uv.lock
@@ -3943,7 +3943,7 @@ worker-llm = [
 requires-dist = [
     { name = "argon2-cffi", marker = "extra == 'frontend'", specifier = ">=25.1.0,<26" },
     { name = "ctranslate2", marker = "extra == 'worker'", specifier = ">=4.7.2" },
-    { name = "fakeredis", extras = ["lua"], marker = "extra == 'dev'", specifier = ">=2.35.1,<3" },
+    { name = "fakeredis", extras = ["lua"], marker = "extra == 'dev'", specifier = ">=2.35.1,<2.36.0" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'frontend'", specifier = ">=0.136.3,<1" },
     { name = "faster-whisper", marker = "extra == 'worker'", specifier = ">=1.1.1,<2" },
     { name = "httpx", marker = "extra == 'worker-llm'", specifier = ">=0.27,<1" },


### PR DESCRIPTION
## Why

Dependabot #82 想把 `fakeredis[lua]` 從 2.35.1 升到 2.36.0，但該 PR 的 CI 全紅（`KeyError: 'addr'`）。

根因：fakeredis **2.36.0** 重構了 `CLIENT INFO`（見其 changelog「Improved CLIENT INFO and CLIENT GETNAME commands」），使 **in-process 連線**不再回傳 `addr` / `laddr` / `fd` 欄位。RQ 在 `Worker.__init__(prepare_for_work=True)`（`SimpleWorker` 預設）會呼叫 `_set_ip_address()`，其中以 `client['addr']` 直接索引且**只捕捉 `ResponseError`、未捕捉 `KeyError`**，於是測試建立 `SimpleWorker` 時拋出 `KeyError: 'addr'`，破壞：

- `tests/unit/test_pipeline_dag_parallelism.py`（burst worker）
- `tests/integration/test_e2e_golden_path.py`（burst worker）

**生產不受影響**：worker 走 `rq` CLI 對真實 Redis 連線，`CLIENT LIST` 必含 `addr`。這是純測試替身（fakeredis in-process）的回歸。2.36.0 目前是最新版、尚無修復版；fakeredis 對本專案僅為測試依賴，2.36.0 無實質好處。

## How

- `pyproject.toml`：dev extra 的 `fakeredis[lua]` 由 `>=2.35.1,<3` 收斂為 `>=2.35.1,<2.36.0`（鎖定版本仍為 2.35.1，`uv.lock` 僅更新 specifier metadata），並補上 why 註解。
- `.github/dependabot.yml`：在 uv update entry 新增 `ignore` fakeredis `>=2.36.0`，避免被重複提案。
- 上游修復（恢復 `addr` 或 RQ 改用 `.get('addr')` / 捕捉 KeyError）後，移除 `<2.36.0` 上限與此 ignore 即可。

取代並關閉 #82。

## 驗證

- `uv lock` 乾淨解析（176 packages），fakeredis 維持 2.35.1。
- 本地以 redis 8.0.0 + rq 2.9.0 + fakeredis 2.35.1 環境跑單元測試：**793 passed**，無 `KeyError: 'addr'`。
- pre-commit（check-yaml / check-toml / yamlfmt / taplo）全通過。