### PR TITLE
fix: retry transient X guest-token/5xx download failures

### DIFF
--- a/src/whisper_ui/core/messages.py
+++ b/src/whisper_ui/core/messages.py
@@ -9,6 +9,7 @@ DOWNLOAD_IN_PROGRESS = "正在下載音訊..."
 DOWNLOAD_GDRIVE_IN_PROGRESS = "正在從 Google Drive 下載檔案..."
 DOWNLOAD_DONE = "音訊下載完成。"
 DOWNLOAD_TWITTER_RESTRICTED = "無法下載此貼文，可能需要登入、內容受限，或影片為 X 直播/Spaces（目前不支援）。"
+DOWNLOAD_SOURCE_TRANSIENT = "來源暫時無法回應（可能正在限流或維護中），請稍後再試一次。"
 
 # -- Pipeline progress messages --
 PREPROCESS_CONVERTING = "正在將音訊轉換為 16kHz 單聲道 WAV..."

--- a/src/whisper_ui/pipeline/download.py
+++ b/src/whisper_ui/pipeline/download.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs, urlparse
@@ -14,6 +15,7 @@ from whisper_ui.core.messages import (
     DOWNLOAD_EXTRACTING_INFO,
     DOWNLOAD_GDRIVE_IN_PROGRESS,
     DOWNLOAD_IN_PROGRESS,
+    DOWNLOAD_SOURCE_TRANSIENT,
     DOWNLOAD_TWITTER_RESTRICTED,
 )
 from whisper_ui.web.url_validation import extract_gdrive_file_id, is_google_drive_url, is_twitter_url
@@ -43,6 +45,31 @@ _TWITTER_RESTRICTED_MARKERS = (
     "no suitable extractor",
     "broadcast",
 )
+
+# Substrings (lowercase) that mark a *transient* download failure worth
+# retrying with a fresh yt-dlp client. The headline case is X throttling its
+# anonymous guest-token endpoint ("Bad guest token"): yt-dlp 2026.03.17 fetches
+# a new token on every attempt but does not retry the rejection itself, so a
+# clean retry clears the blip (verified on the 129 production host). HTTP 429
+# and 5xx are likewise server-side and retryable. The HTTP codes are matched in
+# their "http error NNN" form so a tweet/video id that merely contains "503"
+# cannot trip a false positive.
+_RETRYABLE_MARKERS = (
+    "guest token",
+    "http error 429",
+    "http error 500",
+    "http error 502",
+    "http error 503",
+    "http error 504",
+    "service unavailable",
+    "temporarily unavailable",
+)
+
+# A transient failure gets this many total extraction attempts; the backoff is
+# multiplied by the attempt number (2s, then 4s) so X's per-IP guest-token rate
+# limit has a moment to clear without risking the stage's job timeout.
+_MAX_DOWNLOAD_ATTEMPTS = 3
+_RETRY_BACKOFF_SECONDS = 2
 
 
 class DownloadStage:
@@ -192,30 +219,7 @@ class DownloadStage:
         if cookiefile:
             ydl_opts["cookiefile"] = cookiefile
 
-        try:
-            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-                info = ydl.extract_info(source_url, download=False)
-                if info is None:
-                    raise DownloadError("Failed to extract video information.")
-
-                duration = info.get("duration") or 0
-                if duration > self._max_duration:
-                    hours = self._max_duration // 3600
-                    raise DownloadError(f"Video duration ({duration}s) exceeds the maximum allowed ({hours}h).")
-
-                info = ydl.extract_info(source_url, download=True)
-                if info is None:
-                    raise DownloadError("Download returned no information.")
-        except DownloadError:
-            raise
-        except BaseTimeoutException:
-            # Let RQ's death penalty propagate so the worker task classifies
-            # it as a timeout instead of a download failure.
-            raise
-        except Exception as e:
-            if "twitter" in allowed_extractors and any(m in str(e).lower() for m in _TWITTER_RESTRICTED_MARKERS):
-                raise DownloadError(DOWNLOAD_TWITTER_RESTRICTED) from e
-            raise DownloadError(f"Failed to download video: {e}") from e
+        info = self._extract_with_retries(yt_dlp, source_url, ydl_opts, allowed_extractors=allowed_extractors)
 
         downloaded_files = list(download_dir.glob("video.*"))
         if not downloaded_files:
@@ -224,6 +228,64 @@ class DownloadStage:
         context["input_path"] = str(downloaded_files[0])
         context["video_title"] = info.get("title", "")
         return context
