### PR TITLE
chore: release v2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.11.0] - 2026-06-10
+
+### Added
+
+- YouTube playlist URLs are now accepted on the URL upload form and expanded
+  at submit time into one transcription job per video, grouped as a batch.
+  Expansion is a metadata-only yt-dlp flat extraction in the web layer (no
+  media download); the per-video download pipeline is unchanged. Auto-generated
+  Mixes (`RD*`/`UL*`) and login-bound lists (Watch Later, Liked videos) are
+  rejected with a dedicated message, as are playlists that are private,
+  deleted, empty, or larger than the batch limit — nothing is persisted on a
+  failed expansion. Private/deleted entries inside an otherwise-valid playlist
+  are skipped and reported in the toast. yt-dlp is now part of the `frontend`
+  extra.
+- Playlist batches show the playlist title in the job list batch header
+  (new nullable `batch_title` column on `jobs`, migrated automatically) and
+  the title is searchable in the client-side job filter.
+- `youtu.be/<id>?list=` share links now resolve to their single video instead
+  of being rejected as playlists, matching the existing `watch?v=<id>&list=`
+  behavior.
+
+### Changed
+
+- `MAX_BATCH_SIZE` raised from 50 to 100 (shared by file uploads, URL
+  submissions, and playlist expansion).
+
+### Fixed
+
+- The liveness-aware stale reaper now re-arms the pipeline state TTL each time
+  it spares a queued job, so a batch backlog deeper than 7 days can no longer
+  expire the generation keys and reap a still-healthy pipeline on a later
+  round.
+
 ## [2.10.1] - 2026-06-09
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.10.1"
+version = "2.11.0"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3955,7 +3955,7 @@ wheels = [
 
 [[package]]
 name = "whisper-ui"
-version = "2.10.1"
+version = "2.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Release v2.11.0 — YouTube playlist batch transcription (PR #107).

- Version bump 2.10.1 → 2.11.0 (minor: new feature)
- CHANGELOG entry covering: playlist URL expansion into batch jobs, batch header playlist title (`batch_title` column, auto-migrated), `youtu.be?list=` refinement, `MAX_BATCH_SIZE` 50 → 100, stale-reaper TTL re-arm fix
- uv.lock version sync

Deployment notes (129/211): frontend image gains the yt-dlp dependency and outbound YouTube access (verified reachable from both hosts during PR #107 e2e); the `batch_title` schema migration applies automatically on first start.