### PR TITLE
feat: minimal observability — JSON logs + /metrics + monitoring profile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -181,3 +181,17 @@ TRUST_PROXY_HEADERS=false
 # attempt, every stage start, etc.) and drop back to INFO once done —
 # DEBUG is too noisy for steady-state operation.
 # LOG_LEVEL=INFO
+# Emit one JSON object per log line (ts, level, logger, request_id, user_id,
+# message, plus structured fields — worker stage logs carry stage/job_id/
+# elapsed_ms) instead of the human-readable text format. Truthy values:
+# 1/true/yes/on. Default false. Set true in production for log aggregation
+# (Loki) and `jq` filtering. The text default stays easiest to read by eye.
+# LOG_JSON=false
+
+# -- Monitoring (optional) --
+# `docker compose --profile monitoring up -d` adds Prometheus + a Redis
+# exporter (uses REDIS_PASSWORD) + an AMD GPU exporter that scrape the
+# frontend /metrics endpoint and the box. No new required keys: VIDEO_GID /
+# RENDER_GID (set above for the ROCm worker) are reused by the GPU exporter.
+# Prometheus is bound to 127.0.0.1:9090 and /metrics is unauthenticated —
+# keep both internal / behind an authenticated proxy.

--- a/README.md
+++ b/README.md
@@ -438,9 +438,10 @@ three of those, which is why it is silenced.
 
 **Tunables.**
 
-| Variable    | Default | Description                                                                       |
-| ----------- | ------- | --------------------------------------------------------------------------------- |
-| `LOG_LEVEL` | `INFO`  | One of `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`; invalid values fall back. |
+| Variable    | Default | Description                                                                                                                                                                                                        |
+| ----------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `LOG_LEVEL` | `INFO`  | One of `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`; invalid values fall back.                                                                                                                                  |
+| `LOG_JSON`  | `false` | Truthy (`1`/`true`/`yes`/`on`) emits one JSON object per line (ts/level/logger/request_id/user_id/message + structured fields like `stage`/`job_id`/`elapsed_ms`) for Loki/`jq`. Default is the text format above. |
 
 The worker container starts via `python -m whisper_ui.worker`, which
 calls `setup_logging()` before delegating to RQ so the dictConfig (and
@@ -451,6 +452,39 @@ the RQ-noise suppression) applies inside the worker process.
 (100 MB per container). Larger deployments should plug a centralised
 driver (Loki, Splunk, Datadog) via a compose override; the file-driver
 ceiling is sized for small-office deployments only.
+
+### Observability: metrics & monitoring (minimal)
+
+The frontend exposes Prometheus metrics at **`/metrics`** — unauthenticated,
+same posture as `/health`, so keep it internal. They are computed at scrape
+time from RQ/Redis and the SQLite `jobs` table, with no persistent counters:
+
+| Metric                                         | Type  | Labels   | Source             |
+| ---------------------------------------------- | ----- | -------- | ------------------ |
+| `whisper_jobs_total`                           | gauge | `status` | SQLite `jobs`      |
+| `whisper_queue_depth`                          | gauge | `queue`  | RQ queue length    |
+| `whisper_failed_jobs` / `whisper_started_jobs` | gauge | `queue`  | RQ registries      |
+| `whisper_rq_workers`                           | gauge | —        | RQ worker registry |
+
+A Redis blip degrades the scrape to the SQLite-only metrics rather than failing
+it. Per-stage latency is intentionally **not** a metric here (workers have no
+HTTP server); it ships as `elapsed_ms` in the structured JSON logs
+(`LOG_JSON=true`) and a histogram is a follow-up.
+
+Bring up a self-hosted stack with the `monitoring` profile:
+
+```bash
+docker compose --profile rocm --profile monitoring up -d
+# Prometheus UI: http://127.0.0.1:9090/targets  (whisper-frontend / redis / gpu should be UP)
+```
+
+It adds **Prometheus** (config in `monitoring/prometheus.yml`), a **Redis
+exporter**, and an **AMD GPU exporter** (`rocm/device-metrics-exporter`,
+reusing the ROCm `/dev/kfd`+`/dev/dri` passthrough). Caveats: that GPU exporter
+is officially validated on Instinct (MI) GPUs — on a gfx1151 APU some fields may
+be empty; if so, fall back to `node_exporter` + an `amd-smi metric --json`
+textfile collector. Grafana dashboards are a deliberate follow-up — Prometheus
+alone is queryable in the meantime.
 
 ## Local Development
 

