### PR TITLE
feat: dedicated whisper:llm queue + disable Ollama thinking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,15 +52,18 @@ BATCH_SIZE=4
 # with `getent group video render`. Defaults (44 / 993) suit a Strix Halo box.
 # VIDEO_GID=44
 # RENDER_GID=993
-# WORKER_ROCM_QUEUES: queues the rocm worker listens on.
-# WORKER_ROCM_QUEUES=whisper:gpu whisper:io whisper:cpu default
-# AMD single-GPU scaled topology: keep the rocm worker on GPU stages only and
-# run a separate CPU worker for io/cpu so download / preprocess / llm / assign /
-# postprocess never block transcribe/diarize. Do NOT scale worker-rocm past 1
-# on one card (VRAM/compute contention).
+# WORKER_ROCM_QUEUES / WORKER_IO_QUEUES / WORKER_LLM_QUEUES: queues each worker
+# listens on. Defaults include every queue (incl. whisper:llm) so a single
+# worker still runs the whole pipeline.
+# WORKER_ROCM_QUEUES=whisper:gpu whisper:io whisper:cpu whisper:llm default
+# AMD single-GPU scaled topology: keep the rocm worker on GPU stages only, run a
+# separate CPU worker for io/cpu, and a dedicated worker for the slow optional
+# LLM correction so it never blocks the io/cpu finalisation path. Do NOT scale
+# worker-rocm past 1 on one card (VRAM/compute contention).
 #   WORKER_ROCM_QUEUES="whisper:gpu default"
 #   WORKER_IO_QUEUES="whisper:io whisper:cpu default"
-#   docker compose --profile rocm --profile io up -d --scale worker-io=2
+#   WORKER_LLM_QUEUES="whisper:llm default"
+#   docker compose --profile rocm --profile io --profile llm-worker up -d --scale worker-io=2
 
 # Language
 LANGUAGE=zh
@@ -114,6 +117,11 @@ HF_TOKEN=
 # LLM_CHUNK_SIZE=8
 # LLM_CHUNK_CONTEXT=2
 # LLM_TEMPERATURE=0.1
+# Let a thinking-capable model emit chain-of-thought before its answer. Default
+# false: for JSON transcript correction, thinking is markedly slower and (on
+# gemma-class models) degrades the output. Set true only if a reasoning model
+# is shown to help.
+# OLLAMA_THINK=false
 
 # GPU pinning (multi-GPU hosts).
 # WORKER_GPU_DEVICE_ID pins the Whisper worker whenever the gpu profile is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Dedicated `whisper:llm` queue for the optional LLM correction stage, plus a
   `worker-llm` compose service (`llm-worker` profile) and `WORKER_LLM_QUEUES`.
-  The slow LLM stage no longer shares a worker with the fast io/cpu
-  finalisation, so a slow Ollama model can no longer starve `whisper:cpu` from
-  draining. Single-container deployments are unchanged — every worker still
-  drains `whisper:llm` by default.
+  This lets a dedicated `worker-llm` run the slow LLM without blocking the fast
+  io/cpu finalisation — previously `llm_correction` shared `whisper:io`, so the
+  io worker (which also drains `whisper:cpu`) was held up by a slow model.
+  Default / single-container deployments still run everything on one worker
+  (every worker drains `whisper:llm` by default); the isolation is opt-in via
+  the `llm-worker` profile.
 - `OLLAMA_THINK` (default `false`) to disable a thinking-capable Ollama model's
   chain-of-thought. For JSON transcript correction, thinking is markedly slower
   and (on gemma-class models) degrades the output; off is faster and cleaner.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   chain-of-thought. For JSON transcript correction, thinking is markedly slower
   and (on gemma-class models) degrades the output; off is faster and cleaner.
 
+### Migration
+
+- **Scaled topologies with LLM correction:** because `llm_correction` moved off
+  `whisper:io` to its own `whisper:llm` queue, a deployment that explicitly
+  narrows `WORKER_*_QUEUES` and has `OLLAMA_BASE_URL` set must ensure some worker
+  listens on `whisper:llm` — add it to a worker's queue list (e.g.
+  `WORKER_IO_QUEUES="whisper:io whisper:cpu whisper:llm default"`) or run a
+  dedicated `worker-llm` (`--profile llm-worker`). Otherwise an LLM-enabled job's
+  final stage strands with no consumer. Default and single-container deployments
+  are unaffected (every worker drains `whisper:llm` by default).
+
 ## [2.8.0] - 2026-06-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.9.0] - 2026-06-09
+
+### Added
+
+- Dedicated `whisper:llm` queue for the optional LLM correction stage, plus a
+  `worker-llm` compose service (`llm-worker` profile) and `WORKER_LLM_QUEUES`.
+  The slow LLM stage no longer shares a worker with the fast io/cpu
+  finalisation, so a slow Ollama model can no longer starve `whisper:cpu` from
+  draining. Single-container deployments are unchanged — every worker still
+  drains `whisper:llm` by default.
+- `OLLAMA_THINK` (default `false`) to disable a thinking-capable Ollama model's
+  chain-of-thought. For JSON transcript correction, thinking is markedly slower
+  and (on gemma-class models) degrades the output; off is faster and cleaner.
+
 ## [2.8.0] - 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ $remote_addr;` (overrides any client-sent header).
 
 Each upload is dispatched as an RQ **DAG of sub-jobs** (one per pipeline
 stage) rather than a single monolithic task. Sub-jobs are routed to
-resource-class queues so a long-running IO or network stage never blocks
-a GPU worker from picking up the next job:
+resource-class queues so that, in a scaled topology (below), a long-running
+IO or network stage need not block a GPU worker from picking up the next job:
 
 | Queue         | Stages                            |
 | ------------- | --------------------------------- |
