### PR TITLE
chore: release v2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.10.0] - 2026-06-09
+
+### Added
+
+- Twitter/X post video download. Paste an `x.com` / `twitter.com` status link
+  (incl. `m.` / `mobile.` subdomains) to download and transcribe the video
+  attached to a post, alongside the existing YouTube and Google Drive sources.
+  The URL is host-whitelisted and canonicalised to `https://x.com/i/status/{id}`
+  before download, and yt-dlp's extractor is pinned to `twitter` — the same SSRF
+  defence as the YouTube path.
+- `TWITTER_MAX_DURATION` (default `14400`, mirrors `YOUTUBE_MAX_DURATION`) to cap
+  the attached video length on the X path.
+- Optional `TWITTER_COOKIES_FILE` (default unset → anonymous) to fetch
+  login-walled / age-restricted posts. Enabling it needs both the env var AND
+  the `cookies.txt` mounted read-only into the download worker — see
+  `.env.example`. X Broadcasts / Spaces are intentionally out of scope and
+  surface a clear error.
+
 ## [2.9.0] - 2026-06-09
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.9.0"
+version = "2.10.0"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3955,7 +3955,7 @@ wheels = [
 
 [[package]]
 name = "whisper-ui"
-version = "2.9.0"
+version = "2.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Release v2.10.0 — Twitter/X post video download (PR #103) plus the compose/doc follow-ups.

Bumps `pyproject` 2.9.0→2.10.0, resyncs `uv.lock`, adds the `[2.10.0]` CHANGELOG entry. Tagging `v2.10.0` after merge publishes all four images (incl. worker-rocm) to ghcr for the 129 deploy.