--- a/compose.yml
+++ b/compose.yml
@@ -389,8 +389,65 @@ services:
       ollama:
         condition: service_healthy
     restart: "no"
+  # -- Monitoring profile (minimal): docker compose --profile monitoring up -d
+  # Prometheus scrapes the frontend /metrics, the Redis exporter, and the AMD
+  # GPU exporter. Keep these on the internal network: /metrics and :9090 have
+  # NO auth, so :9090 is bound to 127.0.0.1 and an operator wanting remote
+  # access should front them with an authenticated reverse proxy. Grafana
+  # dashboards are a documented follow-up. Pin the :latest tags below to a
+  # specific digest/version before a production rollout.
+  prometheus:
+    profiles: [monitoring]
+    image: prom/prometheus:latest
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "127.0.0.1:9090:9090"
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "5"
+  redis-exporter:
+    profiles: [monitoring]
+    image: oliver006/redis_exporter:latest
+    environment:
+      - REDIS_ADDR=redis://redis:6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-}
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "5"
+  # AMD GPU metrics — reuses the same /dev/kfd + /dev/dri passthrough as the
+  # ROCm worker. NOTE: rocm/device-metrics-exporter is officially validated on
+  # Instinct (MI) GPUs; on a gfx1151 (Strix Halo APU) some fields may be empty.
+  # If so, fall back to node_exporter + an `amd-smi metric --json` textfile
+  # collector. Verify the image tag + gfx1151 coverage during the 211 rollout.
+  gpu-exporter:
+    profiles: [monitoring]
+    image: rocm/device-metrics-exporter:latest
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    group_add:
+      - "${VIDEO_GID:-44}"
+      - "${RENDER_GID:-993}"
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "5"
 volumes:
   app-data:
   redis-data:
   model-cache:
   ollama-data:
+  prometheus-data:

--- a/compose.yml
+++ b/compose.yml
@@ -10,6 +10,10 @@ services:
       - "8080:8000"
     environment:
       - REDIS_URL=redis://:${REDIS_PASSWORD:-}@redis:6379/0
+      # Logging knobs reach the container only if listed here — compose has no
+      # env_file, so a .env value alone would never apply. See README.
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - LOG_JSON=${LOG_JSON:-false}
       - DATABASE_PATH=/app/data/db/whisper_ui.db
       - UPLOAD_DIR=/app/data/uploads
       - OUTPUT_DIR=/app/data/outputs
@@ -46,6 +50,10 @@ services:
       - MAX_LOGIN_ATTEMPTS_PER_IP=${MAX_LOGIN_ATTEMPTS_PER_IP:-20}
       - LOGIN_LOCKOUT_SECONDS=${LOGIN_LOCKOUT_SECONDS:-900}
       - TRUST_PROXY_HEADERS=${TRUST_PROXY_HEADERS:-false}
+      # Registration gate + per-file upload cap (frontend-only; same
+      # pass-through reason as the logging knobs above).
+      - ALLOW_REGISTRATION=${ALLOW_REGISTRATION:-true}
+      - MAX_UPLOAD_SIZE=${MAX_UPLOAD_SIZE:-2147483648}
     volumes:
       - app-data:/app/data
     depends_on:
@@ -122,6 +130,10 @@ services:
       # a dedicated worker-io handles download / preprocess / llm_correction.
       - WORKER_QUEUES=${WORKER_GPU_QUEUES:-whisper:gpu whisper:io whisper:cpu default}
       - REDIS_URL=redis://:${REDIS_PASSWORD:-}@redis:6379/0
+      # Logging knobs reach the container only if listed here — compose has no
+      # env_file, so a .env value alone would never apply. See README.
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - LOG_JSON=${LOG_JSON:-false}
       - DATABASE_PATH=/app/data/db/whisper_ui.db
       - UPLOAD_DIR=/app/data/uploads
       - OUTPUT_DIR=/app/data/outputs
@@ -183,6 +195,10 @@ services:
       # `WORKER_CPU_QUEUES=whisper:cpu default` to specialise.
       - WORKER_QUEUES=${WORKER_CPU_QUEUES:-whisper:gpu whisper:io whisper:cpu default}
       - REDIS_URL=redis://:${REDIS_PASSWORD:-}@redis:6379/0