@@ -243,11 +243,12 @@ back to back overlap: job B can be downloading while job A is on the GPU.
 (Keeping `whisper:llm` here means the io worker also runs LLM correction; to
 isolate a slow LLM onto its own worker, see the AMD example below.)
 
-The optional, slow LLM correction has its own `whisper:llm` queue so it
-cannot starve the fast io/cpu finalisation path. Every worker drains it by
-default; on a host where the LLM is slow, run a dedicated `worker-llm` (the
-`llm-worker` profile) and drop `whisper:llm` from the other workers'
-`WORKER_*_QUEUES` — see the AMD example below.
+The optional, slow LLM correction has its own `whisper:llm` queue, so a
+dedicated `worker-llm` (the `llm-worker` profile) can run it without blocking
+the fast io/cpu finalisation path. Every worker drains `whisper:llm` by
+default, so by default a slow LLM still shares a worker with io/cpu; the
+isolation is opt-in — run `worker-llm` and drop `whisper:llm` from the other
+workers' `WORKER_*_QUEUES` (see the AMD example below).
 
 **AMD / ROCm single-GPU box.** The ROCm worker has a single GPU, so the same
 split applies, plus a dedicated LLM worker so a slow Ollama model never blocks

--- a/README.md
+++ b/README.md
@@ -213,11 +213,12 @@ stage) rather than a single monolithic task. Sub-jobs are routed to
 resource-class queues so a long-running IO or network stage never blocks
 a GPU worker from picking up the next job:
 
-| Queue         | Stages                                     |
-| ------------- | ------------------------------------------ |
-| `whisper:gpu` | `transcribe_align`, `diarize`              |
-| `whisper:io`  | `download`, `preprocess`, `llm_correction` |
-| `whisper:cpu` | `assign_speakers`, `postprocess`           |
+| Queue         | Stages                            |
+| ------------- | --------------------------------- |
+| `whisper:gpu` | `transcribe_align`, `diarize`     |
+| `whisper:io`  | `download`, `preprocess`          |
+| `whisper:cpu` | `assign_speakers`, `postprocess`  |
+| `whisper:llm` | `llm_correction` (optional, slow) |
 
 **Single-container (default).** `docker compose --profile gpu up -d` keeps
 the existing behaviour: `worker-gpu` listens to every queue so one
@@ -236,29 +237,37 @@ docker compose --profile gpu --profile io up -d
 ```
 
 `worker-io` is a lightweight CPU container that drains `whisper:io`
-(download / preprocess / llm_correction) in parallel with `worker-gpu`
-running transcribe_align / diarize on the GPU. Two jobs enqueued back to
-back overlap: job B can be downloading while job A is on the GPU, and
-job A can be in llm_correction (hitting an external Ollama server) while
-job B is already transcribing.
+(download / preprocess) in parallel with `worker-gpu` running
+transcribe_align / diarize on the GPU. Two jobs enqueued back to back
+overlap: job B can be downloading while job A is on the GPU.
 
-**AMD / ROCm single-GPU box.** The ROCm worker has a single GPU, so the
-same split applies — keep it on GPU stages only and run a separate CPU
-worker for the rest:
+The optional, slow LLM correction has its own `whisper:llm` queue so it
+cannot starve the fast io/cpu finalisation path. Every worker drains it by
+default; on a host where the LLM is slow, run a dedicated `worker-llm` (the
+`llm-worker` profile) and drop `whisper:llm` from the other workers'
+`WORKER_*_QUEUES` — see the AMD example below.
+
+**AMD / ROCm single-GPU box.** The ROCm worker has a single GPU, so the same
+split applies, plus a dedicated LLM worker so a slow Ollama model never blocks
+the io/cpu path:
 
 ```bash
 # .env
 WORKER_ROCM_QUEUES="whisper:gpu default"
 WORKER_IO_QUEUES="whisper:io whisper:cpu default"
+WORKER_LLM_QUEUES="whisper:llm default"
 
-docker compose --profile rocm --profile io up -d --scale worker-io=2
+docker compose --profile rocm --profile io --profile llm-worker up -d --scale worker-io=2
 ```
 
-`worker-io` uses the CPU image (the io/cpu stages need no GPU), so two
-replicas drain download / preprocess / assign / postprocess / llm while
-the single `worker-rocm` stays dedicated to transcribe_align / diarize. Do
-**not** scale `worker-rocm` past one on a single card — two whisper.cpp /
-pyannote processes would contend for the same VRAM and compute queue.
+`worker-io` (×2) and `worker-llm` use the CPU image (none of these stages need
+the GPU). `worker-io` drains download / preprocess / assign / postprocess;
+`worker-llm` drains the optional LLM correction (HTTP calls to Ollama); the
+single `worker-rocm` stays dedicated to transcribe_align / diarize. Do **not**
+scale `worker-rocm` past one on a single card — two whisper.cpp / pyannote
+processes would contend for the same VRAM and compute queue. Ollama itself
+still shares the GPU with the worker; if that contention hurts transcription,
+point Ollama at CPU or use a smaller model.
 
 **Multi-GPU hosts.** When the DAG fans out transcribe_align and diarize
 as sibling branches they will automatically run in parallel once you

--- a/README.md
+++ b/README.md
@@ -231,15 +231,17 @@ add the `io` profile and narrow the GPU worker's queue set:
 ```bash
 # .env
 WORKER_GPU_QUEUES="whisper:gpu default"
