### PR TITLE
fix: keep transcript when optional LLM correction stage fails

### DIFF
--- a/src/whisper_ui/core/messages.py
+++ b/src/whisper_ui/core/messages.py
@@ -43,6 +43,7 @@ LLM_CORRECTION_SKIPPED = "已跳過 LLM 文字校驗。"
 LLM_CORRECTION_DEGRADED = "LLM 文字校驗部分失敗，已保留原文的段落："
 
 PIPELINE_COMPLETE = "完成"
+RESULT_PERSIST_FAILED = "結果儲存失敗"
 
 # -- Export --
 EXPORT_DOCX_HEADING = "轉錄結果"

--- a/src/whisper_ui/worker/pipeline_dispatcher.py
+++ b/src/whisper_ui/worker/pipeline_dispatcher.py
@@ -30,7 +30,7 @@ from whisper_ui.core.constants import (
     WORKER_QUEUE_GPU,
     WORKER_QUEUE_IO,
 )
-from whisper_ui.core.messages import LLM_CORRECTION_SKIPPED, PIPELINE_COMPLETE
+from whisper_ui.core.messages import LLM_CORRECTION_SKIPPED, PIPELINE_COMPLETE, RESULT_PERSIST_FAILED
 from whisper_ui.core.models import JobStatus
 from whisper_ui.worker.context_store import PipelineContextStore
 from whisper_ui.worker.pipeline_callbacks import (
@@ -316,23 +316,61 @@ def _persist_completion(
     """
     reporter = runtime.reporter
     try:
-        _apply_filename_from_video_title(job, context)
-        result_path = runtime.filestore.save_result(job.id, transcript_result)
+        try:
+            _apply_filename_from_video_title(job, context)
+            result_path = runtime.filestore.save_result(job.id, transcript_result)
 
-        job.status = JobStatus.COMPLETED
-        job.progress = 1.0
-        job.progress_message = progress_message
-        job.result_path = str(result_path)
-        job.duration = transcript_result.duration
-        runtime.db.update_job(job)
-        reporter.complete(str(result_path))
-
+            job.status = JobStatus.COMPLETED
+            job.progress = 1.0
+            job.progress_message = progress_message
+            job.result_path = str(result_path)
+            job.duration = transcript_result.duration
+            runtime.db.update_job(job)
+        except Exception as exc:
+            # Persisting the finished transcript failed (e.g. disk full writing
+            # the result file, or a DB error). Never leave the parent stuck in
+            # PROCESSING: mark it FAILED so the UI and the stale reaper reflect
+            # reality. We only reach here while the durable DB status is still
+            # pre-COMPLETED, so this can never demote an already-COMPLETED job.
+            # If the DB write itself is what failed, mark_failed re-raises and
+            # the liveness-based stale reaper is the backstop — nothing at this
+            # layer can persist a status while the DB is unavailable.
+            logger.exception("Failed to persist completion for job %s; marking FAILED", job.id)
+            mark_failed(job, runtime.db, reporter, f"{RESULT_PERSIST_FAILED}: {exc}")
+            return
+        # The DB durably says COMPLETED now; the Redis terminal write is
+        # best-effort. Swallow its errors (log only) so a Redis hiccup can
+        # neither raise out of the callback nor demote a job the DB already
+        # completed.
+        try:
+            reporter.complete(str(result_path))
+        except Exception:
+            logger.exception("reporter.complete failed for job %s (already COMPLETED in DB)", job.id)
         logger.info("Job %s completed successfully via DAG pipeline", job.id)
     finally:
         cleanup_preprocessed_audio(context)
         ctx_store.delete()
         if meta_generation is not None:
             _clear_subjob_set(runtime.redis, job.id, meta_generation)
+
+
+def _is_llm_correction_subjob(rq_job) -> bool:
+    """True when ``rq_job`` is the optional llm_correction tail.
+
+    Prefers the explicit ``meta["stage"]`` tag set at enqueue, but falls back
+    to the RQ ``func_name`` so sub-jobs enqueued *before* this change — which
+    survive a redeploy/host reboot via Redis AOF and are then picked up by a
+    new worker — are still recognised and salvaged rather than failed.
+    ``func_name`` is always present on a real sub-job; a bare MagicMock used by
+    some unit tests has no string ``func_name`` and correctly resolves to
+    non-llm.
+    """
+    name = run_llm_correction.__name__
+    meta = getattr(rq_job, "meta", None)
+    if meta and meta.get("stage") == name:
+        return True
+    func_name = getattr(rq_job, "func_name", None)
+    return isinstance(func_name, str) and func_name.rsplit(".", 1)[-1] == name
 
 
 def finalize_success(rq_job, connection, _result) -> None:
@@ -469,13 +507,12 @@ def finalize_failure(rq_job, connection, _exc_type, exc_value, _traceback) -> No
         # route for that sub-job uniformly: an in-task exception, the RQ
         # death-penalty, and the AbandonedJobError raised when a worker/host
         # restart (e.g. a scheduled reboot) kills the long LLM stage mid-run.
-        stage_name = rq_job.meta.get("stage") if rq_job.meta else None
         transcript_result = context.get("transcript_result")
-        if stage_name == run_llm_correction.__name__ and transcript_result is not None:
+        if _is_llm_correction_subjob(rq_job) and transcript_result is not None:
             logger.warning(
                 "Optional stage %s failed for job %s (%s); completing with the "
                 "un-corrected transcript instead of failing the job",
-                stage_name,
+                run_llm_correction.__name__,
                 parent_job_id,
                 _exc_type.__name__ if _exc_type is not None else "?",
             )

--- a/src/whisper_ui/worker/pipeline_dispatcher.py
+++ b/src/whisper_ui/worker/pipeline_dispatcher.py
@@ -30,7 +30,7 @@ from whisper_ui.core.constants import (
     WORKER_QUEUE_GPU,
     WORKER_QUEUE_IO,
 )
-from whisper_ui.core.messages import PIPELINE_COMPLETE
+from whisper_ui.core.messages import LLM_CORRECTION_SKIPPED, PIPELINE_COMPLETE
 from whisper_ui.core.models import JobStatus
 from whisper_ui.worker.context_store import PipelineContextStore
 from whisper_ui.worker.pipeline_callbacks import (
@@ -218,7 +218,10 @@ def enqueue_pipeline(
         queue_name = _STAGE_QUEUES[func.__name__]
         kwargs = {
             "job_timeout": timeout,
-            "meta": dict(meta),
+            # Tag each sub-job with its stage name so finalize_failure can
+            # recognise the optional llm_correction tail and complete with the
+            # already-produced transcript instead of failing the whole job.
+            "meta": {**meta, "stage": func.__name__},
             "on_failure": failure_cb,
         }
         if depends_on is not None:
@@ -290,6 +293,48 @@ def _apply_filename_from_video_title(job: Job, context: dict) -> None:
         job.filename = context["video_title"]
 
 
+def _persist_completion(
+    runtime,
+    job: Job,
+    context: dict,
+    ctx_store: PipelineContextStore,
+    transcript_result,
+    meta_generation: int | None,
+    *,
+    progress_message: str = PIPELINE_COMPLETE,
+) -> None:
+    """Save ``transcript_result``, mark ``job`` COMPLETED, then clean up.
+
+    Shared by ``finalize_success`` (the normal pipeline tail) and
+    ``finalize_failure``'s best-effort branch for an optional stage
+    (``llm_correction``) that failed after the transcript was already
+    produced. Keeping the persist + cleanup in one place means the success
+    path and the optional-stage-salvage path cannot drift on what they save
+    or clear. The ``finally`` mirrors ``finalize_success``'s original
+    cleanup: delete the preprocessed WAV, drop the Redis context hash, and
+    clear the per-generation sub-job tracking set.
+    """
+    reporter = runtime.reporter
+    try:
+        _apply_filename_from_video_title(job, context)
+        result_path = runtime.filestore.save_result(job.id, transcript_result)
+
+        job.status = JobStatus.COMPLETED
+        job.progress = 1.0
+        job.progress_message = progress_message
+        job.result_path = str(result_path)
+        job.duration = transcript_result.duration
+        runtime.db.update_job(job)
+        reporter.complete(str(result_path))
+
+        logger.info("Job %s completed successfully via DAG pipeline", job.id)
+    finally:
+        cleanup_preprocessed_audio(context)
+        ctx_store.delete()
+        if meta_generation is not None:
+            _clear_subjob_set(runtime.redis, job.id, meta_generation)
+
+
 def finalize_success(rq_job, connection, _result) -> None:
     """RQ ``on_success`` callback for the final sub-job.
 
@@ -349,24 +394,7 @@ def finalize_success(rq_job, connection, _result) -> None:
                 _clear_subjob_set(runtime.redis, parent_job_id, meta_generation)
             return
 
-        try:
-            _apply_filename_from_video_title(job, context)
-            result_path = runtime.filestore.save_result(parent_job_id, transcript_result)
-
-            job.status = JobStatus.COMPLETED
-            job.progress = 1.0
-            job.progress_message = PIPELINE_COMPLETE
-            job.result_path = str(result_path)
-            job.duration = transcript_result.duration
-            runtime.db.update_job(job)
-            reporter.complete(str(result_path))
-
-            logger.info("Job %s completed successfully via DAG pipeline", parent_job_id)
-        finally:
-            cleanup_preprocessed_audio(context)
-            ctx_store.delete()
-            if meta_generation is not None:
-                _clear_subjob_set(runtime.redis, parent_job_id, meta_generation)
+        _persist_completion(runtime, job, context, ctx_store, transcript_result, meta_generation)
 
 
 def finalize_failure(rq_job, connection, _exc_type, exc_value, _traceback) -> None:
@@ -432,6 +460,35 @@ def finalize_failure(rq_job, connection, _exc_type, exc_value, _traceback) -> No
         ctx_store = PipelineContextStore(runtime.redis, parent_job_id)
         context = ctx_store.load()
         reporter = runtime.reporter
+
+        # Optional stages must never discard a finished transcript. If the
+        # failing sub-job is the optional llm_correction tail and the
+        # transcript is already in context (postprocess ran before it), the
+        # job is effectively done — complete it with the un-corrected
+        # transcript instead of marking it FAILED. This covers every failure
+        # route for that sub-job uniformly: an in-task exception, the RQ
+        # death-penalty, and the AbandonedJobError raised when a worker/host
+        # restart (e.g. a scheduled reboot) kills the long LLM stage mid-run.
+        stage_name = rq_job.meta.get("stage") if rq_job.meta else None
+        transcript_result = context.get("transcript_result")
+        if stage_name == run_llm_correction.__name__ and transcript_result is not None:
+            logger.warning(
+                "Optional stage %s failed for job %s (%s); completing with the "
+                "un-corrected transcript instead of failing the job",
+                stage_name,
+                parent_job_id,
+                _exc_type.__name__ if _exc_type is not None else "?",
+            )
+            _persist_completion(
+                runtime,
+                job,
+                context,
+                ctx_store,
+                transcript_result,
+                meta_generation,
+                progress_message=LLM_CORRECTION_SKIPPED,
+            )
+            return
 
         try:
             if meta_generation is not None:

--- a/tests/unit/test_pipeline_dispatcher.py
+++ b/tests/unit/test_pipeline_dispatcher.py
@@ -935,3 +935,108 @@ def test_finalize_failure_generic_exception_still_uses_str(monkeypatch, tmp_path
     assert "whisper model oom" in (job.error or "")
     # Must not be silently rewritten to the timeout label.
     assert "任務總執行時間" not in (job.error or "")
+
+
+def _setup_llm_failure_case(monkeypatch, tmp_path, *, seed_transcript: bool):
+    """Build a pipeline with an active llm_correction tail and return the
+    handles a finalize_failure-on-LLM test needs.
+
+    Mirrors the production shape: postprocess has already written
+    ``transcript_result`` into the context (when ``seed_transcript``) by the
+    time the optional llm_correction sub-job fails.
+    """
+    from whisper_ui.core.models import TranscriptResult
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings()  # ollama set -> llm_correction active
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-llm-besteffort",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.PROCESSING,
+        llm_correction_enabled=True,
+    )
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    llm_sub = _by_stage(_load_subjobs(redis, job.id))["run_llm_correction"]
+
+    preprocessed = tmp_path / "preprocessed.wav"
+    preprocessed.write_bytes(b"fake")
+    if seed_transcript:
+        PipelineContextStore(redis, job.id).update(
+            {"transcript_result": TranscriptResult(language="zh", duration=42.0), "audio_path": str(preprocessed)}
+        )
+
+    runtime = MagicMock()
+    runtime.redis = redis
+    runtime.db.get_job.return_value = job
+    runtime.filestore.save_result.return_value = tmp_path / "result.json"
+    runtime.settings.redis_processing_expiry = 7200
+
+    from contextlib import contextmanager
+
+    from whisper_ui.worker.progress import RedisProgressReporter
+
+    @contextmanager
+    def _fake_builder(job_id, *, generation=None):
+        runtime.reporter = RedisProgressReporter(redis, job_id, processing_ttl=7200, generation=generation)
+        yield runtime
+
+    monkeypatch.setattr(pd, "build_worker_runtime", _fake_builder)
+    return pd, redis, job, llm_sub, preprocessed
+
+
+def test_finalize_failure_on_llm_correction_completes_with_uncorrected_transcript(monkeypatch, tmp_path):
+    """An optional llm_correction sub-job that is abandoned mid-run (the
+    production incident: a scheduled host reboot killed the long LLM stage)
+    must NOT discard the finished transcript — the job completes with the
+    un-corrected text instead of being marked FAILED.
+    """
+    from whisper_ui.core.messages import LLM_CORRECTION_SKIPPED
+
+    pd, redis, job, llm_sub, preprocessed = _setup_llm_failure_case(monkeypatch, tmp_path, seed_transcript=True)
+
+    # AbandonedJobError-style failure: the worker died, RQ fires on_failure.
+    pd.finalize_failure(llm_sub, redis, RuntimeError, RuntimeError("Moved to FailedJobRegistry"), None)
+
+    assert job.status == JobStatus.COMPLETED, "optional LLM failure must not fail the whole job"
+    assert job.result_path == str(tmp_path / "result.json")
+    assert job.progress == 1.0
+    assert job.progress_message == LLM_CORRECTION_SKIPPED
+    stored = {
+        k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else v
+        for k, v in redis.hgetall(f"job:{job.id}").items()
+    }
+    assert stored["status"] == "completed"
+    assert not preprocessed.exists(), "preprocessed WAV should still be cleaned up"
+    assert PipelineContextStore(redis, job.id).load() == {}
+
+
+def test_finalize_failure_on_llm_correction_timeout_completes_not_fails(monkeypatch, tmp_path):
+    """Even an RQ death-penalty (BaseTimeoutException) on the optional LLM
+    tail must salvage the transcript rather than surface the timeout error —
+    LLM correction is strictly best-effort.
+    """
+    from rq.timeouts import JobTimeoutException
+
+    pd, redis, job, llm_sub, _ = _setup_llm_failure_case(monkeypatch, tmp_path, seed_transcript=True)
+
+    pd.finalize_failure(llm_sub, redis, JobTimeoutException, JobTimeoutException("timed out"), None)
+
+    assert job.status == JobStatus.COMPLETED
+    assert job.result_path == str(tmp_path / "result.json")
+    assert "任務總執行時間" not in (job.error or "")
+
+
+def test_finalize_failure_on_llm_correction_without_transcript_still_fails(monkeypatch, tmp_path):
+    """Defensive fallback: if there is genuinely no transcript to salvage
+    (postprocess never produced one), an LLM failure still fails the job
+    instead of completing with nothing.
+    """
+    pd, redis, job, llm_sub, _ = _setup_llm_failure_case(monkeypatch, tmp_path, seed_transcript=False)
+
+    pd.finalize_failure(llm_sub, redis, RuntimeError, RuntimeError("boom"), None)
+
+    assert job.status == JobStatus.FAILED
+    assert "boom" in (job.error or "")

--- a/tests/unit/test_pipeline_dispatcher.py
+++ b/tests/unit/test_pipeline_dispatcher.py
@@ -1040,3 +1040,177 @@ def test_finalize_failure_on_llm_correction_without_transcript_still_fails(monke
 
     assert job.status == JobStatus.FAILED
     assert "boom" in (job.error or "")
+
+
+def _build_completion_runtime(redis, job, tmp_path, *, save_side_effect=None):
+    """Build a MagicMock WorkerRuntime + a real generation-aware reporter for
+    the persist-failure tests. ``save_side_effect`` (when set) makes
+    ``filestore.save_result`` raise that exception."""
+    from whisper_ui.worker.progress import RedisProgressReporter
+
+    runtime = MagicMock()
+    runtime.redis = redis
+    runtime.db.get_job.return_value = job
+    if save_side_effect is not None:
+        runtime.filestore.save_result.side_effect = save_side_effect
+    else:
+        runtime.filestore.save_result.return_value = tmp_path / "result.json"
+    runtime.settings.redis_processing_expiry = 7200
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_builder(job_id, *, generation=None):
+        runtime.reporter = RedisProgressReporter(redis, job_id, processing_ttl=7200, generation=generation)
+        yield runtime
+
+    return runtime, _fake_builder
+
+
+def test_persist_completion_save_failure_on_salvage_marks_failed_not_stuck(monkeypatch, tmp_path):
+    """PR #94 review #1: if salvaging the un-corrected transcript fails to
+    persist (disk full / DB error), the parent must be marked FAILED — never
+    left stuck in PROCESSING with its context already deleted."""
+    from whisper_ui.core.messages import RESULT_PERSIST_FAILED
+    from whisper_ui.core.models import TranscriptResult
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    job = Job(
+        id="job-salvage-savefail",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.PROCESSING,
+        llm_correction_enabled=True,
+    )
+    enqueue_pipeline(job, redis=redis, settings=_build_settings(), filestore=_build_filestore(tmp_path))
+    llm_sub = _by_stage(_load_subjobs(redis, job.id))["run_llm_correction"]
+    PipelineContextStore(redis, job.id).update({"transcript_result": TranscriptResult(language="zh", duration=42.0)})
+
+    _, builder = _build_completion_runtime(redis, job, tmp_path, save_side_effect=OSError("disk full"))
+    monkeypatch.setattr(pd, "build_worker_runtime", builder)
+
+    pd.finalize_failure(llm_sub, redis, RuntimeError, RuntimeError("llm crashed"), None)
+
+    assert job.status == JobStatus.FAILED, "save failure during salvage must not leave the job PROCESSING"
+    assert RESULT_PERSIST_FAILED in (job.error or "")
+    # The finally still runs, so context is cleaned up regardless.
+    assert PipelineContextStore(redis, job.id).load() == {}
+
+
+def test_finalize_success_save_failure_marks_failed(monkeypatch, tmp_path):
+    """The same guard protects the normal completion path: a save_result
+    failure in finalize_success marks FAILED instead of leaving PROCESSING
+    (pre-existing latent bug, now fixed via the shared helper)."""
+    from whisper_ui.core.messages import RESULT_PERSIST_FAILED
+    from whisper_ui.core.models import TranscriptResult
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    job = Job(id="job-succ-savefail", filename="m.mp3", filepath=str(tmp_path / "m.mp3"), status=JobStatus.PROCESSING)
+    PipelineContextStore(redis, job.id).initialize(
+        {"transcript_result": TranscriptResult(language="zh", duration=10.0)}
+    )
+
+    _, builder = _build_completion_runtime(redis, job, tmp_path, save_side_effect=OSError("disk full"))
+    monkeypatch.setattr(pd, "build_worker_runtime", builder)
+
+    rq_job = MagicMock()
+    rq_job.meta = {"parent_job_id": job.id}
+    pd.finalize_success(rq_job, redis, None)
+
+    assert job.status == JobStatus.FAILED
+    assert RESULT_PERSIST_FAILED in (job.error or "")
+
+
+def test_finalize_success_db_update_failure_marks_failed(monkeypatch, tmp_path):
+    """A DB error while writing the COMPLETED row also marks FAILED rather than
+    leaving the job stuck (save_result succeeds, the first update_job raises)."""
+    from whisper_ui.core.models import TranscriptResult
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    job = Job(id="job-succ-dbfail", filename="m.mp3", filepath=str(tmp_path / "m.mp3"), status=JobStatus.PROCESSING)
+    PipelineContextStore(redis, job.id).initialize(
+        {"transcript_result": TranscriptResult(language="zh", duration=10.0)}
+    )
+
+    runtime, builder = _build_completion_runtime(redis, job, tmp_path)
+    # First update_job (COMPLETED) raises; mark_failed's update_job then succeeds.
+    runtime.db.update_job.side_effect = [RuntimeError("db locked"), None]
+    monkeypatch.setattr(pd, "build_worker_runtime", builder)
+
+    rq_job = MagicMock()
+    rq_job.meta = {"parent_job_id": job.id}
+    pd.finalize_success(rq_job, redis, None)
+
+    assert job.status == JobStatus.FAILED
+
+
+def test_finalize_success_reporter_failure_keeps_completed(monkeypatch, tmp_path):
+    """A best-effort Redis terminal-write failure (reporter.complete) AFTER the
+    DB durably recorded COMPLETED must neither raise out of the callback nor
+    demote the finished job to FAILED."""
+    from whisper_ui.core.models import TranscriptResult
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    job = Job(
+        id="job-succ-reporterfail", filename="m.mp3", filepath=str(tmp_path / "m.mp3"), status=JobStatus.PROCESSING
+    )
+    PipelineContextStore(redis, job.id).initialize(
+        {"transcript_result": TranscriptResult(language="zh", duration=10.0)}
+    )
+
+    runtime = MagicMock()
+    runtime.redis = redis
+    runtime.db.get_job.return_value = job
+    runtime.filestore.save_result.return_value = tmp_path / "result.json"
+    runtime.settings.redis_processing_expiry = 7200
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_builder(job_id, *, generation=None):
+        reporter = MagicMock()
+        reporter.complete.side_effect = RuntimeError("redis down")
+        runtime.reporter = reporter
+        yield runtime
+
+    monkeypatch.setattr(pd, "build_worker_runtime", _fake_builder)
+
+    rq_job = MagicMock()
+    rq_job.meta = {"parent_job_id": job.id}
+    pd.finalize_success(rq_job, redis, None)  # must not raise
+
+    assert job.status == JobStatus.COMPLETED
+    runtime.db.update_job.assert_called_once()
+
+
+def test_is_llm_correction_subjob_identifies_via_func_name_without_meta(tmp_path):
+    """PR #94 review #2: the salvage path must recognise the llm_correction
+    tail even for a sub-job enqueued before meta["stage"] existed (in-flight
+    across a rolling deploy / reboot), via the stable RQ func_name."""
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    job = Job(
+        id="job-funcname",
+        filename="m.mp3",
+        filepath=str(tmp_path / "m.mp3"),
+        status=JobStatus.PROCESSING,
+        llm_correction_enabled=True,
+    )
+    enqueue_pipeline(job, redis=redis, settings=_build_settings(), filestore=_build_filestore(tmp_path))
+    subs = _by_stage(_load_subjobs(redis, job.id))
+    llm_sub = subs["run_llm_correction"]
+    transcribe_sub = subs["run_transcribe_align"]
+
+    # Simulate pre-change sub-jobs by stripping the new meta["stage"] tag.
+    llm_sub.meta.pop("stage", None)
+    transcribe_sub.meta.pop("stage", None)
+
+    assert pd._is_llm_correction_subjob(llm_sub) is True
+    assert pd._is_llm_correction_subjob(transcribe_sub) is False
+    # A bare mock (no string func_name) is never mis-identified as llm.
+    assert pd._is_llm_correction_subjob(MagicMock()) is False


### PR DESCRIPTION
## Why

A production batch on the NV box (220) lost jobs even though transcription had
essentially finished. Root cause (verified from live `exc_info` + host logs):
the optional **`llm_correction`** stage is the pipeline tail, and **any** failure
of that sub-job routes through `finalize_failure` → the whole job is marked
**FAILED**, discarding the already-produced transcript.

In the incident, a **scheduled host reboot** (recurring ~01:3x) abandoned the long
(30–34 min) LLM stage mid-run → RQ `AbandonedJobError` → 4 jobs at `progress≈0.95`
were thrown away with empty error. An RQ death-penalty or an in-task exception
would do the same. The LLM stage is *optional polish*; it must never destroy a
finished transcript.

## How

- Tag every sub-job's `meta["stage"]` at enqueue so callbacks can recognise the
  optional `llm_correction` tail.
- In `finalize_failure`, when the failing sub-job is `run_llm_correction` and a
  `transcript_result` is already in the context (postprocess ran before it),
  **complete the job with the un-corrected transcript** (progress_message =
  `LLM_CORRECTION_SKIPPED`) instead of marking it FAILED. This covers all failure
  routes uniformly: in-task exception, RQ death-penalty (`BaseTimeoutException`),
  and `AbandonedJobError` from a worker/host restart.
- Extract the persist + cleanup body shared by `finalize_success` and this new
  branch into `_persist_completion` so the two paths cannot drift.
- Defensive fallback: if there is genuinely no transcript to salvage, the job
  still fails as before.

This makes the pipeline resilient to the restarts/reboots/death-penalties that
*will* happen, rather than trying to prevent them.

## Tests

- `test_finalize_failure_on_llm_correction_completes_with_uncorrected_transcript`
  (AbandonedJobError-style) → job COMPLETED with saved result, context cleaned up.
- `test_finalize_failure_on_llm_correction_timeout_completes_not_fails`
  (RQ `JobTimeoutException`) → COMPLETED, no timeout error surfaced.
- `test_finalize_failure_on_llm_correction_without_transcript_still_fails`
  (defensive) → still FAILED when nothing to salvage.
- Full unit suite: 796 passed; ruff check + format clean.

## Scope

Part of the batch-failure remediation (P0). The companion fix — making the
stale-job reaper liveness-based instead of wall-age based (the 211 mass-failure)
— is a separate PR.