+      # Logging knobs reach the container only if listed here — compose has no
+      # env_file, so a .env value alone would never apply. See README.
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - LOG_JSON=${LOG_JSON:-false}
       - DATABASE_PATH=/app/data/db/whisper_ui.db
       - UPLOAD_DIR=/app/data/uploads
       - OUTPUT_DIR=/app/data/outputs
@@ -241,6 +257,10 @@ services:
     environment:
       - WORKER_QUEUES=${WORKER_ROCM_QUEUES:-whisper:gpu whisper:io whisper:cpu default}
       - REDIS_URL=redis://:${REDIS_PASSWORD:-}@redis:6379/0
+      # Logging knobs reach the container only if listed here — compose has no
+      # env_file, so a .env value alone would never apply. See README.
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - LOG_JSON=${LOG_JSON:-false}
       - DATABASE_PATH=/app/data/db/whisper_ui.db
       - UPLOAD_DIR=/app/data/uploads
       - OUTPUT_DIR=/app/data/outputs
@@ -312,6 +332,10 @@ services:
     environment:
       - WORKER_QUEUES=${WORKER_IO_QUEUES:-whisper:io whisper:cpu default}
       - REDIS_URL=redis://:${REDIS_PASSWORD:-}@redis:6379/0
+      # Logging knobs reach the container only if listed here — compose has no
+      # env_file, so a .env value alone would never apply. See README.
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - LOG_JSON=${LOG_JSON:-false}
       - DATABASE_PATH=/app/data/db/whisper_ui.db
       - UPLOAD_DIR=/app/data/uploads
       - OUTPUT_DIR=/app/data/outputs
@@ -433,6 +457,11 @@ services:
   gpu-exporter:
     profiles: [monitoring]
     image: rocm/device-metrics-exporter:latest
