### PR TITLE
chore: release v2.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.10.1] - 2026-06-09
+
+### Fixed
+
+- X post download no longer fails on a transient `Bad guest token` (X throttling
+  its anonymous guest-token endpoint) or HTTP 429/5xx. The yt-dlp extraction now
+  retries up to 3 times with a fresh client (2s/4s backoff) so a re-fetched guest
+  token clears the blip; login walls, age/NSFW gating and over-length media still
+  fail fast. When retries are exhausted the user gets an actionable "source
+  temporarily unavailable, retry later" hint instead of the raw yt-dlp error.
+
 ## [2.10.0] - 2026-06-09
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.10.0"
+version = "2.10.1"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3955,7 +3955,7 @@ wheels = [
 
 [[package]]
 name = "whisper-ui"
-version = "2.10.0"
+version = "2.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Patch release.

### Fixed (#105)

- X post download no longer fails on a transient `Bad guest token` (X throttling its anonymous guest-token endpoint) or HTTP 429/5xx. yt-dlp extraction now retries up to 3 times with a fresh client (2s/4s backoff); login walls / age-NSFW / over-length still fail fast. On exhaustion the user gets an actionable "source temporarily unavailable" hint instead of the raw yt-dlp error.

Bumps `pyproject.toml` 2.10.0 → 2.10.1 and `uv.lock` self-version (no dependency drift). Merging and tagging `v2.10.1` triggers the four-image publish.