### PR TITLE
fix: make stale-job reaper liveness-based, not wall-age

### DIFF
--- a/src/whisper_ui/core/constants.py
+++ b/src/whisper_ui/core/constants.py
@@ -51,20 +51,23 @@ REDIS_COMPLETED_EXPIRY = 86400  # 24 hours
 REDIS_FAILED_EXPIRY = 86400  # 24 hours
 
 # Pipeline TTLs at a glance (three layers, longest to shortest):
-#   PIPELINE_STATE_TTL_SECONDS (here, 24h)
+#   PIPELINE_STATE_TTL_SECONDS (here, 7d)
 #       Safety net for per-pipeline state (context HSET, generation
 #       counter, sub-job sets). Only matters when a worker is killed
 #       between bumping the generation counter and writing the
 #       finalizer; a successful/failed pipeline always deletes these
-#       keys explicitly. Must outlive the longest plausible stage so
-#       late writers still observe the bumped generation and self-drop.
+#       keys explicitly. Under the liveness-aware stale reaper a job can stay
+#       PROCESSING (queued behind a slow worker) far longer than any single
+#       stage, so this must outlive the longest plausible BACKLOG WAIT, not
+#       just the longest stage — otherwise is_pipeline_dead reads the expired
+#       generation counter as "no live work" and reaps a healthy queued job.
 #   Settings.redis_processing_expiry (core/config.py, default ~8.5h)
 #       TTL on the per-job progress HSET emitted by RedisProgressReporter
 #       during a running job, sized to outlive job_timeout_max.
 #   progress._DEFAULT_PROCESSING_TTL (worker/progress.py, 2h)
 #       Fallback when callers construct a reporter without going through
 #       Settings (unit tests, ad-hoc scripts).
-PIPELINE_STATE_TTL_SECONDS = 86_400  # 24 hours
+PIPELINE_STATE_TTL_SECONDS = 604_800  # 7 days (must outlive max backlog wait)
 
 # Worker queues. Stages are partitioned across these queues by the resource
 # they consume so a long-running IO or network stage (download, llm_correction)

--- a/src/whisper_ui/storage/database.py
+++ b/src/whisper_ui/storage/database.py
@@ -192,8 +192,29 @@ class JobDatabase:
         ).fetchall()
         return [_row_to_job(r) for r in rows]
 