-WORKER_IO_QUEUES="whisper:io whisper:cpu default"
+WORKER_IO_QUEUES="whisper:io whisper:cpu whisper:llm default"
 
 docker compose --profile gpu --profile io up -d
 ```
 
 `worker-io` is a lightweight CPU container that drains `whisper:io`
-(download / preprocess) in parallel with `worker-gpu` running
-transcribe_align / diarize on the GPU. Two jobs enqueued back to back
-overlap: job B can be downloading while job A is on the GPU.
+(download / preprocess), `whisper:cpu`, and `whisper:llm` in parallel with
+`worker-gpu` running transcribe_align / diarize on the GPU. Two jobs enqueued
+back to back overlap: job B can be downloading while job A is on the GPU.
+(Keeping `whisper:llm` here means the io worker also runs LLM correction; to
+isolate a slow LLM onto its own worker, see the AMD example below.)
 
 The optional, slow LLM correction has its own `whisper:llm` queue so it
 cannot starve the fast io/cpu finalisation path. Every worker drains it by
@@ -396,15 +398,16 @@ server, or split Whisper and Ollama onto separate GPUs as above.
 
 **Tuning (all optional):**
 
-| Variable                 | Default      | Description                                                                            |
-| ------------------------ | ------------ | -------------------------------------------------------------------------------------- |
-| `OLLAMA_BASE_URL`        | (empty)      | Empty disables the feature globally. Set to reach a bundled or external Ollama server. |
-| `OLLAMA_MODEL`           | `gemma4:e4b` | Any Ollama-compatible chat model. Bigger = better accuracy, more VRAM (see note).      |
-| `OLLAMA_KEEP_ALIVE`      | `30m`        | How long Ollama keeps the model loaded in VRAM between requests.                       |
-| `OLLAMA_REQUEST_TIMEOUT` | `120`        | Per-request timeout in seconds.                                                        |
-| `LLM_CHUNK_SIZE`         | `8`          | Segments corrected per Ollama request. Larger reduces HTTP overhead.                   |
-| `LLM_CHUNK_CONTEXT`      | `2`          | Neighbor segments attached as read-only context for disambiguation.                    |
-| `LLM_TEMPERATURE`        | `0.1`        | Sampling temperature. Low values keep corrections deterministic.                       |
+| Variable                 | Default      | Description                                                                                                                                                      |
+| ------------------------ | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OLLAMA_BASE_URL`        | (empty)      | Empty disables the feature globally. Set to reach a bundled or external Ollama server.                                                                           |
+| `OLLAMA_MODEL`           | `gemma4:e4b` | Any Ollama-compatible chat model. Bigger = better accuracy, more VRAM (see note).                                                                                |
+| `OLLAMA_KEEP_ALIVE`      | `30m`        | How long Ollama keeps the model loaded in VRAM between requests.                                                                                                 |
+| `OLLAMA_REQUEST_TIMEOUT` | `120`        | Per-request timeout in seconds.                                                                                                                                  |
+| `LLM_CHUNK_SIZE`         | `8`          | Segments corrected per Ollama request. Larger reduces HTTP overhead.                                                                                             |
+| `LLM_CHUNK_CONTEXT`      | `2`          | Neighbor segments attached as read-only context for disambiguation.                                                                                              |
+| `LLM_TEMPERATURE`        | `0.1`        | Sampling temperature. Low values keep corrections deterministic.                                                                                                 |
+| `OLLAMA_THINK`           | `false`      | Let a thinking-capable model reason before answering. Off is faster and gives cleaner JSON for correction; set `true` only for a reasoning model proven to help. |
 
 ### Optional upload retention
 

--- a/compose.yml
+++ b/compose.yml
@@ -132,7 +132,7 @@ services:
       # pipeline end-to-end. For the scaled topology, set
       # `WORKER_GPU_QUEUES=whisper:gpu default` and add the `io` profile so
       # a dedicated worker-io handles download / preprocess / llm_correction.
-      - WORKER_QUEUES=${WORKER_GPU_QUEUES:-whisper:gpu whisper:io whisper:cpu default}
+      - WORKER_QUEUES=${WORKER_GPU_QUEUES:-whisper:gpu whisper:io whisper:cpu whisper:llm default}
       - REDIS_URL=redis://:${REDIS_PASSWORD:-}@redis:6379/0
       # Logging knobs reach the container only if listed here — compose has no
       # env_file, so a .env value alone would never apply. See README.
@@ -164,6 +164,7 @@ services:
       - LLM_CHUNK_SIZE=${LLM_CHUNK_SIZE:-8}
       - LLM_CHUNK_CONTEXT=${LLM_CHUNK_CONTEXT:-2}
       - LLM_TEMPERATURE=${LLM_TEMPERATURE:-0.1}
+      - OLLAMA_THINK=${OLLAMA_THINK:-false}
     volumes:
       - app-data:/app/data
       - model-cache:/cache/huggingface
@@ -197,7 +198,7 @@ services:
       # Same broad default as worker-gpu: runs the whole pipeline in a
       # single container when the CPU profile is used alone. Override with
       # `WORKER_CPU_QUEUES=whisper:cpu default` to specialise.
-      - WORKER_QUEUES=${WORKER_CPU_QUEUES:-whisper:gpu whisper:io whisper:cpu default}
+      - WORKER_QUEUES=${WORKER_CPU_QUEUES:-whisper:gpu whisper:io whisper:cpu whisper:llm default}
       - REDIS_URL=redis://:${REDIS_PASSWORD:-}@redis:6379/0
       # Logging knobs reach the container only if listed here — compose has no
       # env_file, so a .env value alone would never apply. See README.
