### PR TITLE
chore: release v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,18 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.7.0] - 2026-06-03
+
 ### Changed
 
 - Default LLM correction model (`OLLAMA_MODEL`) is now `gemma4:e4b` instead of
   `gemma4:e2b`, trading a larger VRAM/disk footprint (~9.6 GB pull) for better
   correction accuracy. Set `OLLAMA_MODEL=gemma4:e2b` to keep the previous
   default.
+- Upgraded the `redis` client to 8.0 (from 6.4) and `rq` to 2.9.0. redis-py 8.0
+  defaults to the RESP3 protocol; the bundled `redis:7-alpine` server supports
+  it and the worker/web Redis code paths were validated against a real server.
+- Upgraded `ctranslate2` (the faster-whisper backend) to 4.7.2.
 
 ## [2.6.0] - 2026-06-01
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.6.0"
+version = "2.7.0"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3895,7 +3895,7 @@ wheels = [
 
 [[package]]
 name = "whisper-ui"
-version = "2.6.0"
+version = "2.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Release v2.7.0

第一個包含本批依賴升級的版本（領先 v2.6.0）。

### Changed
- 預設 LLM 校正模型改為 `gemma4:e4b`（原 `gemma4:e2b`）。
- `redis` client 6.4 → **8.0**（redis-py 預設 RESP3；`redis:7-alpine` server 支援，worker/web 的 Redis 路徑已對真實 server 驗證）、`rq` 2.8 → 2.9.0。
- `ctranslate2`（faster-whisper backend）→ 4.7.2。

### 備註
- `fakeredis` 為 dev-only，已 pin `<2.36.0`（CLIENT INFO/RQ `addr` 回歸，見 #89），不影響部署 image。
- 合併後將打 annotated tag `v2.7.0` 觸發 `docker-publish`（發佈 `latest` / `2.7.0` / `2.7` image，含 ROCm worker）。

詳見 `CHANGELOG.md` 的 `[2.7.0]` 區段。