-    def recover_stale_jobs(self, timeout_seconds: int, error_message: str) -> int:
+    def list_stale_processing_job_ids(self, timeout_seconds: int) -> list[str]:
+        """Return ids of PROCESSING jobs whose updated_at is older than the timeout.
+
+        Candidate list for the liveness-aware stale reaper
+        (``worker.pipeline_dispatcher.recover_stale_pipeline_jobs``): the caller
+        checks each candidate's RQ pipeline liveness and only fails the
+        genuinely-dead ones, sparing jobs that are merely waiting behind a
+        slow/backed-up worker. Ordered oldest-first for deterministic logs.
+        """
+        threshold = (datetime.now(UTC) - timedelta(seconds=timeout_seconds)).isoformat()
+        rows = self._conn.execute(
+            "SELECT id FROM jobs WHERE status = ? AND updated_at < ? ORDER BY updated_at ASC, id ASC",
+            (JobStatus.PROCESSING.value, threshold),
+        ).fetchall()
+        return [row["id"] for row in rows]
+
+    def recover_stale_jobs(self, timeout_seconds: int, error_message: str, *, only_ids: list[str] | None = None) -> int:
         """Mark PROCESSING jobs whose updated_at is older than the timeout as FAILED.
+
+        When ``only_ids`` is given, the UPDATE is additionally restricted to
+        that id set — the liveness-aware reaper passes the subset of stale
+        candidates whose RQ pipeline is genuinely dead, so jobs still waiting
+        in a queue are never failed. ``only_ids=[]`` is a no-op.
 
         Concurrency contract: this is a single UPDATE statement with a WHERE
         clause gated on ``updated_at < threshold``. SQLite WAL mode allows
@@ -227,16 +248,22 @@ class JobDatabase:
         # cache limit. Tighter bounding would require batching the
         # UPDATE (e.g. SELECT id LIMIT N then UPDATE WHERE id IN ...)
         # and is not justified at current row sizes.
-        cursor = self._conn.execute(
-            "UPDATE jobs SET status = ?, error = ?, updated_at = ? WHERE status = ? AND updated_at < ? RETURNING id",
-            (
-                JobStatus.FAILED.value,
-                error_message,
-                datetime.now(UTC).isoformat(),
-                JobStatus.PROCESSING.value,
-                threshold,
-            ),
-        )
+        sql = "UPDATE jobs SET status = ?, error = ?, updated_at = ? WHERE status = ? AND updated_at < ?"
+        params: list[object] = [
+            JobStatus.FAILED.value,
+            error_message,
+            datetime.now(UTC).isoformat(),
+            JobStatus.PROCESSING.value,
+            threshold,
+        ]
+        if only_ids is not None:
+            if not only_ids:
+                return 0
+            placeholders = ", ".join("?" for _ in only_ids)
+            sql += f" AND id IN ({placeholders})"
+            params.extend(only_ids)
+        sql += " RETURNING id"
+        cursor = self._conn.execute(sql, params)
         recovered = 0
         shown: list[str] = []
         for row in cursor:

--- a/src/whisper_ui/web/app.py
+++ b/src/whisper_ui/web/app.py
@@ -83,6 +83,26 @@ def _run_retention_sweep(db_path, filestore, threshold_iso: str, limit: int) -> 
     return removed
 
 
+def _run_stale_recovery(db_path, redis, timeout_seconds: int, error_message: str) -> int:
+    """Sync helper run inside ``asyncio.to_thread`` for the stale-job checker.
+
+    The liveness-aware reaper does a SQLite scan plus several Redis roundtrips
+    per stale candidate (one ``RQJob.fetch`` per sub-job), so running it inline
+    on the event loop would block the web tier during the sweep. Mirrors
+    ``_run_retention_sweep``: it opens its own short-lived ``JobDatabase``
+    instead of borrowing ``app.state.db`` (Python's sqlite3 does not serialise a
+    shared connection across threads); the redis client is thread-safe and is
+    passed straight through.
+    """
+    from contextlib import closing
+
+    from whisper_ui.storage.database import JobDatabase
+    from whisper_ui.worker.pipeline_dispatcher import recover_stale_pipeline_jobs
+
+    with closing(JobDatabase(db_path)) as db:
+        return recover_stale_pipeline_jobs(db, redis, timeout_seconds, error_message)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     from datetime import UTC, datetime, timedelta
@@ -95,7 +115,6 @@ async def lifespan(app: FastAPI):
     from whisper_ui.storage.database import JobDatabase
     from whisper_ui.storage.filestore import FileStore
     from whisper_ui.ui.labels import JOBS_STALE_ERROR
-    from whisper_ui.worker.pipeline_dispatcher import recover_stale_pipeline_jobs
 
     settings = get_settings()
     app.state.settings = settings
@@ -111,8 +130,12 @@ async def lifespan(app: FastAPI):
         while True:
             await asyncio.sleep(STALE_JOB_CHECK_INTERVAL)
             try:
-                recovered = recover_stale_pipeline_jobs(
-                    app.state.db, app.state.redis, settings.stale_job_timeout, JOBS_STALE_ERROR
+                recovered = await asyncio.to_thread(
+                    _run_stale_recovery,
+                    settings.database_path,
+                    app.state.redis,
+                    settings.stale_job_timeout,
+                    JOBS_STALE_ERROR,
                 )
                 if recovered > 0:
                     logger.warning("Recovered %d stale job(s)", recovered)

--- a/src/whisper_ui/web/app.py
+++ b/src/whisper_ui/web/app.py
@@ -95,6 +95,7 @@ async def lifespan(app: FastAPI):
     from whisper_ui.storage.database import JobDatabase
     from whisper_ui.storage.filestore import FileStore
     from whisper_ui.ui.labels import JOBS_STALE_ERROR
+    from whisper_ui.worker.pipeline_dispatcher import recover_stale_pipeline_jobs
 
     settings = get_settings()
     app.state.settings = settings
@@ -110,7 +111,9 @@ async def lifespan(app: FastAPI):
         while True:
             await asyncio.sleep(STALE_JOB_CHECK_INTERVAL)
             try:
-                recovered = app.state.db.recover_stale_jobs(settings.stale_job_timeout, JOBS_STALE_ERROR)
+                recovered = recover_stale_pipeline_jobs(
+                    app.state.db, app.state.redis, settings.stale_job_timeout, JOBS_STALE_ERROR
+                )
                 if recovered > 0:
                     logger.warning("Recovered %d stale job(s)", recovered)
             except Exception:

--- a/src/whisper_ui/worker/pipeline_dispatcher.py
+++ b/src/whisper_ui/worker/pipeline_dispatcher.py
@@ -559,6 +559,7 @@ def is_pipeline_dead(redis: Redis, parent_job_id: str) -> bool:
     death-penalty ``job_timeout``); treating STARTED as live therefore only ever
     errs toward sparing a job, never toward failing a healthy one.
     """