@@ -229,6 +230,7 @@ services:
       - LLM_CHUNK_SIZE=${LLM_CHUNK_SIZE:-8}
       - LLM_CHUNK_CONTEXT=${LLM_CHUNK_CONTEXT:-2}
       - LLM_TEMPERATURE=${LLM_TEMPERATURE:-0.1}
+      - OLLAMA_THINK=${OLLAMA_THINK:-false}
     volumes:
       - app-data:/app/data
       - model-cache:/cache/huggingface
@@ -259,7 +261,7 @@ services:
         PIP_INDEX_URL: ${PIP_INDEX_URL:-}
         AMDGPU_TARGETS: ${AMDGPU_TARGETS:-gfx1151}
     environment:
-      - WORKER_QUEUES=${WORKER_ROCM_QUEUES:-whisper:gpu whisper:io whisper:cpu default}
+      - WORKER_QUEUES=${WORKER_ROCM_QUEUES:-whisper:gpu whisper:io whisper:cpu whisper:llm default}
       - REDIS_URL=redis://:${REDIS_PASSWORD:-}@redis:6379/0
       # Logging knobs reach the container only if listed here — compose has no
       # env_file, so a .env value alone would never apply. See README.
@@ -292,6 +294,7 @@ services:
       - LLM_CHUNK_SIZE=${LLM_CHUNK_SIZE:-8}
       - LLM_CHUNK_CONTEXT=${LLM_CHUNK_CONTEXT:-2}
       - LLM_TEMPERATURE=${LLM_TEMPERATURE:-0.1}
+      - OLLAMA_THINK=${OLLAMA_THINK:-false}
     devices:
       - /dev/kfd
       - /dev/dri
@@ -334,7 +337,7 @@ services:
       args:
         PIP_INDEX_URL: ${PIP_INDEX_URL:-}
     environment:
-      - WORKER_QUEUES=${WORKER_IO_QUEUES:-whisper:io whisper:cpu default}
+      - WORKER_QUEUES=${WORKER_IO_QUEUES:-whisper:io whisper:cpu whisper:llm default}
       - REDIS_URL=redis://:${REDIS_PASSWORD:-}@redis:6379/0
       # Logging knobs reach the container only if listed here — compose has no
       # env_file, so a .env value alone would never apply. See README.
@@ -360,6 +363,58 @@ services:
       - LLM_CHUNK_SIZE=${LLM_CHUNK_SIZE:-8}
       - LLM_CHUNK_CONTEXT=${LLM_CHUNK_CONTEXT:-2}
       - LLM_TEMPERATURE=${LLM_TEMPERATURE:-0.1}
+      - OLLAMA_THINK=${OLLAMA_THINK:-false}
+    volumes:
+      - app-data:/app/data
+    depends_on:
+      redis:
+        condition: service_healthy
+      volume-init:
+        condition: service_completed_successfully
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "5"
+  # Dedicated LLM-correction worker (whisper:llm queue only). Enable with
+  # `--profile llm-worker` on hosts where the LLM is slow (a big Ollama model)
+  # and must NOT block the fast io/cpu finalisation path. Uses the CPU image —
+  # the stage only makes HTTP calls to Ollama, so it needs no GPU. When you run
+  # it, narrow the other workers off whisper:llm (e.g. set
+  # WORKER_IO_QUEUES="whisper:io whisper:cpu default").
+  worker-llm:
+    profiles: [llm-worker]
+    image: ghcr.io/fdff87554/whisper-ui-worker-cpu:${WHISPER_UI_VERSION:-latest}
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.worker.cpu
+      args:
+        PIP_INDEX_URL: ${PIP_INDEX_URL:-}
+    environment:
+      - WORKER_QUEUES=${WORKER_LLM_QUEUES:-whisper:llm default}
+      - REDIS_URL=redis://:${REDIS_PASSWORD:-}@redis:6379/0
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - LOG_JSON=${LOG_JSON:-false}
+      - DATABASE_PATH=/app/data/db/whisper_ui.db
+      - UPLOAD_DIR=/app/data/uploads
+      - OUTPUT_DIR=/app/data/outputs
+      - DEVICE=cpu
+      - LANGUAGE=${LANGUAGE:-zh}
+      - JOB_TIMEOUT_DEFAULT=${JOB_TIMEOUT_DEFAULT:-7200}
+      - JOB_TIMEOUT_FLOOR=${JOB_TIMEOUT_FLOOR:-1800}
+      - JOB_TIMEOUT_AUDIO_MULTIPLIER=${JOB_TIMEOUT_AUDIO_MULTIPLIER:-3.0}
+      - JOB_TIMEOUT_MAX=${JOB_TIMEOUT_MAX:-28800}
+      - STALE_JOB_BUFFER=${STALE_JOB_BUFFER:-1800}
+      - REDIS_PROCESSING_EXPIRY=${REDIS_PROCESSING_EXPIRY:-30600}
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-}
+      - OLLAMA_MODEL=${OLLAMA_MODEL:-gemma4:e4b}
+      - OLLAMA_KEEP_ALIVE=${OLLAMA_KEEP_ALIVE:-30m}
+      - OLLAMA_REQUEST_TIMEOUT=${OLLAMA_REQUEST_TIMEOUT:-120}
+      - LLM_CHUNK_SIZE=${LLM_CHUNK_SIZE:-8}
+      - LLM_CHUNK_CONTEXT=${LLM_CHUNK_CONTEXT:-2}
+      - LLM_TEMPERATURE=${LLM_TEMPERATURE:-0.1}
+      - OLLAMA_THINK=${OLLAMA_THINK:-false}
     volumes:
       - app-data:/app/data
     depends_on:

--- a/docker/entrypoint-worker.sh
+++ b/docker/entrypoint-worker.sh
@@ -20,7 +20,7 @@ echo "Device: ${DEVICE:-auto}, Compute type: ${COMPUTE_TYPE:-int8_float16}"
 MODEL_DIR="${HF_HOME:-/cache/huggingface}"
 echo "Model cache directory: ${MODEL_DIR}"
 
-WORKER_QUEUES="${WORKER_QUEUES:-whisper:gpu whisper:io whisper:cpu default}"
+WORKER_QUEUES="${WORKER_QUEUES:-whisper:gpu whisper:io whisper:cpu whisper:llm default}"
 
 # CUDA cannot be re-initialised in a forked subprocess. When the device is
 # set to cuda, use SimpleWorker which runs jobs in the main process instead

--- a/src/whisper_ui/core/config.py
+++ b/src/whisper_ui/core/config.py
@@ -143,6 +143,12 @@ class Settings(BaseSettings):
     llm_chunk_size: int = 8
     llm_chunk_context: int = 2
     llm_temperature: float = 0.1
+    # Whether to let a thinking-capable Ollama model emit chain-of-thought
+    # before its answer. Default false: for JSON transcript correction,
+    # thinking is markedly slower and (measured on gemma-class models)
+    # degrades the corrected output. Set true only if a reasoning model is
+    # shown to benefit.
+    ollama_think: bool = False
 
     @field_validator("transcribe_backend")
     @classmethod

--- a/src/whisper_ui/core/constants.py
+++ b/src/whisper_ui/core/constants.py
@@ -76,8 +76,9 @@ PIPELINE_STATE_TTL_SECONDS = 604_800  # 7 days (must outlive max backlog wait)
 #   whisper:gpu -> GPU inference (transcribe_align, diarize)
 #   whisper:cpu -> lightweight CPU finalisation (assign_speakers, postprocess)
 #   whisper:llm -> optional Ollama LLM correction. Kept separate from whisper:io
-#                  so a slow LLM call cannot starve the fast io/cpu finalisation
-#                  path (a worker serving io+cpu would otherwise block on it).
+#                  so a worker bound to only io+cpu does not pick up (and block
+#                  on) a slow LLM; bind whisper:llm to a dedicated worker to
+#                  isolate it from the fast io/cpu path.
 # The default queue stays listed because worker startup scripts include it in
 # their queue list so an operator can drop ad-hoc maintenance jobs on every
 # worker without learning the resource-class names.

--- a/src/whisper_ui/core/constants.py
+++ b/src/whisper_ui/core/constants.py
@@ -70,15 +70,19 @@ REDIS_FAILED_EXPIRY = 86400  # 24 hours
 PIPELINE_STATE_TTL_SECONDS = 604_800  # 7 days (must outlive max backlog wait)
 
 # Worker queues. Stages are partitioned across these queues by the resource
-# they consume so a long-running IO or network stage (download, llm_correction)
-# never blocks a GPU worker from picking up the next job.
-#   whisper:io  -> network / disk IO (download, preprocess, llm_correction)
+# they consume so a long-running stage never blocks an unrelated worker from
+# picking up the next job.
+#   whisper:io  -> network / disk IO (download, preprocess)
 #   whisper:gpu -> GPU inference (transcribe_align, diarize)
 #   whisper:cpu -> lightweight CPU finalisation (assign_speakers, postprocess)
+#   whisper:llm -> optional Ollama LLM correction. Kept separate from whisper:io
+#                  so a slow LLM call cannot starve the fast io/cpu finalisation
+#                  path (a worker serving io+cpu would otherwise block on it).
 # The default queue stays listed because worker startup scripts include it in
 # their queue list so an operator can drop ad-hoc maintenance jobs on every
 # worker without learning the resource-class names.
 WORKER_QUEUE_IO = "whisper:io"
 WORKER_QUEUE_GPU = "whisper:gpu"
 WORKER_QUEUE_CPU = "whisper:cpu"
+WORKER_QUEUE_LLM = "whisper:llm"
 WORKER_QUEUE_DEFAULT = "default"

--- a/src/whisper_ui/pipeline/llm_correction.py
+++ b/src/whisper_ui/pipeline/llm_correction.py
@@ -62,6 +62,7 @@ class OllamaClient(Protocol):
         user: str,
         temperature: float,
         keep_alive: str,
+        think: bool,
     ) -> str: ...
 
     def close(self) -> None: ...
@@ -81,12 +82,16 @@ class HttpxOllamaClient:
         user: str,
         temperature: float,
         keep_alive: str,
+        think: bool,
     ) -> str:
         payload = {
             "model": model,
             "stream": False,
             "format": "json",
             "keep_alive": keep_alive,
+            # Top-level (not an `options` key): Ollama's /api/chat reads `think`
+            # to toggle a reasoning model's chain-of-thought. Off for correction.
+            "think": think,
             "options": {
                 "temperature": temperature,
                 "top_p": 0.9,
@@ -134,6 +139,7 @@ class LLMCorrectionStage:
         chunk_context: int,
         temperature: float,
         request_timeout: float,
+        think: bool = False,
         client: OllamaClient | None = None,
     ) -> None:
         self._base_url = base_url
@@ -143,6 +149,7 @@ class LLMCorrectionStage:
         self._chunk_context = chunk_context
         self._temperature = temperature
         self._request_timeout = request_timeout
+        self._think = think
         self._client = client
         self._owns_client = client is None
 
@@ -248,6 +255,7 @@ class LLMCorrectionStage:
             user=user_prompt,
             temperature=self._temperature,
             keep_alive=self._keep_alive,
+            think=self._think,
         )
         return _parse_response(raw_response, {idx for idx, _ in chunk.edit_items})
 