+    # /sys (read-only) is required by device-metrics-exporter for inband-RAS
+    # metrics per AMD's docker docs. The :5000 port stays internal — Prometheus
+    # scrapes gpu-exporter:5000 over the compose network, not the host.
+    volumes:
+      - /sys:/sys:ro
     devices:
       - /dev/kfd
       - /dev/dri

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,21 @@
+# Minimal Prometheus scrape config for the `monitoring` compose profile.
+# Targets resolve over the default compose network by service name. Mounted
+# read-only into the prometheus container at /etc/prometheus/prometheus.yml.
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+scrape_configs:
+  # Whisper-UI app metrics (queue depth, job status, RQ workers). The frontend
+  # container listens on 8000 internally (8080 is only the host port map).
+  - job_name: whisper-frontend
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["frontend:8000"]
+  # Redis / RQ internals (memory, clients, keyspace).
+  - job_name: redis
+    static_configs:
+      - targets: ["redis-exporter:9121"]
+  # AMD GPU metrics (rocm/device-metrics-exporter, default port 5000).
+  - job_name: gpu
+    static_configs:
+      - targets: ["gpu-exporter:5000"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ frontend = [
   # SessionMiddleware needs itsdangerous to sign session cookies. It is
   # not a transitive dependency of fastapi[standard], so list it here.
   "itsdangerous>=2.0,<3",
+  # /metrics endpoint (Prometheus exposition).
+  "prometheus-client>=0.21,<1",
 ]
 worker = [
   # whisperx is installed separately in Dockerfile (--no-deps) to avoid its

--- a/src/whisper_ui/core/logging_setup.py
+++ b/src/whisper_ui/core/logging_setup.py
@@ -1,8 +1,12 @@
 """Centralised logging configuration for the frontend and worker processes.
 
 Reads ``LOG_LEVEL`` from the environment (one of ``DEBUG``, ``INFO``,
-``WARNING``, ``ERROR``, ``CRITICAL``; default ``INFO``). ``LOG_JSON`` is
-reserved for a future structured-output mode and currently has no effect.
+``WARNING``, ``ERROR``, ``CRITICAL``; default ``INFO``). ``LOG_JSON``
+(truthy: ``1``/``true``/``yes``/``on``) switches the stderr handler to a
+single-line JSON formatter — ts/level/logger/request_id/user_id/message plus
+any structured ``extra={}`` fields (e.g. worker stage logs carry
+stage/job_id/elapsed_ms) — for log aggregation (Loki/jq). Default stays the
+human-readable text format.
 
 The :class:`RequestContextFilter` pulls ``request_id`` and ``user_id`` from
 context vars set by :mod:`whisper_ui.web.middleware.request_id`, so every
@@ -17,6 +21,7 @@ entrypoint call it once at process startup.
 
 from __future__ import annotations
 
+import json
 import logging
 import logging.config
 import os
@@ -108,6 +113,57 @@ def _resolve_level(raw: str | None) -> str:
     return candidate if candidate in _VALID_LEVELS else "INFO"
 
 
+_LOG_JSON_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _resolve_json(raw: str | None) -> bool:
+    return raw is not None and raw.strip().lower() in _LOG_JSON_TRUTHY
+
+
+# Standard LogRecord attributes plus the request-context fields rendered
+# explicitly. Anything NOT in here that a call site passed via ``extra={}``
+# is copied into the JSON object as a structured field.
+_RESERVED_LOGRECORD_ATTRS = frozenset(
+    {
+        "name", "msg", "args", "levelname", "levelno", "pathname", "filename",
+        "module", "exc_info", "exc_text", "stack_info", "lineno", "funcName",
+        "created", "msecs", "relativeCreated", "thread", "threadName",
+        "processName", "process", "taskName", "message", "asctime",
+        "request_id", "user_id",
+    }
+)  # fmt: skip
+
+
+class JsonFormatter(logging.Formatter):
+    """Render each LogRecord as one JSON line (selected when ``LOG_JSON`` is set).
+
+    Emits ts/level/logger/request_id/user_id/message, the rendered exception
+    under ``exc`` when present, and any structured ``extra={}`` fields passed at
+    the call site — so worker stage logs (stage/job_id/elapsed_ms) are queryable
+    by jq/Loki without per-call-site formatting. ``default=str`` keeps a
+    non-serialisable extra from breaking the line; ``ensure_ascii=False`` keeps
+    non-ASCII (e.g. Chinese) readable.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, object] = {
+            "ts": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            "request_id": getattr(record, "request_id", _DEFAULT_REQUEST_ID),
+            "user_id": getattr(record, "user_id", _DEFAULT_USER_ID),
+            "message": record.getMessage(),
+        }
+        for key, value in record.__dict__.items():
+            if key not in _RESERVED_LOGRECORD_ATTRS and not key.startswith("_"):
+                payload[key] = value
+        if record.exc_info:
+            payload["exc"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            payload["stack"] = self.formatStack(record.stack_info)
+        return json.dumps(payload, ensure_ascii=False, default=str)
+
+
 def setup_logging() -> None:
     """Apply the project-wide ``dictConfig``; safe to call multiple times.
 
@@ -118,6 +174,7 @@ def setup_logging() -> None:
     structured access log emitted from :mod:`whisper_ui.web.middleware.request_id`.
     """
     level = _resolve_level(os.getenv("LOG_LEVEL"))
+    formatter = "json" if _resolve_json(os.getenv("LOG_JSON")) else "default"
 
     config: dict = {
         "version": 1,
@@ -132,12 +189,16 @@ def setup_logging() -> None:
                 "format": ("%(asctime)s %(levelname)s %(name)s [req=%(request_id)s user=%(user_id)s] %(message)s"),
                 "datefmt": "%Y-%m-%dT%H:%M:%S%z",
             },
+            "json": {
+                "()": JsonFormatter,
+                "datefmt": "%Y-%m-%dT%H:%M:%S%z",
+            },
         },
         "handlers": {
             "stderr": {
                 "class": "logging.StreamHandler",
                 "stream": "ext://sys.stderr",
-                "formatter": "default",
+                "formatter": formatter,
                 "filters": ["request_context"],
             },
         },

--- a/src/whisper_ui/web/app.py
+++ b/src/whisper_ui/web/app.py
@@ -246,7 +246,7 @@ def create_app() -> FastAPI:
     templates.env.globals["export_formats"] = available_formats()
 
     # Routes
-    from whisper_ui.web.routes import admin, auth_routes, dashboard, jobs, upload, viewer
+    from whisper_ui.web.routes import admin, auth_routes, dashboard, jobs, metrics, upload, viewer
 
     application.include_router(auth_routes.router)
     application.include_router(dashboard.router)
@@ -254,6 +254,7 @@ def create_app() -> FastAPI:
     application.include_router(jobs.router)
     application.include_router(viewer.router)
     application.include_router(admin.router)
+    application.include_router(metrics.router)
 
     @application.get("/health")
     async def health():

--- a/src/whisper_ui/web/auth.py
+++ b/src/whisper_ui/web/auth.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 # ``/login/extra`` would still be gated — there's no nested route below
 # any of these so exact match is precise enough and avoids accidental
 # bypass via path traversal.
-PUBLIC_PATHS = frozenset({"/login", "/register", "/logout", "/health", "/favicon.ico"})
+PUBLIC_PATHS = frozenset({"/login", "/register", "/logout", "/health", "/metrics", "/favicon.ico"})
 
 # Path prefixes that never require authentication. ``/static/`` covers
 # CSS, vendored JS, and any future static assets.

--- a/src/whisper_ui/web/auth.py
+++ b/src/whisper_ui/web/auth.py
@@ -18,8 +18,9 @@ in practice:
   is paired with ``SameSite=Lax`` session cookies; htmx requests in the
   same browser context send a same-origin ``Origin`` header automatically.
 * **Public path whitelist** — ``/login``, ``/register``, ``/logout``,
-  ``/health``, ``/favicon.ico`` and anything under ``/static/`` skip the
-  auth gate so the login form and assets are reachable while signed out.
+  ``/health``, ``/metrics``, ``/favicon.ico`` and anything under ``/static/``
+  skip the auth gate so the login form, health check, Prometheus scrape and
+  assets are reachable while signed out.
 
 Dependencies (:data:`CurrentUserDep`, :data:`AdminUserDep`) read what the
 middleware put on ``request.state``; they do not re-query the DB.

--- a/src/whisper_ui/web/routes/metrics.py
+++ b/src/whisper_ui/web/routes/metrics.py
@@ -1,0 +1,106 @@
+"""Prometheus ``/metrics`` endpoint (minimal, scrape-time, pull-based).
+
+Exposes operational gauges computed on each scrape from the data the frontend
+already holds — RQ/Redis registries and the SQLite ``jobs`` table — with no
+persistent counters. A Redis blip degrades to the SQLite-only metrics instead
+of failing the scrape (mirrors the lifespan's tolerance of an unreachable
+Redis). The endpoint is unauthenticated (added to ``auth.PUBLIC_PATHS``, same
+posture as ``/health``); it exposes only counts/depths, no PII. An operator
+fronting the box publicly should block ``/metrics`` at the reverse proxy.
+
+Per-stage latency is intentionally NOT exposed here (workers have no HTTP
+server); it ships as ``elapsed_ms`` in the structured JSON logs and a
+histogram is a documented follow-up.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, Response
+from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest
+from prometheus_client.core import GaugeMetricFamily
+
+from whisper_ui.core.constants import WORKER_QUEUE_CPU, WORKER_QUEUE_GPU, WORKER_QUEUE_IO
+from whisper_ui.core.models import JobStatus
+
+# DbDep/RedisDep stay runtime imports: FastAPI evaluates these Depends
+# annotations at startup, so moving them into TYPE_CHECKING would NameError.
+from whisper_ui.web.deps import DbDep, RedisDep  # noqa: TC001
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from redis import Redis
+
+    from whisper_ui.storage.database import JobDatabase
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# RQ queues to report. "default" is the ad-hoc maintenance queue every worker
+# also subscribes to.
+_QUEUES = (WORKER_QUEUE_GPU, WORKER_QUEUE_IO, WORKER_QUEUE_CPU, "default")
+_STATUSES = tuple(s.value for s in JobStatus)
+
+
+class WhisperCollector:
+    """Scrape-time collector reading current state from SQLite + Redis/RQ.
+
+    ``collect()`` never raises: SQLite and Redis sections are independently
+    guarded so a failure in one still yields the other's metrics and the
+    scrape returns 200.
+    """
+
+    def __init__(self, db: JobDatabase, redis: Redis) -> None:
+        self._db = db
+        self._redis = redis
+
+    def collect(self) -> Iterator[GaugeMetricFamily]:
+        jobs = GaugeMetricFamily(
+            "whisper_jobs_total",
+            "Job rows by status (from SQLite).",
+            labels=["status"],
+        )
+        try:
+            counts = self._db.get_status_counts()
+            for status in _STATUSES:
+                jobs.add_metric([status], counts.get(status, 0))
+        except Exception:
+            logger.exception("metrics: get_status_counts failed; emitting empty whisper_jobs_total")
+        yield jobs
+
+        depth = GaugeMetricFamily("whisper_queue_depth", "Jobs waiting in each RQ queue.", labels=["queue"])
+        failed = GaugeMetricFamily("whisper_failed_jobs", "Jobs in each RQ failed registry.", labels=["queue"])
+        started = GaugeMetricFamily(
+            "whisper_started_jobs", "Jobs in each RQ started (in-flight) registry.", labels=["queue"]
+        )
+        workers = GaugeMetricFamily("whisper_rq_workers", "Registered RQ workers.")
+        try:
+            from rq import Queue, Worker
+            from rq.registry import FailedJobRegistry, StartedJobRegistry
+
+            for name in _QUEUES:
+                depth.add_metric([name], len(Queue(name, connection=self._redis)))
+                failed.add_metric([name], FailedJobRegistry(name, connection=self._redis).count)
+                started.add_metric([name], StartedJobRegistry(name, connection=self._redis).count)
+            workers.add_metric([], len(Worker.all(connection=self._redis)))
+        except Exception:
+            # Redis unreachable / RQ error → skip these gauges, keep the scrape healthy.
+            logger.exception("metrics: RQ/Redis collection failed; emitting SQLite metrics only")
+            return
+        yield depth
+        yield failed
+        yield started
+        yield workers
+
+
+@router.get("/metrics")
+async def metrics(db: DbDep, redis: RedisDep) -> Response:
+    # A fresh per-request registry keeps the collector stateless — no module
+    # globals, no double-registration across scrapes.
+    registry = CollectorRegistry()
+    registry.register(WhisperCollector(db, redis))
+    return Response(generate_latest(registry), media_type=CONTENT_TYPE_LATEST)

--- a/src/whisper_ui/worker/stage_tasks.py
+++ b/src/whisper_ui/worker/stage_tasks.py
@@ -216,6 +216,13 @@ def _log_stage_start(stage_name: str, parent_job_id: str) -> int:
         parent_job_id,
         generation if generation is not None else "-",
         timeout_seconds if timeout_seconds is not None else "-",
+        extra={
+            "event": "stage_start",
+            "stage": stage_name,
+            "job_id": parent_job_id,
+            "generation": generation,
+            "timeout_s": timeout_seconds,
+        },
     )
     return time.perf_counter_ns()
 
@@ -234,6 +241,12 @@ def _log_stage_finish(stage_name: str, parent_job_id: str, start_ns: int) -> Non
         stage_name,
         parent_job_id,
         elapsed_ms,
+        extra={
+            "event": "stage_finish",
+            "stage": stage_name,
+            "job_id": parent_job_id,
+            "elapsed_ms": elapsed_ms,
+        },
     )
 
 

--- a/tests/unit/test_logging_setup.py
+++ b/tests/unit/test_logging_setup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 
 import pytest
@@ -9,7 +10,9 @@ import pytest
 from whisper_ui.core.logging_setup import (
     _DEFAULT_REQUEST_ID,
     _DEFAULT_USER_ID,
+    JsonFormatter,
     RequestContextFilter,
+    _resolve_json,
     current_request_id,
     current_user_id,
     reset_request_context,
@@ -141,3 +144,82 @@ def test_request_context_isolated_across_nested_blocks():
         assert current_request_id() == "outer"
     finally:
         reset_request_context(outer)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("1", True),
+        ("true", True),
+        ("TRUE", True),
+        ("  Yes ", True),
+        ("on", True),
+        ("0", False),
+        ("false", False),
+        ("", False),
+        (None, False),
+        ("nope", False),
+    ],
+)
+def test_resolve_json(raw, expected):
+    assert _resolve_json(raw) is expected
+
+
+def test_json_formatter_emits_structured_extra_fields():
+    record = logging.LogRecord("w", logging.INFO, "p", 1, "Stage %s finished", ("diarize",), None)
+    record.request_id = "req-1"
+    record.user_id = "u-1"
+    record.event = "stage_finish"
+    record.stage = "diarize"
+    record.job_id = "abc123"
+    record.elapsed_ms = 651060
+
+    payload = json.loads(JsonFormatter(datefmt="%Y-%m-%dT%H:%M:%S%z").format(record))
+
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == "w"
+    assert payload["request_id"] == "req-1"
+    assert payload["user_id"] == "u-1"
+    assert payload["message"] == "Stage diarize finished"
+    assert payload["event"] == "stage_finish"
+    assert payload["stage"] == "diarize"
+    assert payload["job_id"] == "abc123"
+    assert payload["elapsed_ms"] == 651060
+
+
+def test_json_formatter_includes_rendered_exception():
+    import sys
+
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        record = logging.LogRecord("w", logging.ERROR, "p", 1, "failed", (), sys.exc_info())
+
+    payload = json.loads(JsonFormatter().format(record))
+
+    assert "ValueError: boom" in payload["exc"]
+
+
+def test_setup_logging_json_mode_outputs_one_json_object_per_line(monkeypatch, capsys):
+    monkeypatch.setenv("LOG_JSON", "true")
+    setup_logging()
+
+    logging.getLogger("whisper_ui.test").info("hello %s", "world", extra={"event": "x", "elapsed_ms": 5})
+
+    line = capsys.readouterr().err.strip().splitlines()[-1]
+    payload = json.loads(line)  # must be valid JSON
+    assert payload["message"] == "hello world"
+    assert payload["event"] == "x"
+    assert payload["elapsed_ms"] == 5
+    assert payload["request_id"] == _DEFAULT_REQUEST_ID  # no request context -> default dash
+
+
+def test_setup_logging_defaults_to_text_when_log_json_unset(monkeypatch, capsys):
+    monkeypatch.delenv("LOG_JSON", raising=False)
+    setup_logging()
+
+    logging.getLogger("whisper_ui.test").info("plain line")
+
+    captured = capsys.readouterr().err
+    assert "plain line" in captured
+    assert "[req=" in captured  # text format, not JSON

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,0 +1,70 @@
+"""Tests for the Prometheus /metrics collector."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import fakeredis
+from prometheus_client import CollectorRegistry, generate_latest
+
+from whisper_ui.core.models import Job, JobStatus
+from whisper_ui.storage.database import JobDatabase
+from whisper_ui.web.routes.metrics import WhisperCollector
+
+
+def _seed_jobs(db: JobDatabase, statuses: list[JobStatus]) -> None:
+    for status in statuses:
+        job = Job(filename="x.mp3", filepath="/tmp/x.mp3")
+        job.status = status
+        db.insert_job(job)
+
+
+def _scrape(db: JobDatabase, redis) -> str:
+    registry = CollectorRegistry()
+    registry.register(WhisperCollector(db, redis))
+    return generate_latest(registry).decode()
+
+
+def test_whisper_collector_reports_status_counts_and_queue_depth(tmp_path):
+    from rq import Queue
+
+    redis = fakeredis.FakeRedis()
+    db = JobDatabase(tmp_path / "m.db")
+    try:
+        _seed_jobs(
+            db,
+            [JobStatus.QUEUED, JobStatus.PROCESSING, JobStatus.COMPLETED, JobStatus.COMPLETED, JobStatus.FAILED],
+        )
+        Queue("whisper:gpu", connection=redis).enqueue("math.sqrt", 4)
+
+        out = _scrape(db, redis)
+
+        assert 'whisper_jobs_total{status="completed"} 2.0' in out
+        assert 'whisper_jobs_total{status="failed"} 1.0' in out
+        assert 'whisper_jobs_total{status="queued"} 1.0' in out
+        assert 'whisper_jobs_total{status="processing"} 1.0' in out
+        assert 'whisper_jobs_total{status="pending"} 0.0' in out  # missing status -> 0, series never disappears
+        assert 'whisper_queue_depth{queue="whisper:gpu"} 1.0' in out
+        assert 'whisper_queue_depth{queue="whisper:io"} 0.0' in out
+        assert "whisper_failed_jobs" in out
+        assert "whisper_started_jobs" in out
+        assert "whisper_rq_workers " in out
+    finally:
+        db.close()
+
+
+def test_whisper_collector_degrades_when_redis_fails(tmp_path):
+    """A Redis failure must not break the scrape: SQLite job metrics still emit,
+    queue gauges are skipped, and collect() never raises."""
+    db = JobDatabase(tmp_path / "m.db")
+    try:
+        _seed_jobs(db, [JobStatus.COMPLETED])
+        broken = MagicMock()
+        broken.llen.side_effect = RuntimeError("redis down")
+
+        out = _scrape(db, broken)  # must not raise
+
+        assert 'whisper_jobs_total{status="completed"} 1.0' in out
+        assert "whisper_queue_depth" not in out  # redis gauges skipped on failure
+    finally:
+        db.close()

--- a/tests/unit/test_web_routes.py
+++ b/tests/unit/test_web_routes.py
@@ -89,6 +89,16 @@ class TestHealthEndpoint:
         assert resp.json() == {"status": "ok"}
 
 
+class TestMetricsEndpoint:
+    def test_metrics_returns_prometheus_exposition(self, client):
+        # app fixture uses a MagicMock redis, so the RQ gauges degrade out; the
+        # SQLite job metric must still render and the scrape must be 200.
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        assert "text/plain" in resp.headers["content-type"]
+        assert "whisper_jobs_total" in resp.text
+
+
 class TestDashboardRoutes:
     def test_root_serves_dashboard(self, client):
         resp = client.get("/")

--- a/uv.lock
+++ b/uv.lock
@@ -2393,6 +2393,15 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3911,6 +3920,7 @@ dev = [
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
     { name = "itsdangerous" },
+    { name = "prometheus-client" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-playwright" },
@@ -3920,6 +3930,7 @@ frontend = [
     { name = "argon2-cffi" },
     { name = "fastapi", extra = ["standard"] },
     { name = "itsdangerous" },
+    { name = "prometheus-client" },
     { name = "python-docx" },
 ]
 worker = [
@@ -3953,6 +3964,7 @@ requires-dist = [
     { name = "omegaconf", marker = "extra == 'worker'", specifier = ">=2.3.0" },
     { name = "opencc-python-reimplemented", marker = "extra == 'worker'", specifier = ">=0.1.7" },
     { name = "pandas", marker = "extra == 'worker'", specifier = ">=2.2.3" },
+    { name = "prometheus-client", marker = "extra == 'frontend'", specifier = ">=0.21,<1" },
     { name = "pyannote-audio", marker = "extra == 'worker'", specifier = ">=4.0.0" },
     { name = "pydantic", specifier = ">=2.0,<3" },
     { name = "pydantic-settings", specifier = ">=2.0,<3" },


### PR DESCRIPTION
## Why

The deployments (esp. the AMD prod box) have **no monitoring** — when a batch
stalls or fails there's nothing to scrape. This adds a *minimal* observability
layer (the explicitly-chosen "minimal start"): structured logs + one `/metrics`
endpoint + a basic exporter stack. Grafana dashboards and per-stage latency
histograms are deliberate follow-ups.

## What

**Structured JSON logs** (`core/logging_setup.py`)
- Implements the previously-reserved `LOG_JSON` env (stdlib `JsonFormatter`, no
  new dep). **Text stays the default**; JSON is opt-in for Loki/`jq`.
- Worker stage logs (`stage_tasks.py`) gain structured `extra={}` fields
  (`event`/`stage`/`job_id`/`elapsed_ms`) — **text output is byte-identical**,
  the fields only surface in JSON mode.

**`/metrics` endpoint** (`web/routes/metrics.py`, unauthenticated like `/health`)
- A scrape-time, pull-based collector — no persistent counters:
  `whisper_jobs_total{status}` (SQLite), `whisper_queue_depth{queue}`,
  `whisper_failed_jobs`/`whisper_started_jobs{queue}`, `whisper_rq_workers`
  (RQ/Redis).
- **Degrades** to the SQLite-only metrics on a Redis blip rather than failing
  the scrape; `collect()` never raises.
- `prometheus-client` added to the `frontend` extra (`uv.lock` updated).

**`monitoring` compose profile** + `monitoring/prometheus.yml`
- Prometheus + `redis_exporter` (uses `REDIS_PASSWORD`) + AMD
  `rocm/device-metrics-exporter` (reuses the ROCm `/dev/kfd`+`/dev/dri`
  passthrough). Prometheus bound to `127.0.0.1`. `:latest` tags flagged to pin
  before prod; the GPU exporter's gfx1151 coverage is flagged to verify (with a
  `node_exporter` + `amd-smi` textfile fallback documented).

`.env.example` + README updated (new "Observability (minimal)" section).

## Tests
- JSON formatter: structured extras, exception rendering, JSON-vs-text mode,
  `_resolve_json` truthiness.
- Collector: full metrics with fakeredis; **degradation** when Redis fails.
- `/metrics` endpoint returns 200 + Prometheus content-type.
- Full unit suite: **828 passed**; ruff + pre-commit clean.

## Scope
Part 1 of the 211 optimization effort (see plan). Part 2 (queue-split topology
+ throughput test + Redis maxmemory + CHANGELOG) is a separate PR; then a
v2.8.0 release ships both — plus the already-merged #94/#95 — to 211.