+    from rq.exceptions import NoSuchJobError
     from rq.job import Job as RQJob
     from rq.job import JobStatus as RQJobStatus
 
@@ -572,8 +573,13 @@ def is_pipeline_dead(redis: Redis, parent_job_id: str) -> bool:
     for sub_id in sub_ids:
         try:
             status = RQJob.fetch(sub_id, connection=redis).get_status(refresh=True)
-        except Exception:
-            # Sub-job hash is gone → that branch is dead; keep checking the rest.
+        except NoSuchJobError:
+            # The sub-job hash is genuinely gone → that branch is dead; keep
+            # checking the rest. Only NoSuchJobError is swallowed: a transient
+            # redis.exceptions.RedisError must NOT be treated as "dead" (that
+            # would mark a live, queued job FAILED on a Redis blip) — it
+            # propagates so the stale checker's outer handler logs it and skips
+            # this round, leaving every candidate untouched.
             continue
         if status in live:
             return False

--- a/src/whisper_ui/worker/pipeline_dispatcher.py
+++ b/src/whisper_ui/worker/pipeline_dispatcher.py
@@ -76,6 +76,7 @@ if TYPE_CHECKING:
 
     from whisper_ui.core.config import Settings
     from whisper_ui.core.models import Job
+    from whisper_ui.storage.database import JobDatabase
     from whisper_ui.storage.filestore import FileStore
 
 logger = logging.getLogger(__name__)
@@ -542,8 +543,86 @@ def finalize_failure(rq_job, connection, _exc_type, exc_value, _traceback) -> No
                 _clear_subjob_set(runtime.redis, parent_job_id, meta_generation)
 
 
+def is_pipeline_dead(redis: Redis, parent_job_id: str) -> bool:
+    """Return True when a PROCESSING parent has no live RQ work left.
+
+    "Live" means at least one current-generation sub-job is still queued,
+    deferred, scheduled, or started. A parent whose sub-jobs are all finished,
+    failed, cancelled, or gone has nothing progressing it and is a genuine
+    stale/dead pipeline. A job merely waiting in a backed-up queue is ALIVE and
+    must not be reaped — that is the whole point of moving the stale reaper from
+    wall-age to liveness, so a slow single-worker box stops mass-failing a
+    healthy batch whose tail simply has not been reached yet.
+
+    A started sub-job whose worker has died is still reported STARTED until RQ's
+    own maintenance moves it to the failed registry (bounded by its
+    death-penalty ``job_timeout``); treating STARTED as live therefore only ever
+    errs toward sparing a job, never toward failing a healthy one.
+    """
+    from rq.job import Job as RQJob
+    from rq.job import JobStatus as RQJobStatus
+
+    generation = _current_generation(redis, parent_job_id)
+    if generation is None:
+        return True
+    sub_ids = _load_subjob_ids(redis, parent_job_id, generation)
+    if not sub_ids:
+        return True
+    live = {RQJobStatus.QUEUED, RQJobStatus.STARTED, RQJobStatus.DEFERRED, RQJobStatus.SCHEDULED}
+    for sub_id in sub_ids:
+        try:
+            status = RQJob.fetch(sub_id, connection=redis).get_status(refresh=True)
+        except Exception:
+            # Sub-job hash is gone → that branch is dead; keep checking the rest.
+            continue
+        if status in live:
+            return False
+    return True
+
+
+def recover_stale_pipeline_jobs(
+    db: JobDatabase,
+    redis: Redis,
+    timeout_seconds: int,
+    error_message: str,
+) -> int:
+    """Fail only genuinely-dead stale jobs; spare jobs still waiting in RQ.
+
+    Replaces the blind wall-age reaper. A parent PROCESSING for longer than
+    ``timeout_seconds`` is failed only if :func:`is_pipeline_dead` confirms none
+    of its current-generation sub-jobs is still alive in RQ. This stops a
+    single-/slow-worker box from mass-failing a healthy batch whose tail had
+    simply not been reached yet (the production incident: 31/38 jobs reaped
+    while their transcribe sub-jobs were still queued behind one worker).
+
+    For each job it does fail, the generation counter is bumped so any zombie
+    sub-job that later resurfaces drops its writes through the existing
+    generation gate.
+    """
+    candidates = db.list_stale_processing_job_ids(timeout_seconds)
+    if not candidates:
+        return 0
+    dead = [job_id for job_id in candidates if is_pipeline_dead(redis, job_id)]
+    spared = len(candidates) - len(dead)
+    if spared:
+        logger.info(
+            "stale check: %d candidate(s) older than %ds, %d still live (spared), %d dead",
+            len(candidates),
+            timeout_seconds,
+            spared,
+            len(dead),
+        )
+    if not dead:
+        return 0
+    for job_id in dead:
+        _bump_generation(redis, job_id)
+    return db.recover_stale_jobs(timeout_seconds, error_message, only_ids=dead)
+
+
 __all__ = [
     "enqueue_pipeline",
     "finalize_failure",
     "finalize_success",
+    "is_pipeline_dead",
+    "recover_stale_pipeline_jobs",
 ]

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -602,6 +602,62 @@ def test_recover_stale_jobs_ignores_non_processing(db: JobDatabase):
     assert fetched.status == JobStatus.QUEUED
 
 