--- a/src/whisper_ui/web/routes/metrics.py
+++ b/src/whisper_ui/web/routes/metrics.py
@@ -22,7 +22,7 @@ from fastapi import APIRouter, Response
 from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest
 from prometheus_client.core import GaugeMetricFamily
 
-from whisper_ui.core.constants import WORKER_QUEUE_CPU, WORKER_QUEUE_GPU, WORKER_QUEUE_IO
+from whisper_ui.core.constants import WORKER_QUEUE_CPU, WORKER_QUEUE_GPU, WORKER_QUEUE_IO, WORKER_QUEUE_LLM
 from whisper_ui.core.models import JobStatus
 
 # DbDep/RedisDep stay runtime imports: FastAPI evaluates these Depends
@@ -42,7 +42,7 @@ router = APIRouter()
 
 # RQ queues to report. "default" is the ad-hoc maintenance queue every worker
 # also subscribes to.
-_QUEUES = (WORKER_QUEUE_GPU, WORKER_QUEUE_IO, WORKER_QUEUE_CPU, "default")
+_QUEUES = (WORKER_QUEUE_GPU, WORKER_QUEUE_IO, WORKER_QUEUE_CPU, WORKER_QUEUE_LLM, "default")
 _STATUSES = tuple(s.value for s in JobStatus)
 
 

--- a/src/whisper_ui/worker/pipeline_dispatcher.py
+++ b/src/whisper_ui/worker/pipeline_dispatcher.py
@@ -60,8 +60,9 @@ from whisper_ui.worker.timeout import calculate_job_timeout
 # Stage function → queue name. IO stages (download, preprocess) go to a queue
 # serviced by workers that do not hold a CUDA context; GPU stages go to the GPU
 # queue; lightweight CPU finalisation stages go to the CPU queue; the optional,
