### PR TITLE
chore: release v2.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.7.0"
+version = "2.8.0"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3904,7 +3904,7 @@ wheels = [
 
 [[package]]
 name = "whisper-ui"
-version = "2.7.0"
+version = "2.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Release **v2.8.0**. Bumps `pyproject.toml` / `uv.lock` to 2.8.0; the
`CHANGELOG [2.8.0]` entry landed with #98.

Collects since v2.7.0:

- **#94** LLM correction is strictly best-effort (un-corrected transcript on
  failure; never leaves a job stuck in PROCESSING).
- **#95** Liveness-based stale-job reaper (no more mass-reaping queued work);
  `PIPELINE_STATE_TTL` 24h → 7d.
- **#96** Minimal observability: `LOG_JSON` structured logs, `/metrics`, a
  `monitoring` compose profile; plus the fix that documented `.env` knobs
  (`LOG_*`, `ALLOW_REGISTRATION`, `MAX_UPLOAD_SIZE`) actually reach containers.
- **#97** Deterministic queue-split throughput integration test.
- **#98** AMD/ROCm single-GPU scaled-topology docs + defensive `REDIS_MAXMEMORY`
  cap (policy hardcoded to `noeviction`).

Tagging `v2.8.0` after merge triggers the GHCR image publish, including the
ROCm worker image (`worker-rocm:2.8.0`, ~38 GB, tag-gated).