+
+    def _extract_with_retries(
+        self,
+        yt_dlp_mod: Any,
+        source_url: str,
+        ydl_opts: dict[str, Any],
+        *,
+        allowed_extractors: list[str],
+    ) -> dict[str, Any]:
+        """Extract+download via yt-dlp, retrying only *transient* failures.
+
+        Each attempt uses a fresh ``YoutubeDL`` instance so a rejected guest
+        token (or other server-side blip) is re-fetched cleanly. Login walls,
+        age/NSFW gating and over-length media are not transient and fail fast;
+        RQ timeouts propagate untouched so the worker still classifies them as
+        timeouts rather than download failures.
+        """
+        for attempt in range(1, _MAX_DOWNLOAD_ATTEMPTS + 1):
+            try:
+                return self._extract_once(yt_dlp_mod, source_url, ydl_opts)
+            except DownloadError:
+                raise
+            except BaseTimeoutException:
+                raise
+            except Exception as e:
+                msg = str(e).lower()
+                if "twitter" in allowed_extractors and any(m in msg for m in _TWITTER_RESTRICTED_MARKERS):
+                    raise DownloadError(DOWNLOAD_TWITTER_RESTRICTED) from e
+                if not any(m in msg for m in _RETRYABLE_MARKERS):
+                    raise DownloadError(f"Failed to download video: {e}") from e
+                if attempt >= _MAX_DOWNLOAD_ATTEMPTS:
+                    raise DownloadError(DOWNLOAD_SOURCE_TRANSIENT) from e
+                logger.warning(
+                    "Download attempt %d/%d failed transiently (%s); retrying",
+                    attempt,
+                    _MAX_DOWNLOAD_ATTEMPTS,
+                    e,
+                )
+                time.sleep(_RETRY_BACKOFF_SECONDS * attempt)
+        # Defensive: every loop iteration returns or raises above.
+        raise DownloadError(DOWNLOAD_SOURCE_TRANSIENT)
+
+    def _extract_once(self, yt_dlp_mod: Any, source_url: str, ydl_opts: dict[str, Any]) -> dict[str, Any]:
+        """Run one yt-dlp pass: probe metadata, enforce the duration cap, then download."""
+        with yt_dlp_mod.YoutubeDL(ydl_opts) as ydl:
+            info = ydl.extract_info(source_url, download=False)
+            if info is None:
+                raise DownloadError("Failed to extract video information.")
+
+            duration = info.get("duration") or 0
+            if duration > self._max_duration:
+                hours = self._max_duration // 3600
+                raise DownloadError(f"Video duration ({duration}s) exceeds the maximum allowed ({hours}h).")
+
+            info = ydl.extract_info(source_url, download=True)
+            if info is None:
+                raise DownloadError("Download returned no information.")
+            return info
 
     def cleanup(self) -> None:
         pass

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from whisper_ui.core.exceptions import DownloadError
-from whisper_ui.pipeline.download import DownloadStage
+from whisper_ui.pipeline.download import _MAX_DOWNLOAD_ATTEMPTS, DownloadStage
 
 
 class TestDownloadStageNoOp:
@@ -406,9 +406,45 @@ class TestTwitterDownload:
         with patch.dict("sys.modules", {"yt_dlp": mock_module}), pytest.raises(DownloadError, match="無法下載此貼文"):
             DownloadStage().execute(context)
 
-    def test_transient_server_error_stays_generic(self, context, download_dir):
+    def test_transient_guest_token_error_retries_then_succeeds(self, context, download_dir):
+        # X intermittently rejects anonymous guest tokens. The first attempt
+        # fails with "Bad guest token"; a fresh-client retry fetches a new token
+        # and succeeds, so the user never sees the error.
+        calls = {"n": 0}
+
+        def extract_info(url, download=True):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise Exception(
+                    "ERROR: [twitter] 123: Error(s) while querying API: Bad guest token; please report this issue"
+                )
+            info = {"duration": 120, "title": "X Post"}
+            if download:
+                (Path(download_dir) / "video.mp4").write_bytes(b"fake video")
+            return info
+
+        mock_ydl_instance = MagicMock()
+        mock_ydl_instance.extract_info = extract_info
+        mock_ydl_instance.__enter__ = lambda self: self
+        mock_ydl_instance.__exit__ = MagicMock(return_value=False)
+        mock_module = MagicMock()
+        mock_module.YoutubeDL.return_value = mock_ydl_instance
+
+        with (
+            patch.dict("sys.modules", {"yt_dlp": mock_module}),
+            patch("whisper_ui.pipeline.download.time.sleep"),
+        ):
+            result = DownloadStage().execute(context)
+
+        assert result["input_path"] == str(download_dir / "video.mp4")
+        # First attempt failed at the metadata probe, second attempt built a
+        # fresh client and completed: two YoutubeDL instances in total.
+        assert mock_module.YoutubeDL.call_count == 2
+
+    def test_transient_error_exhausts_retries_then_raises_transient_message(self, context, download_dir):
         # A retryable HTTP 503 must NOT be reported as "restricted" (which would