+def test_list_stale_processing_job_ids_returns_old_processing_only(db: JobDatabase):
+    stale = Job(filename="stale.mp3", filepath="/tmp/stale.mp3")
+    stale.status = JobStatus.PROCESSING
+    db.insert_job(stale)
+    fresh = Job(filename="fresh.mp3", filepath="/tmp/fresh.mp3")
+    fresh.status = JobStatus.PROCESSING
+    db.insert_job(fresh)
+    queued = Job(filename="queued.mp3", filepath="/tmp/queued.mp3")
+    queued.status = JobStatus.QUEUED
+    db.insert_job(queued)
+
+    # Backdate the stale PROCESSING job and the (irrelevant) QUEUED job; only
+    # the old PROCESSING one is a stale-recovery candidate.
+    db._conn.execute(
+        "UPDATE jobs SET updated_at = '2000-01-01T00:00:00+00:00' WHERE id IN (?, ?)",
+        (stale.id, queued.id),
+    )
+    db._conn.commit()
+
+    assert db.list_stale_processing_job_ids(timeout_seconds=60) == [stale.id]
+
+
+def test_recover_stale_jobs_only_ids_restricts_to_subset(db: JobDatabase):
+    """``only_ids`` lets the liveness-aware reaper fail just the genuinely-dead
+    subset, leaving other equally-old PROCESSING jobs untouched."""
+    dead = Job(filename="dead.mp3", filepath="/tmp/dead.mp3")
+    dead.status = JobStatus.PROCESSING
+    db.insert_job(dead)
+    alive = Job(filename="alive.mp3", filepath="/tmp/alive.mp3")
+    alive.status = JobStatus.PROCESSING
+    db.insert_job(alive)
+    db._conn.execute(
+        "UPDATE jobs SET updated_at = '2000-01-01T00:00:00+00:00' WHERE status = ?",
+        (JobStatus.PROCESSING.value,),
+    )
+    db._conn.commit()
+
+    recovered = db.recover_stale_jobs(timeout_seconds=60, error_message="dead pipeline", only_ids=[dead.id])
+
+    assert recovered == 1
+    assert db.get_job(dead.id).status == JobStatus.FAILED
+    # The equally-old but live job is spared because it is not in only_ids.
+    assert db.get_job(alive.id).status == JobStatus.PROCESSING
+
+
+def test_recover_stale_jobs_only_ids_empty_is_noop(db: JobDatabase):
+    stale = Job(filename="s.mp3", filepath="/tmp/s.mp3")
+    stale.status = JobStatus.PROCESSING
+    db.insert_job(stale)
+    db._conn.execute("UPDATE jobs SET updated_at = '2000-01-01T00:00:00+00:00' WHERE id = ?", (stale.id,))
+    db._conn.commit()
+
+    assert db.recover_stale_jobs(timeout_seconds=60, error_message="x", only_ids=[]) == 0
+    assert db.get_job(stale.id).status == JobStatus.PROCESSING
+
+
 def test_recover_stale_jobs_concurrent_workers_dont_double_recover(tmp_path: Path):
     """Two workers calling recover_stale_jobs at the same instant must not
     double-recover the same job. SQLite WAL serializes writers; once the

--- a/tests/unit/test_pipeline_dispatcher.py
+++ b/tests/unit/test_pipeline_dispatcher.py
@@ -1293,3 +1293,95 @@ def test_recover_stale_pipeline_jobs_spares_live_and_fails_dead(tmp_path):
         assert db.get_job(live.id).status == JobStatus.PROCESSING, "a job still waiting in queue must be spared"
     finally:
         db.close()
+
+
+def test_recover_stale_pipeline_jobs_propagates_redis_error_without_reaping(tmp_path, monkeypatch):
+    """PR #95 review #1: a transient RedisError during the liveness probe must
+    PROPAGATE (so the stale checker logs it and skips the round), not be
+    swallowed as 'dead' and used to reap a live job."""
+    from redis.exceptions import RedisError
+
+    from whisper_ui.storage.database import JobDatabase
+    from whisper_ui.ui.labels import JOBS_STALE_ERROR
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    db = JobDatabase(tmp_path / "stale.db")
+    try:
+        job = Job(id="live-candidate", filename="m.mp3", filepath=str(tmp_path / "m.mp3"), status=JobStatus.PROCESSING)
+        db.insert_job(job)
+        enqueue_pipeline(job, redis=redis, settings=_build_settings(ollama=""), filestore=_build_filestore(tmp_path))
+        db._conn.execute(
+            "UPDATE jobs SET updated_at = '2000-01-01T00:00:00+00:00' WHERE status = ?",
+            (JobStatus.PROCESSING.value,),
+        )
+        db._conn.commit()
+
+        def _raise_redis(*args, **kwargs):
+            raise RedisError("connection reset")
+
+        monkeypatch.setattr("rq.job.Job.fetch", _raise_redis)
+
+        with pytest.raises(RedisError):
+            pd.recover_stale_pipeline_jobs(db, redis, timeout_seconds=60, error_message=JOBS_STALE_ERROR)
+
+        # The candidate must be left untouched for a later round, not reaped.
+        assert db.get_job(job.id).status == JobStatus.PROCESSING
+    finally:
+        db.close()
+
+
+def test_is_pipeline_dead_treats_missing_subjob_as_dead_branch(tmp_path):
+    """A genuinely-deleted sub-job (RQJob.fetch raises NoSuchJobError) is a dead
+    branch; when every sub-job is gone the pipeline is dead. Contrast with the
+    propagation test: only NoSuchJobError is swallowed, never a RedisError."""
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    job = Job(id="job-gone", filename="m.mp3", filepath=str(tmp_path / "m.mp3"), status=JobStatus.PROCESSING)
+    enqueue_pipeline(job, redis=redis, settings=_build_settings(ollama=""), filestore=_build_filestore(tmp_path))
+
+    # Remove every RQ job hash so RQJob.fetch raises NoSuchJobError (while the
+    # sub-job id set still lists them).
+    for sub in _load_subjobs(redis, job.id):
+        sub.delete()
+
+    assert pd.is_pipeline_dead(redis, job.id) is True
+
+
+def test_run_stale_recovery_offload_reaps_dead_via_short_lived_db(tmp_path):
+    """PR #95 review (Gemini): the stale check now runs in a thread via a
+    module-level helper that opens its OWN short-lived JobDatabase (instead of
+    blocking the event loop on the shared connection). It still reaps
+    genuinely-dead jobs, equivalent to calling recover_stale_pipeline_jobs."""
+    from whisper_ui.storage.database import JobDatabase
+    from whisper_ui.ui.labels import JOBS_STALE_ERROR
+    from whisper_ui.web.app import _run_stale_recovery
+
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    db_path = tmp_path / "stale.db"
+    seed = JobDatabase(db_path)
+    try:
+        dead = Job(id="dead", filename="d.mp3", filepath=str(tmp_path / "d.mp3"), status=JobStatus.PROCESSING)
+        seed.insert_job(dead)
+        enqueue_pipeline(dead, redis=redis, settings=settings, filestore=filestore)
+        for sub in _load_subjobs(redis, dead.id):
+            sub.cancel()
+        seed._conn.execute(
+            "UPDATE jobs SET updated_at = '2000-01-01T00:00:00+00:00' WHERE status = ?",
+            (JobStatus.PROCESSING.value,),
+        )
+        seed._conn.commit()
+    finally:
+        seed.close()
+
+    recovered = _run_stale_recovery(db_path, redis, 60, JOBS_STALE_ERROR)
+
+    assert recovered == 1
+    verify = JobDatabase(db_path)
+    try:
+        assert verify.get_job(dead.id).status == JobStatus.FAILED
+    finally:
+        verify.close()

--- a/tests/unit/test_pipeline_dispatcher.py
+++ b/tests/unit/test_pipeline_dispatcher.py
@@ -1214,3 +1214,82 @@ def test_is_llm_correction_subjob_identifies_via_func_name_without_meta(tmp_path
     assert pd._is_llm_correction_subjob(transcribe_sub) is False
     # A bare mock (no string func_name) is never mis-identified as llm.
     assert pd._is_llm_correction_subjob(MagicMock()) is False
+
+
+def test_is_pipeline_dead_false_when_a_subjob_is_still_queued(tmp_path):
+    """A job whose pipeline still has a queued/deferred sub-job is ALIVE — the
+    liveness gate must not let the stale reaper fail it. This is the 211 fix:
+    jobs merely waiting behind a slow worker were being mass-failed.
+    """
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    job = Job(id="job-live", filename="m.mp3", filepath=str(tmp_path / "m.mp3"), status=JobStatus.PROCESSING)
+    enqueue_pipeline(job, redis=redis, settings=_build_settings(ollama=""), filestore=_build_filestore(tmp_path))
+
+    # Fresh out of enqueue: preprocess is QUEUED and the rest DEFERRED.
+    assert pd.is_pipeline_dead(redis, job.id) is False
+
+
+def test_is_pipeline_dead_true_when_all_subjobs_terminal(tmp_path):
+    """When every sub-job is cancelled/finished (nothing queued/started), the
+    pipeline is genuinely dead and eligible for stale recovery."""
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    job = Job(id="job-dead", filename="m.mp3", filepath=str(tmp_path / "m.mp3"), status=JobStatus.PROCESSING)
+    enqueue_pipeline(job, redis=redis, settings=_build_settings(ollama=""), filestore=_build_filestore(tmp_path))
+
+    for sub in _load_subjobs(redis, job.id):
+        sub.cancel()
+
+    assert pd.is_pipeline_dead(redis, job.id) is True
+
+
+def test_is_pipeline_dead_true_when_generation_missing(tmp_path):
+    """No generation counter (never enqueued / expired) → nothing to keep the
+    pipeline alive → treated as dead."""
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    assert pd.is_pipeline_dead(redis, "never-enqueued") is True
+
+
+def test_recover_stale_pipeline_jobs_spares_live_and_fails_dead(tmp_path):
+    """End-to-end: a dead pipeline (all sub-jobs cancelled) is failed, while an
+    equally-old job still waiting in the queue is spared."""
+    from whisper_ui.storage.database import JobDatabase
+    from whisper_ui.ui.labels import JOBS_STALE_ERROR
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    db = JobDatabase(tmp_path / "stale.db")
+    try:
+        dead = Job(id="dead", filename="d.mp3", filepath=str(tmp_path / "d.mp3"), status=JobStatus.PROCESSING)
+        live = Job(id="live", filename="l.mp3", filepath=str(tmp_path / "l.mp3"), status=JobStatus.PROCESSING)
+        db.insert_job(dead)
+        db.insert_job(live)
+        enqueue_pipeline(dead, redis=redis, settings=settings, filestore=filestore)
+        enqueue_pipeline(live, redis=redis, settings=settings, filestore=filestore)
+
+        # dead pipeline: cancel every sub-job. live pipeline: leave it waiting.
+        for sub in _load_subjobs(redis, dead.id):
+            sub.cancel()
+
+        # Backdate both jobs so they clear the stale-recovery threshold.
+        db._conn.execute(
+            "UPDATE jobs SET updated_at = '2000-01-01T00:00:00+00:00' WHERE status = ?",
+            (JobStatus.PROCESSING.value,),
+        )
+        db._conn.commit()
+
+        recovered = pd.recover_stale_pipeline_jobs(db, redis, timeout_seconds=60, error_message=JOBS_STALE_ERROR)
+
+        assert recovered == 1
+        assert db.get_job(dead.id).status == JobStatus.FAILED
+        assert db.get_job(dead.id).error == JOBS_STALE_ERROR
+        assert db.get_job(live.id).status == JobStatus.PROCESSING, "a job still waiting in queue must be spared"
+    finally:
+        db.close()


### PR DESCRIPTION
> Stacked on #94 (base = `fix/llm-correction-best-effort`); retarget to `main` once #94 merges.

## Why

The frontend stale-job checker failed **every** PROCESSING job whose
`updated_at` was older than `stale_job_timeout` (= `job_timeout_max +
stale_job_buffer` = **8.5h**), regardless of whether the job's pipeline was
still making progress.

A job flips QUEUED → PROCESSING the moment its **first, cheap** stage runs
(`_mark_processing_if_queued`), but `updated_at` only advances while one of
*its own* stages is actively running. On a slow/single-worker box a perfectly
healthy job can sit in the RQ queue for hours behind the backlog — its clock
freezes, and at 8.5h the reaper mass-fails it. This is the verified cause of
the **211 incident**: a 38-file batch → **31 FAILED** in 60s waves ~8.5h after
upload, all with the generic `JOBS_STALE_ERROR`, and **RQ `failed=0`** (RQ
never failed them — the app did).

## How

- `is_pipeline_dead(redis, parent_job_id)` — a job is *dead* only when **none**
  of its current-generation RQ sub-jobs is still `QUEUED`/`DEFERRED`/
  `SCHEDULED`/`STARTED`. A job waiting in a backed-up queue is *alive* and
  spared. (Treating `STARTED` as alive only ever errs toward sparing; a truly
  abandoned started job is moved to the failed registry by RQ's own
  maintenance within its death-penalty `job_timeout`, after which it reads as
  dead.)
- `recover_stale_pipeline_jobs(db, redis, timeout, msg)` — lists stale
  PROCESSING candidates, keeps only the dead ones, bumps each dead job's
  generation counter (so a resurfacing zombie sub-job drops its writes through
  the existing generation gate), then fails just that subset.
- `JobDatabase.list_stale_processing_job_ids(timeout)` + an `only_ids=`
  restriction on the existing `recover_stale_jobs` (its concurrency-safe
  `RETURNING` UPDATE and bounded logging are unchanged; `only_ids=None`
  preserves the old behaviour, so all existing DB tests stay green).
- The frontend stale checker (`web/app.py`) now calls
  `recover_stale_pipeline_jobs`. The frontend already imports
  `pipeline_dispatcher` (via the upload route), so no new heavy deps reach the
  frontend image.

Net effect: the stale reaper becomes a safety net for genuinely-dead pipelines
instead of a guillotine for healthy queued work. Genuinely stuck *running*
sub-jobs are still bounded by RQ's per-sub-job death-penalty as before.

## Tests

- `is_pipeline_dead`: false when a sub-job is still queued (the 211 case),
  true when all sub-jobs are cancelled, true when no generation counter.
- `recover_stale_pipeline_jobs`: end-to-end — a dead pipeline is failed while
  an equally-old job still waiting in the queue is **spared**.
- DB: `list_stale_processing_job_ids` returns old PROCESSING only;
  `recover_stale_jobs(only_ids=...)` restricts the subset; `only_ids=[]` no-op.
- Full unit suite: 803 passed; ruff check + format clean.

## Scope

P0 of the batch-failure remediation, companion to #94. Capacity/throughput
items (2nd GPU worker on 220, queue split / +workers on 211, Ollama model
sizing, the recurring ~01:3x host reboot) remain ops follow-ups.