### PR TITLE
feat: 211 queue-split topology docs + Redis maxmemory; v2.8.0 changelog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,10 +7,10 @@ REDIS_URL=redis://redis:6379/0
 # Defensive memory cap for the Redis server (-> `redis-server --maxmemory`).
 # Default 0 = unlimited (current behaviour). Set e.g. 2gb on a busy box so a
 # pathological backlog fails writes loudly (OOM) instead of eating all host
-# RAM. Keep the policy at noeviction: RQ generation counters / sub-job sets /
-# pipeline context must never be evicted or the DAG corrupts.
+# RAM. The eviction policy is hardcoded to noeviction in compose and is NOT
+# configurable: RQ generation counters / sub-job sets / pipeline context must
+# never be evicted or the DAG corrupts.
 # REDIS_MAXMEMORY=0
-# REDIS_MAXMEMORY_POLICY=noeviction
 
 # Storage (paths inside container)
 DATABASE_PATH=/app/data/db/whisper_ui.db

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,13 @@ REDIS_URL=redis://redis:6379/0
 # When set, compose.yml will pass --requirepass to the Redis server
 # and include the password in REDIS_URL for all services.
 # REDIS_PASSWORD=
+# Defensive memory cap for the Redis server (-> `redis-server --maxmemory`).
+# Default 0 = unlimited (current behaviour). Set e.g. 2gb on a busy box so a
+# pathological backlog fails writes loudly (OOM) instead of eating all host
+# RAM. Keep the policy at noeviction: RQ generation counters / sub-job sets /
+# pipeline context must never be evicted or the DAG corrupts.
+# REDIS_MAXMEMORY=0
+# REDIS_MAXMEMORY_POLICY=noeviction
 
 # Storage (paths inside container)
 DATABASE_PATH=/app/data/db/whisper_ui.db
@@ -47,6 +54,13 @@ BATCH_SIZE=4
 # RENDER_GID=993
 # WORKER_ROCM_QUEUES: queues the rocm worker listens on.
 # WORKER_ROCM_QUEUES=whisper:gpu whisper:io whisper:cpu default