-        # wrongly tell the user to export cookies); it keeps the generic path.
+        # wrongly tell the user to export cookies). It is retried with a fresh
+        # client up to the cap, then surfaces the actionable transient hint.
         mock_ydl_instance = MagicMock()
         mock_ydl_instance.extract_info.side_effect = Exception(
             "ERROR: Unable to download API page: HTTP Error 503: Service Unavailable"
@@ -420,9 +456,34 @@ class TestTwitterDownload:
 
         with (
             patch.dict("sys.modules", {"yt_dlp": mock_module}),
-            pytest.raises(DownloadError, match="Failed to download"),
+            patch("whisper_ui.pipeline.download.time.sleep"),
+            pytest.raises(DownloadError, match="來源暫時無法回應"),
         ):
             DownloadStage().execute(context)
+
+        assert mock_module.YoutubeDL.call_count == _MAX_DOWNLOAD_ATTEMPTS
+
+    def test_restricted_error_fails_fast_without_retry(self, context, download_dir):
+        # A login wall is permanent: it must raise on the first attempt, never
+        # burning retry budget on a request that cannot succeed.
+        mock_ydl_instance = MagicMock()
+        mock_ydl_instance.extract_info.side_effect = Exception(
+            "Sorry, you are not authorized to view this tweet. Log in."
+        )
+        mock_ydl_instance.__enter__ = lambda self: self
+        mock_ydl_instance.__exit__ = MagicMock(return_value=False)
+        mock_module = MagicMock()
+        mock_module.YoutubeDL.return_value = mock_ydl_instance
+
+        with (
+            patch.dict("sys.modules", {"yt_dlp": mock_module}),
+            patch("whisper_ui.pipeline.download.time.sleep") as mock_sleep,
+            pytest.raises(DownloadError, match="無法下載此貼文"),
+        ):
+            DownloadStage().execute(context)
+
+        assert mock_module.YoutubeDL.call_count == 1
+        mock_sleep.assert_not_called()
 
     def test_duration_exceeds_limit(self, context, download_dir):
         mock_module = MagicMock()


### PR DESCRIPTION
## Why

A production X download on 129 failed with `[twitter] ...: Error(s) while querying API: Bad guest token`. Investigation on the 129 host:

- Deployed yt-dlp is `2026.03.17` — the same build validated working during the v2.10.0 feasibility test, so this is **not** a version regression.
- Reproducing the exact post immediately succeeded; 5/5 consecutive probes passed. The failure is **intermittent**: X throttles its anonymous `guest/activate.json` endpoint and transiently returns a rejected ("bad") guest token.
- Reading the installed extractor: `TwitterBaseIE._call_api` fetches a fresh guest token per call and, on a `Bad guest token` API error, raises immediately with **no internal retry/refresh**.
- The download sub-job is enqueued with **no RQ `retry=`**, so one transient blip was terminal — and `Bad guest token` matches none of `_TWITTER_RESTRICTED_MARKERS`, so the raw yt-dlp text (including the unhelpful "report this issue on github") surfaced to the user.

## How

Wrap the yt-dlp extraction in a bounded retry that rebuilds a **fresh `YoutubeDL` instance per attempt** (each attempt re-fetches a guest token, which clears the blip — proven by the 5/5 separate-process successes):

- `_RETRYABLE_MARKERS`: `guest token`, `http error 429`, `http error 5xx`, `service unavailable`, `temporarily unavailable`. HTTP codes matched in `http error NNN` form so a tweet id containing e.g. `503` can't false-positive.
- 3 total attempts, 2s/4s backoff (bounded well under the stage job timeout).
- **Fail-fast preserved**: login walls / age-NSFW / over-length (`DownloadError`) and RQ timeouts (`BaseTimeoutException`) are not retried.
- On exhaustion the user gets an actionable transient hint (`DOWNLOAD_SOURCE_TRANSIENT`) instead of the raw error.

Benefits the YouTube path too (transient 429/5xx), since both go through `_download_via_ytdlp`.

## Tests

- `test_transient_guest_token_error_retries_then_succeeds` — fail-then-succeed across fresh clients (2 `YoutubeDL` instances).
- `test_transient_error_exhausts_retries_then_raises_transient_message` — persistent 503 retries to the cap, then the transient message (not "restricted").
- `test_restricted_error_fails_fast_without_retry` — login wall raises on attempt 1, no sleep.
- Full unit suite: 910 passed.