-# slow LLM correction goes to its own queue so it never starves the io/cpu
-# finalisation path. See whisper_ui.core.constants for the rationale.
+# slow LLM correction goes to its own queue so it can be isolated onto a
+# dedicated worker, keeping a slow LLM off the io/cpu finalisation path. See
+# whisper_ui.core.constants for the rationale.
 _STAGE_QUEUES = {
     run_download.__name__: WORKER_QUEUE_IO,
     run_preprocess.__name__: WORKER_QUEUE_IO,

--- a/src/whisper_ui/worker/pipeline_dispatcher.py
+++ b/src/whisper_ui/worker/pipeline_dispatcher.py
@@ -29,6 +29,7 @@ from whisper_ui.core.constants import (
     WORKER_QUEUE_CPU,
     WORKER_QUEUE_GPU,
     WORKER_QUEUE_IO,
+    WORKER_QUEUE_LLM,
 )
 from whisper_ui.core.messages import LLM_CORRECTION_SKIPPED, PIPELINE_COMPLETE, RESULT_PERSIST_FAILED
 from whisper_ui.core.models import JobStatus
@@ -56,14 +57,15 @@ from whisper_ui.worker.stage_tasks import (
 )
 from whisper_ui.worker.timeout import calculate_job_timeout
 
-# Stage function → queue name. IO stages (download, preprocess, llm_correction)
-# go to a queue serviced by workers that do not hold a CUDA context, GPU
-# stages go to the GPU queue, and lightweight CPU finalisation stages go to
-# the CPU queue. See whisper_ui.core.constants for the rationale.
+# Stage function → queue name. IO stages (download, preprocess) go to a queue
+# serviced by workers that do not hold a CUDA context; GPU stages go to the GPU
+# queue; lightweight CPU finalisation stages go to the CPU queue; the optional,
+# slow LLM correction goes to its own queue so it never starves the io/cpu
+# finalisation path. See whisper_ui.core.constants for the rationale.
 _STAGE_QUEUES = {
     run_download.__name__: WORKER_QUEUE_IO,
     run_preprocess.__name__: WORKER_QUEUE_IO,
-    run_llm_correction.__name__: WORKER_QUEUE_IO,
+    run_llm_correction.__name__: WORKER_QUEUE_LLM,
     run_transcribe_align.__name__: WORKER_QUEUE_GPU,
     run_diarize.__name__: WORKER_QUEUE_GPU,
     run_assign_speakers.__name__: WORKER_QUEUE_CPU,
@@ -155,7 +157,8 @@ def enqueue_pipeline(
     monitoring to the tail of the pipeline if they want to.
     """
     queues = {
-        name: Queue(name=name, connection=redis) for name in (WORKER_QUEUE_IO, WORKER_QUEUE_GPU, WORKER_QUEUE_CPU)
+        name: Queue(name=name, connection=redis)
+        for name in (WORKER_QUEUE_IO, WORKER_QUEUE_GPU, WORKER_QUEUE_CPU, WORKER_QUEUE_LLM)
     }
 
     initial_context: dict = {

--- a/src/whisper_ui/worker/stage_tasks.py
+++ b/src/whisper_ui/worker/stage_tasks.py
@@ -474,6 +474,7 @@ def run_llm_correction(parent_job_id: str) -> str:
             chunk_context=settings.llm_chunk_context,
             temperature=settings.llm_temperature,
             request_timeout=float(settings.ollama_request_timeout),
+            think=settings.ollama_think,
         )
 
     return _run_single_stage(

--- a/tests/integration/test_e2e_golden_path.py
+++ b/tests/integration/test_e2e_golden_path.py
@@ -30,6 +30,7 @@ from whisper_ui.core.constants import (
     WORKER_QUEUE_CPU,
     WORKER_QUEUE_GPU,
     WORKER_QUEUE_IO,
+    WORKER_QUEUE_LLM,
 )
 from whisper_ui.core.models import JobStatus
 from whisper_ui.pipeline.align import AlignStage
@@ -228,7 +229,8 @@ def _drain_queues(fake_redis: Any) -> None:
     from rq import Queue, SimpleWorker
 
     queues = {
-        name: Queue(name=name, connection=fake_redis) for name in (WORKER_QUEUE_IO, WORKER_QUEUE_GPU, WORKER_QUEUE_CPU)
+        name: Queue(name=name, connection=fake_redis)
+        for name in (WORKER_QUEUE_IO, WORKER_QUEUE_GPU, WORKER_QUEUE_CPU, WORKER_QUEUE_LLM)
     }
     for _ in range(50):
         progressed = False

--- a/tests/integration/test_throughput_queue_split.py
+++ b/tests/integration/test_throughput_queue_split.py
@@ -33,7 +33,7 @@ from tests.unit.test_pipeline_dag_parallelism import (
     _install_runtime,
     _stub_stages,
 )
-from whisper_ui.core.constants import WORKER_QUEUE_CPU, WORKER_QUEUE_GPU, WORKER_QUEUE_IO
+from whisper_ui.core.constants import WORKER_QUEUE_CPU, WORKER_QUEUE_GPU, WORKER_QUEUE_IO, WORKER_QUEUE_LLM
 from whisper_ui.core.models import Job, JobStatus
 from whisper_ui.worker.pipeline_dispatcher import enqueue_pipeline
 
@@ -238,7 +238,7 @@ def test_combined_worker_blocks_io_behind_busy_gpu(monkeypatch, tmp_path):
         # GPU stage with no other worker free to take over.
         combined = threading.Thread(
             target=_burst_worker,
-            args=(fake_redis, [WORKER_QUEUE_IO, WORKER_QUEUE_GPU, WORKER_QUEUE_CPU]),
+            args=(fake_redis, [WORKER_QUEUE_IO, WORKER_QUEUE_GPU, WORKER_QUEUE_CPU, WORKER_QUEUE_LLM]),
         )
         combined.start()
         try:

--- a/tests/unit/test_llm_correction.py
+++ b/tests/unit/test_llm_correction.py
@@ -22,6 +22,7 @@ class RecordedCall:
     user: str
     temperature: float
     keep_alive: str
+    think: bool
 
 
 @dataclass
@@ -40,9 +41,12 @@ class FakeOllamaClient:
         user: str,
         temperature: float,
         keep_alive: str,
+        think: bool,
     ) -> str:
         self.calls.append(
-            RecordedCall(model=model, system=system, user=user, temperature=temperature, keep_alive=keep_alive)
+            RecordedCall(
+                model=model, system=system, user=user, temperature=temperature, keep_alive=keep_alive, think=think
+            )
         )
         if not self.responses:
             return '{"segments": []}'
@@ -342,7 +346,40 @@ def test_request_parameters_passed_through():
     assert call.temperature == 0.1
     assert call.keep_alive == "1h"
     assert call.model == "gemma4:e2b"
+    assert call.think is False  # default: thinking off for JSON correction
     assert "中文轉錄校對助理" in call.system
+
+
+def test_think_flag_propagates_to_client():
+    stage, client = _make_stage(chunk_size=10, chunk_context=0, think=True)
+    transcript = _make_transcript(["甲"])
+    client.responses = [_valid_response_for([0], ["改"])]
+
+    stage.execute({"transcript_result": transcript, "language": "zh"})
+
+    assert client.calls[0].think is True
+
+
+def test_httpx_client_puts_think_at_payload_top_level():
+    import json
+
+    import httpx
+
+    from whisper_ui.pipeline.llm_correction import HttpxOllamaClient
+
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"message": {"content": '{"segments": {}}'}})
+
+    client = HttpxOllamaClient(base_url="http://ollama:11434", timeout=5.0)
+    client._client = httpx.Client(base_url="http://ollama:11434", transport=httpx.MockTransport(handler))
+
+    client.chat_json(model="m", system="s", user="u", temperature=0.1, keep_alive="30m", think=False)
+
+    assert captured["body"]["think"] is False  # top-level
+    assert "think" not in captured["body"]["options"]  # not nested under options
 
 
 def test_aligned_result_not_touched():

--- a/tests/unit/test_llm_correction.py
+++ b/tests/unit/test_llm_correction.py
@@ -374,9 +374,13 @@ def test_httpx_client_puts_think_at_payload_top_level():
         return httpx.Response(200, json={"message": {"content": '{"segments": {}}'}})
 
     client = HttpxOllamaClient(base_url="http://ollama:11434", timeout=5.0)
+    client._client.close()  # discard the real client created by __init__
     client._client = httpx.Client(base_url="http://ollama:11434", transport=httpx.MockTransport(handler))
 
-    client.chat_json(model="m", system="s", user="u", temperature=0.1, keep_alive="30m", think=False)
+    try:
+        client.chat_json(model="m", system="s", user="u", temperature=0.1, keep_alive="30m", think=False)
+    finally:
+        client.close()  # close the mock-backed client
 
     assert captured["body"]["think"] is False  # top-level
     assert "think" not in captured["body"]["options"]  # not nested under options

--- a/tests/unit/test_llm_correction_integration.py
+++ b/tests/unit/test_llm_correction_integration.py
@@ -46,7 +46,7 @@ class _FakeOllamaClient:
         self._corrections = corrections
         self.closed = False
 
-    def chat_json(self, *, model: str, system: str, user: str, temperature: float, keep_alive: str) -> str:
+    def chat_json(self, *, model: str, system: str, user: str, temperature: float, keep_alive: str, think: bool) -> str:
         # Pull the EDIT block's indices back out so we only "correct" the
         # ones the stage asked about; we cheat by returning everything our
         # fixture knows, filtered to what was requested.

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -46,6 +46,7 @@ def test_whisper_collector_reports_status_counts_and_queue_depth(tmp_path):
         assert 'whisper_jobs_total{status="pending"} 0.0' in out  # missing status -> 0, series never disappears
         assert 'whisper_queue_depth{queue="whisper:gpu"} 1.0' in out
         assert 'whisper_queue_depth{queue="whisper:io"} 0.0' in out
+        assert 'whisper_queue_depth{queue="whisper:llm"} 0.0' in out  # dedicated LLM queue is scraped
         assert "whisper_failed_jobs" in out
         assert "whisper_started_jobs" in out
         assert "whisper_rq_workers " in out

--- a/tests/unit/test_pipeline_dag_parallelism.py
+++ b/tests/unit/test_pipeline_dag_parallelism.py
@@ -26,6 +26,7 @@ from whisper_ui.core.constants import (
     WORKER_QUEUE_CPU,
     WORKER_QUEUE_GPU,
     WORKER_QUEUE_IO,
+    WORKER_QUEUE_LLM,
 )
 from whisper_ui.core.models import Job, JobStatus, TranscriptResult
 from whisper_ui.worker import pipeline_dispatcher
@@ -155,7 +156,7 @@ def _drain_queues(fake_redis) -> list[str]:
     finished: list[str] = []
     queues_by_name = {
         name: __import__("rq").Queue(name=name, connection=fake_redis)
-        for name in (WORKER_QUEUE_IO, WORKER_QUEUE_GPU, WORKER_QUEUE_CPU)
+        for name in (WORKER_QUEUE_IO, WORKER_QUEUE_GPU, WORKER_QUEUE_CPU, WORKER_QUEUE_LLM)
     }
 
     for _ in range(50):  # hard cap to guarantee test termination

--- a/tests/unit/test_pipeline_dispatcher.py
+++ b/tests/unit/test_pipeline_dispatcher.py
@@ -10,6 +10,7 @@ from whisper_ui.core.constants import (
     WORKER_QUEUE_CPU,
     WORKER_QUEUE_GPU,
     WORKER_QUEUE_IO,
+    WORKER_QUEUE_LLM,
 )
 from whisper_ui.core.models import Job, JobStatus
 from whisper_ui.worker.context_store import PipelineContextStore
@@ -337,7 +338,7 @@ def test_subjobs_are_routed_to_resource_specific_queues(tmp_path):
     expected = {
         "run_download": WORKER_QUEUE_IO,
         "run_preprocess": WORKER_QUEUE_IO,
-        "run_llm_correction": WORKER_QUEUE_IO,
+        "run_llm_correction": WORKER_QUEUE_LLM,
         "run_transcribe_align": WORKER_QUEUE_GPU,
         "run_diarize": WORKER_QUEUE_GPU,
         "run_assign_speakers": WORKER_QUEUE_CPU,


### PR DESCRIPTION
## Why

Live evidence from the 211 ROCm box exposed two LLM problems behind the
"resource scheduling isn't flexible" symptom:

1. **The slow optional LLM starved the fast path.** `run_llm_correction` lived
   on `whisper:io`, and the io worker also drains `whisper:cpu` — so a slow
   Ollama call occupied the only worker slot and `whisper:cpu` stopped draining.
2. **`gemma4:26b` was unusable with thinking on.** Measured: `think:false` =
   80.7 s / 3-seg with **valid** JSON; `think:true` (the current default, since
   the app never sent `think`) = 114.5 s with 1179 reasoning chars **and garbled
   output**. So thinking was both slower *and* worse for JSON correction.

## What

**Dedicated `whisper:llm` queue** — `run_llm_correction` routes to its own queue
(`_STAGE_QUEUES`), with a new `worker-llm` compose service (`llm-worker`
profile) + `WORKER_LLM_QUEUES`. A slow LLM can no longer starve `whisper:cpu`.
**Backward-compatible**: every worker's default queue list and the entrypoint
default include `whisper:llm`, so a single-container deployment still runs the
whole pipeline. On a busy host, run a dedicated `worker-llm` and drop
`whisper:llm` from the other workers (see the AMD example in the README).

**`OLLAMA_THINK` (default `false`)** — passes `think` to Ollama's `/api/chat`
(top-level, not in `options`). Off is the evidence-backed default for JSON
correction; set `true` only if a reasoning model is shown to help.

## Tests
- Routing: `run_llm_correction → whisper:llm` (`test_pipeline_dispatcher`).
- `think` propagates config → stage → client, and the real `HttpxOllamaClient`
  puts `"think": false` at the payload top level (`MockTransport`).
- `/metrics` scrapes `whisper:llm` depth.
- Drain helpers (dag-parallelism, e2e, throughput) include `whisper:llm`.
- **860 unit + 4 integration pass; ruff + pre-commit clean.**
- `docker compose config` verified: `OLLAMA_THINK` on all 5 workers, `worker-llm`
  present (no GPU), queue defaults include `whisper:llm`.

## Rollout
Part of the pipeline resource-scheduling plan. 211 is already stabilized on the
fast `gemma4:e4b` interim. After merge: cut **v2.9.0**, then redeploy 211 to the
3-way split (`worker-rocm`=gpu, `worker-io`×2=io+cpu, `worker-llm`=llm) and
switch back to `gemma4:26b` with `OLLAMA_THINK=false`, `LLM_CHUNK_SIZE=3`,
`OLLAMA_REQUEST_TIMEOUT=180`. Phase 2 (GPU coordination / backpressure /
interactive priority) is designed and deferred.