+# AMD single-GPU scaled topology: keep the rocm worker on GPU stages only and
+# run a separate CPU worker for io/cpu so download / preprocess / llm / assign /
+# postprocess never block transcribe/diarize. Do NOT scale worker-rocm past 1
+# on one card (VRAM/compute contention).
+#   WORKER_ROCM_QUEUES="whisper:gpu default"
+#   WORKER_IO_QUEUES="whisper:io whisper:cpu default"
+#   docker compose --profile rocm --profile io up -d --scale worker-io=2
 
 # Language
 LANGUAGE=zh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `monitoring` compose profile (Prometheus + Redis exporter + AMD GPU
   exporter). Grafana dashboards and per-stage histograms are deliberate
   follow-ups. (#96)
-- Defensive Redis memory cap via `REDIS_MAXMEMORY` / `REDIS_MAXMEMORY_POLICY`
-  (default `0` / `noeviction` preserves current behaviour). `noeviction` is
-  mandatory — RQ generation counters and pipeline context must never be
-  evicted.
+- Defensive Redis memory cap via `REDIS_MAXMEMORY` (default `0` = unlimited
+  preserves current behaviour). The eviction policy is hardcoded to
+  `noeviction` and is not configurable — RQ generation counters, sub-job sets,
+  and pipeline context must never be evicted or the DAG corrupts.
 - AMD/ROCm single-GPU scaled-topology docs and `.env.example` example (narrow
   `worker-rocm` to GPU stages, run a separate `worker-io`).
 - Deterministic queue-split throughput integration test. (#97)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.8.0] - 2026-06-08
+
+### Added
+
+- Minimal observability: opt-in structured JSON logs via `LOG_JSON` (worker
+  stage logs carry `stage` / `job_id` / `elapsed_ms`), an unauthenticated
+  Prometheus `/metrics` endpoint (queue depth, job status, RQ workers), and a
+  `monitoring` compose profile (Prometheus + Redis exporter + AMD GPU
+  exporter). Grafana dashboards and per-stage histograms are deliberate
+  follow-ups. (#96)
+- Defensive Redis memory cap via `REDIS_MAXMEMORY` / `REDIS_MAXMEMORY_POLICY`
+  (default `0` / `noeviction` preserves current behaviour). `noeviction` is
+  mandatory — RQ generation counters and pipeline context must never be
+  evicted.
+- AMD/ROCm single-GPU scaled-topology docs and `.env.example` example (narrow
+  `worker-rocm` to GPU stages, run a separate `worker-io`).
+- Deterministic queue-split throughput integration test. (#97)
+
+### Fixed
+
+- Optional LLM correction is now strictly best-effort: a failed or timed-out
+  `run_llm_correction` completes the job with the un-corrected transcript
+  instead of failing it, and a persist failure marks the job FAILED rather than
+  leaving it stuck in PROCESSING. (#94)
+- The stale-job reaper is now liveness-based (`is_pipeline_dead` via RQ sub-job
+  state) instead of wall-age, so a queued-but-waiting job behind a slow single
+  worker is no longer mass-reaped; `PIPELINE_STATE_TTL` raised from 24h to 7d.
+  (#95)
+- Documented runtime knobs now reach the containers. compose has no `env_file`,
+  so `LOG_LEVEL` / `LOG_JSON` (frontend + all workers) and `ALLOW_REGISTRATION`
+  / `MAX_UPLOAD_SIZE` (frontend) are passed explicitly; previously a `.env`
+  value for these was silently ignored — notably an `ALLOW_REGISTRATION=false`
+  registration lockdown. (#96)
+
 ## [2.7.0] - 2026-06-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -242,6 +242,24 @@ back overlap: job B can be downloading while job A is on the GPU, and
 job A can be in llm_correction (hitting an external Ollama server) while
 job B is already transcribing.
 
+**AMD / ROCm single-GPU box.** The ROCm worker has a single GPU, so the
+same split applies — keep it on GPU stages only and run a separate CPU
+worker for the rest:
+
+```bash
+# .env
+WORKER_ROCM_QUEUES="whisper:gpu default"
+WORKER_IO_QUEUES="whisper:io whisper:cpu default"
+
+docker compose --profile rocm --profile io up -d --scale worker-io=2
+```
+
+`worker-io` uses the CPU image (the io/cpu stages need no GPU), so two
+replicas drain download / preprocess / assign / postprocess / llm while
+the single `worker-rocm` stays dedicated to transcribe_align / diarize. Do
+**not** scale `worker-rocm` past one on a single card — two whisper.cpp /
+pyannote processes would contend for the same VRAM and compute queue.
+
 **Multi-GPU hosts.** When the DAG fans out transcribe_align and diarize
 as sibling branches they will automatically run in parallel once you
 provision more than one GPU worker. Example with two cards:

--- a/compose.yml
+++ b/compose.yml
@@ -74,7 +74,7 @@ services:
         max-file: "5"
   redis:
     image: redis:7-alpine
-    command: redis-server --appendonly yes ${REDIS_PASSWORD:+--requirepass "${REDIS_PASSWORD}"}
+    command: redis-server --appendonly yes --maxmemory ${REDIS_MAXMEMORY:-0} --maxmemory-policy ${REDIS_MAXMEMORY_POLICY:-noeviction} ${REDIS_PASSWORD:+--requirepass "${REDIS_PASSWORD}"}
     volumes:
       - redis-data:/data
     healthcheck:

--- a/compose.yml
+++ b/compose.yml
@@ -74,7 +74,11 @@ services:
         max-file: "5"
   redis:
     image: redis:7-alpine
-    command: redis-server --appendonly yes --maxmemory ${REDIS_MAXMEMORY:-0} --maxmemory-policy ${REDIS_MAXMEMORY_POLICY:-noeviction} ${REDIS_PASSWORD:+--requirepass "${REDIS_PASSWORD}"}
+    # maxmemory-policy is hardcoded to noeviction on purpose: this Redis holds
+    # only work-queue / DAG state (RQ registries, generation counters, sub-job
+    # sets, pipeline context) — none of it is safe to evict, so an eviction
+    # policy would silently corrupt the pipeline. Only the cap VALUE is tunable.
+    command: redis-server --appendonly yes --maxmemory ${REDIS_MAXMEMORY:-0} --maxmemory-policy noeviction ${REDIS_PASSWORD:+--requirepass "${REDIS_PASSWORD}"}
     volumes:
       - redis-data:/data
     healthcheck:


### PR DESCRIPTION
## Why

Prep for the v2.8.0 release that ships the merged P0 fixes (#94/#95) and the
observability/throughput work (#96/#97) to the AMD/ROCm prod box (211), plus
the config/docs that box's optimization needs. No application code changes —
the queue split is a deploy-time queue-binding concern the repo already
supports (`WORKER_ROCM_QUEUES` + the `worker-io` `io` profile).

## What

- **Redis memory cap (defensive).** `compose` redis now takes
  `REDIS_MAXMEMORY` / `REDIS_MAXMEMORY_POLICY`. Default `0` / `noeviction`
  renders identically to today (verified via `docker compose config`), so no
  behaviour change for existing deployments. `noeviction` is **required** — RQ
  generation counters, sub-job sets, and pickled pipeline context must never be
  evicted or the DAG corrupts; the cap just makes a pathological backlog fail
  writes loudly instead of eating host RAM.
- **AMD/ROCm single-GPU scaled topology** documented in `README` + an
  `.env.example` example: narrow `worker-rocm` to `whisper:gpu default` and run
  a separate `worker-io` (`--scale worker-io=2`) so download / preprocess /
  llm / assign / postprocess stop blocking transcribe/diarize. Includes the
  **don't scale `worker-rocm` past one** caveat (single card → VRAM/compute
  contention).
- **CHANGELOG `[2.8.0]`** collecting #94 (LLM best-effort), #95 (liveness
  stale reaper), #96 (observability + the env-passthrough fix), #97 (throughput
  test), and this change.

## Verification

- `docker compose config` renders `--maxmemory 0 --maxmemory-policy noeviction`
  by default and `--maxmemory 2gb ...` under `REDIS_MAXMEMORY=2gb`; full config
  validates across gpu/cpu/rocm/io/monitoring profiles.
- pre-commit (prettier / markdownlint / yamlfmt) clean.

## Next

After this merges, cut `v2.8.0` (tag triggers the ROCm image publish), then
deploy to 211 per the plan (queue split + `--scale worker-io=2` +
`OLLAMA_MODEL=gemma4:26b`, keeping `RENDER_GID=110`) — each prod step
confirmed individually.