### PR TITLE
fix: stop the jobs page from interrupting users on every poll tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- The jobs list poll now actually morphs the DOM instead of replacing it:
+  whitespace inside the `morph:{...}` swap config broke htmx's swap-spec
+  tokenization, so the idiomorph extension (introduced in v1.10.0) never ran
+  on `#job-list-wrapper` and every 3s poll silently fell back to an innerHTML
+  swap — nesting a fresh wrapper inside the old one and destroying open
+  dropdowns, focus, scroll position, and text selection on each tick. This
+  was the root cause of the jobs page feeling like it constantly reloads.
+- Background polls no longer animate the global top loading bar, and a failed
+  background tick no longer pops a network-error toast every 3 seconds during
+  a backend hiccup. Polling wrappers opt out via `data-quiet-poll`;
+  user-initiated requests (pagination, filters, actions) keep both behaviors.
+- The export dropdown on job cards is driven by DaisyUI's focus mechanism
+  alone. Mixing Alpine `x-show` with the `:focus-within` CSS left two sources
+  of truth that could desync, producing a menu that needs two clicks to
+  reopen.
+- The sticky-header status chip counts refresh during polling via
+  out-of-band swaps instead of going stale until a full page reload; the
+  chip markup is now shared between `/jobs` and `/admin/jobs`.
+
 ## [2.11.0] - 2026-06-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The sticky-header status chip counts refresh during polling via
   out-of-band swaps instead of going stale until a full page reload; the
   chip markup is now shared between `/jobs` and `/admin/jobs`.
+- Several `x-data` / `@click` attributes that interpolated a string with
+  `|tojson` rendered literal double quotes that terminated the attribute
+  early, breaking the status filter chips, the dashboard greeting heading,
+  the dashboard active-job ETA, and the admin reset-password dialog. They now
+  use single-quoted JS literals (for quote-free values) or a data attribute
+  read via `$el.dataset` (for the username).
+- The `/jobs/list` polling fragment now resets an unknown `status` filter to
+  empty, matching `/jobs` and `/admin/jobs/list`, so a bogus value no longer
+  stays baked into the poll URL.
 
 ## [2.11.0] - 2026-06-10
 

--- a/src/whisper_ui/web/routes/admin.py
+++ b/src/whisper_ui/web/routes/admin.py
@@ -236,7 +236,6 @@ async def admin_jobs_page(
     # owner_id=None → no owner filter; admin sees everything.
     ctx = build_list_context(db, redis, filestore, status, page, owner_id=None)
     ctx["active_page"] = "admin_jobs"
-    ctx["status_counts"] = db.get_status_counts()
     ctx["DEFAULT_JOBS_PER_PAGE"] = DEFAULT_JOBS_PER_PAGE
     _add_admin_list_context(ctx, db)
     return templates.TemplateResponse(request=request, name="admin_jobs.html", context=ctx)
@@ -260,4 +259,6 @@ async def admin_jobs_list_fragment(
         status = ""
     ctx = build_list_context(db, redis, filestore, status, page, owner_id=None)
     _add_admin_list_context(ctx, db)
+    # Fragment-only OOB chip-count spans — same contract as /jobs/list.
+    ctx["oob_counts"] = True
     return templates.TemplateResponse(request=request, name="_job_list.html", context=ctx)

--- a/src/whisper_ui/web/routes/jobs.py
+++ b/src/whisper_ui/web/routes/jobs.py
@@ -141,6 +141,11 @@ async def jobs_list_fragment(
     status: str = "",
     page: int = 0,
 ):
+    # Mirror jobs_page / admin_jobs_list_fragment: reject an unknown status so
+    # the poll does not keep re-requesting with a bogus filter (and the
+    # wrapper's hx-get URL stays clean).
+    if status not in _VALID_STATUS_FILTERS:
+        status = ""
     ctx = build_list_context(db, redis, filestore, status, page, owner_filter(user))
     # Fragment-only: lets _job_list.html emit the OOB chip-count spans (the
     # full page renders the chips itself — duplicating the ids there breaks

--- a/src/whisper_ui/web/routes/jobs.py
+++ b/src/whisper_ui/web/routes/jobs.py
@@ -84,6 +84,10 @@ def build_list_context(db: JobDatabase, redis, filestore, status: str, page: int
     progress_data = _get_progress_data(redis, jobs)
     media_available_map = _build_media_available_map(filestore, jobs)
     has_active = db.has_active_jobs(owner_id=owner_id)
+    # Chip counts ride along on every list render so the polled fragment can
+    # refresh the sticky-header badges out-of-band (_job_list.html); without
+    # this the header reads stale counts until a full page reload.
+    status_counts = db.get_status_counts(owner_id=owner_id)
 
     return {
         "groups": groups,
@@ -95,6 +99,7 @@ def build_list_context(db: JobDatabase, redis, filestore, status: str, page: int
         "page": page,
         "total_pages": total_pages,
         "total_count": total_count,
+        "status_counts": status_counts,
     }
 
 
@@ -114,7 +119,6 @@ async def jobs_page(
     owner_id = owner_filter(user)
     ctx = build_list_context(db, redis, filestore, status, page, owner_id)
     ctx["active_page"] = "jobs"
-    ctx["status_counts"] = db.get_status_counts(owner_id=owner_id)
     # The re-transcribe modal (full page only, not the /jobs/list fragment)
     # reuses the upload form's option choices.
     ctx["supported_languages"] = SUPPORTED_LANGUAGES
@@ -138,6 +142,10 @@ async def jobs_list_fragment(
     page: int = 0,
 ):
     ctx = build_list_context(db, redis, filestore, status, page, owner_filter(user))
+    # Fragment-only: lets _job_list.html emit the OOB chip-count spans (the
+    # full page renders the chips itself — duplicating the ids there breaks
+    # the OOB targeting).
+    ctx["oob_counts"] = True
     return templates.TemplateResponse(request=request, name="_job_list.html", context=ctx)
 
 

--- a/src/whisper_ui/web/templates/_dashboard_active.html
+++ b/src/whisper_ui/web/templates/_dashboard_active.html
@@ -43,7 +43,12 @@
     <div id="dashboard-active-{{ job.id }}"
          class="card bg-base-200 border border-line mb-2"
          x-data="{
-           createdAt: {{ (job.created_at or '')|tojson }},
+           {# Single-quoted literal, not |tojson: tojson would wrap the
+              timestamp in literal double quotes and terminate this
+              double-quoted x-data attribute early. created_at is a
+              server-generated ISO string (quote-free); '' parses to NaN and
+              is handled by the etaText guard below. #}
+           createdAt: '{{ job.created_at or "" }}',
            progress: {{ progress_val }},
            etaTemplate: '{{ labels.DASHBOARD_HERO_ETA }}',
            etaUnknownLabel: '{{ labels.DASHBOARD_HERO_ETA_UNKNOWN }}',

--- a/src/whisper_ui/web/templates/_dashboard_active.html
+++ b/src/whisper_ui/web/templates/_dashboard_active.html
@@ -20,7 +20,7 @@
   'correct': labels.DASHBOARD_STAGE_CORRECT,
   'export': labels.DASHBOARD_STAGE_EXPORT,
 } -%}
-<div id="dashboard-active"
+<div id="dashboard-active" data-quiet-poll
      hx-get="/dashboard/active"
      hx-trigger="every {% if active_jobs %}5s{% else %}30s{% endif %}"
      hx-swap="morph:outerHTML">

--- a/src/whisper_ui/web/templates/_job_card.html
+++ b/src/whisper_ui/web/templates/_job_card.html
@@ -52,10 +52,16 @@
   <div class="flex gap-1 flex-shrink-0">
     {% if job.status.value == 'completed' %}
     <a href="/viewer/{{ job.id }}" class="btn btn-primary btn-xs">{{ labels.JOBS_VIEW }}</a>
-    {# Inline export dropdown #}
-    <div class="dropdown dropdown-end" x-data="{ open: false }" @click.away="open = false">
-      <button class="btn btn-ghost btn-xs" @click="open = !open">{{ labels.JOBS_INLINE_EXPORT }}</button>
-      <ul class="dropdown-content menu bg-base-100 rounded-box shadow-lg z-10 w-36 p-1 border border-line" x-show="open" x-transition>
+    {# Inline export dropdown. Visibility is driven by DaisyUI's
+       :focus-within CSS alone — an Alpine x-show here would be a second
+       source of truth that desyncs whenever a swap or focus loss closes
+       the menu while Alpine still thinks it is open (reopening then takes
+       two clicks). The trigger is a div[role=button], not <button>,
+       because Safari does not focus buttons on click (DaisyUI's
+       documented pattern). #}
+    <div class="dropdown dropdown-end">
+      <div tabindex="0" role="button" class="btn btn-ghost btn-xs">{{ labels.JOBS_INLINE_EXPORT }}</div>
+      <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box shadow-lg z-10 w-36 p-1 border border-line">
         {% for fmt in export_formats %}
         <li><a href="/viewer/{{ job.id }}/export/{{ fmt }}" download class="text-xs">{{ fmt|upper }}</a></li>
         {% endfor %}

--- a/src/whisper_ui/web/templates/_job_list.html
+++ b/src/whisper_ui/web/templates/_job_list.html
@@ -133,3 +133,16 @@
 
 {% endif %}
 </div>
+
+{% if oob_counts %}
+{# Out-of-band refresh of the sticky-header chip counts (rendered by
+   _status_chips.html), so a poll that changes job states updates the header
+   too. Gated on oob_counts — set only by the fragment routes: the full pages
+   render the chips themselves, and emitting these spans there would
+   duplicate the ids. htmx extracts hx-swap-oob elements before the main
+   morph swap, so they must sit top-level, outside #job-list-wrapper. #}
+{% from "_status_count_badge.html" import count_badge %}
+{% for value in [''] + labels.STATUS_LABELS.keys()|list %}
+{{ count_badge(value, status_counts, oob=true) }}
+{% endfor %}
+{% endif %}

--- a/src/whisper_ui/web/templates/_job_list.html
+++ b/src/whisper_ui/web/templates/_job_list.html
@@ -1,8 +1,10 @@
 {# htmx fragment: job list with polling — Idiomorph morphs unchanged DOM in place,
    preserving collapse state, focus, and scroll between polls. The callbacks
    reference (defined in base.html) makes data-morph-skip-checked elements opt
-   out of `checked` syncing so user-toggled batch collapses are not reset. #}
-<div id="job-list-wrapper"
+   out of `checked` syncing so user-toggled batch collapses are not reset.
+   data-quiet-poll opts the wrapper's own background requests out of the
+   global page loader (see base.html) — a 3s poll is not a user action. #}
+<div id="job-list-wrapper" data-quiet-poll
      hx-get="{{ list_url|default('/jobs/list', true) }}?status={{ status|default('', true) }}&page={{ page }}"
      {% if has_active %}hx-trigger="every 3s, refreshJobList from:body"{% else %}hx-trigger="refreshJobList from:body"{% endif %}
      hx-swap="morph:{morphStyle:'outerHTML', ignoreActiveValue:true, callbacks:window.__whisperUiMorphCallbacks}">

--- a/src/whisper_ui/web/templates/_job_list.html
+++ b/src/whisper_ui/web/templates/_job_list.html
@@ -4,10 +4,14 @@
    out of `checked` syncing so user-toggled batch collapses are not reset.
    data-quiet-poll opts the wrapper's own background requests out of the
    global page loader (see base.html) — a 3s poll is not a user action. #}
+{# The morph config must contain NO whitespace: htmx tokenizes hx-swap on
+   spaces, so "morph:{a, b}" truncates the swap style to "morph:{a," — the
+   extension never matches it and htmx silently falls back to innerHTML,
+   nesting a fresh wrapper inside the old one on every poll. #}
 <div id="job-list-wrapper" data-quiet-poll
      hx-get="{{ list_url|default('/jobs/list', true) }}?status={{ status|default('', true) }}&page={{ page }}"
      {% if has_active %}hx-trigger="every 3s, refreshJobList from:body"{% else %}hx-trigger="refreshJobList from:body"{% endif %}
-     hx-swap="morph:{morphStyle:'outerHTML', ignoreActiveValue:true, callbacks:window.__whisperUiMorphCallbacks}">
+     hx-swap="morph:{morphStyle:'outerHTML',ignoreActiveValue:true,callbacks:window.__whisperUiMorphCallbacks}">
 
 {% if total_count == 0 %}
   <div class="text-center py-12 opacity-60">

--- a/src/whisper_ui/web/templates/_status_chips.html
+++ b/src/whisper_ui/web/templates/_status_chips.html
@@ -1,0 +1,18 @@
+{# Status filter chips shared by /jobs and /admin/jobs — `list_url` keeps the
+   filter requests in the caller's scope. total_count is filtered by the
+   active status, so the 全部 chip sums the per-status counts instead. The
+   count badges carry stable ids so the polled list fragment can refresh them
+   out-of-band (see _job_list.html); without that, a poll that changes job
+   states leaves the sticky-header counts stale until a full reload. #}
+{% from "_status_count_badge.html" import count_badge %}
+<div class="flex flex-wrap gap-2 mb-3" x-data="{ activeFilter: {{ status|tojson }} }">
+  {% for value, label in [('', labels.JOBS_FILTER_ALL)] + labels.STATUS_LABELS.items()|list %}
+  <button class="btn btn-sm gap-1.5"
+          :class="activeFilter === '{{ value }}' ? 'btn-primary' : 'btn-ghost border border-line'"
+          hx-get="{{ list_url|default('/jobs/list', true) }}?status={{ value }}" hx-target="#job-list-wrapper" hx-swap="outerHTML"
+          @click="activeFilter = '{{ value }}'">
+    <span>{{ label }}</span>
+    {{ count_badge(value, status_counts) }}
+  </button>
+  {% endfor %}
+</div>

--- a/src/whisper_ui/web/templates/_status_chips.html
+++ b/src/whisper_ui/web/templates/_status_chips.html
@@ -5,7 +5,11 @@
    out-of-band (see _job_list.html); without that, a poll that changes job
    states leaves the sticky-header counts stale until a full reload. #}
 {% from "_status_count_badge.html" import count_badge %}
-<div class="flex flex-wrap gap-2 mb-3" x-data="{ activeFilter: {{ status|tojson }} }">
+{# activeFilter uses a single-quoted JS literal, not |tojson: tojson wraps a
+   string in literal double quotes, which would terminate this double-quoted
+   x-data attribute early (the v2.3.1 breakage). status is validated to an
+   empty string or a JobStatus value, so it is always quote-free. #}
+<div class="flex flex-wrap gap-2 mb-3" x-data="{ activeFilter: '{{ status }}' }">
   {% for value, label in [('', labels.JOBS_FILTER_ALL)] + labels.STATUS_LABELS.items()|list %}
   <button class="btn btn-sm gap-1.5"
           :class="activeFilter === '{{ value }}' ? 'btn-primary' : 'btn-ghost border border-line'"

--- a/src/whisper_ui/web/templates/_status_count_badge.html
+++ b/src/whisper_ui/web/templates/_status_count_badge.html
@@ -1,0 +1,10 @@
+{# Macro-only file (no body): both _status_chips.html and the OOB block in
+   _job_list.html import it, and a Jinja import executes the source template's
+   top-level body — chip markup here would blow up on the fragment routes'
+   context. The badge carries a stable id so the polled list fragment can
+   refresh the sticky-header counts via hx-swap-oob. #}
+{% macro count_badge(value, status_counts, oob=false) -%}
+<span id="status-count-{{ value or 'all' }}" class="badge badge-sm"{% if oob %} hx-swap-oob="true"{% endif %}>
+  {{- status_counts.values()|sum if value == '' else status_counts.get(value, 0) -}}
+</span>
+{%- endmacro %}

--- a/src/whisper_ui/web/templates/admin_jobs.html
+++ b/src/whisper_ui/web/templates/admin_jobs.html
@@ -10,19 +10,8 @@
    polled list fragment point at /admin/jobs/list so the admin (owner_id=None)
    scope and owner badges are preserved. #}
 <div class="sticky top-0 z-10 bg-base-100 pt-1 pb-3 mb-4 -mx-4 sm:-mx-6 lg:-mx-8 px-4 sm:px-6 lg:px-8 border-b border-line">
-  <div class="flex flex-wrap gap-2 mb-3" x-data="{ activeFilter: {{ status|tojson }} }">
-    {% set _all_count = status_counts.values()|sum %}
-    {% for value, label in [('', labels.JOBS_FILTER_ALL)] + labels.STATUS_LABELS.items()|list %}
-    {%- set _count = _all_count if value == '' else status_counts.get(value, 0) -%}
-    <button class="btn btn-sm gap-1.5"
-            :class="activeFilter === '{{ value }}' ? 'btn-primary' : 'btn-ghost border border-line'"
-            hx-get="/admin/jobs/list?status={{ value }}" hx-target="#job-list-wrapper" hx-swap="outerHTML"
-            @click="activeFilter = '{{ value }}'">
-      <span>{{ label }}</span>
-      <span class="badge badge-sm">{{ _count }}</span>
-    </button>
-    {% endfor %}
-  </div>
+  {# list_url (set by the admin routes) points the chips at /admin/jobs/list. #}
+  {% include "_status_chips.html" %}
 
   {% include "_job_search.html" %}
 </div>

--- a/src/whisper_ui/web/templates/admin_users.html
+++ b/src/whisper_ui/web/templates/admin_users.html
@@ -84,8 +84,13 @@
                 </button>
               </form>
 
+              {# username comes from a data attribute (HTML-autoescaped) read
+                 via dataset, not |tojson: tojson would wrap it in literal
+                 double quotes and terminate this double-quoted @click
+                 attribute early. userId is an integer, so it stays inline. #}
               <button type="button" class="btn btn-xs"
-                      @click="$dispatch('open-reset-pw', { userId: {{ user.id }}, username: {{ user.username|tojson }} })">
+                      data-username="{{ user.username }}"
+                      @click="$dispatch('open-reset-pw', { userId: {{ user.id }}, username: $el.dataset.username })">
                 {{ labels.ADMIN_ACTION_RESET_PASSWORD }}
               </button>
             </div>

--- a/src/whisper_ui/web/templates/base.html
+++ b/src/whisper_ui/web/templates/base.html
@@ -120,13 +120,26 @@
     const loader = document.getElementById('page-loader');
     let loaderTimeout;
 
-    document.body.addEventListener('htmx:beforeRequest', function() {
+    // Background pollers (hx-trigger="every ...") mark their wrapper with
+    // data-quiet-poll: a poll tick is not a user action, so it must not
+    // animate the global loader — that reads as "the page keeps reloading".
+    // detail.elt is matched directly (no closest()) so user-initiated
+    // requests from elements *inside* a polling wrapper, like the
+    // pagination buttons, still get loader feedback.
+    function isQuietPoll(evt) {
+      const elt = evt.detail && evt.detail.elt;
+      return !!(elt && elt.hasAttribute && elt.hasAttribute('data-quiet-poll'));
+    }
+
+    document.body.addEventListener('htmx:beforeRequest', function(evt) {
+      if (isQuietPoll(evt)) return;
       clearTimeout(loaderTimeout);
       loader.style.width = '0';
       loader.style.opacity = '1';
       requestAnimationFrame(() => { loader.style.width = '80%'; });
     });
-    document.body.addEventListener('htmx:afterRequest', function() {
+    document.body.addEventListener('htmx:afterRequest', function(evt) {
+      if (isQuietPoll(evt)) return;
       loader.style.width = '100%';
       loaderTimeout = setTimeout(() => {
         loader.style.opacity = '0';

--- a/src/whisper_ui/web/templates/base.html
+++ b/src/whisper_ui/web/templates/base.html
@@ -168,8 +168,12 @@
       }
     });
 
-    // htmx error handling — show toast on network errors
-    document.body.addEventListener('htmx:sendError', function() {
+    // htmx error handling — show toast on network errors. Quiet polls are
+    // skipped: a failed background tick retries on the next interval, and
+    // toasting it every 3s during a backend hiccup buries the user in
+    // error popups for requests they never made.
+    document.body.addEventListener('htmx:sendError', function(evt) {
+      if (isQuietPoll(evt)) return;
       if (Alpine.store('toasts')) {
         Alpine.store('toasts').add({ message: '{{ labels.TOAST_NETWORK_ERROR }}', type: 'error' });
       }
@@ -180,6 +184,7 @@
     // htmx:sendError (network layer) was handled. A 401 is left alone so
     // the server's HX-Redirect to /login takes effect.
     document.body.addEventListener('htmx:responseError', function(evt) {
+      if (isQuietPoll(evt)) return;
       if (evt.detail && evt.detail.xhr && evt.detail.xhr.status === 401) {
         return;
       }

--- a/src/whisper_ui/web/templates/dashboard.html
+++ b/src/whisper_ui/web/templates/dashboard.html
@@ -3,7 +3,11 @@
 
 {% block content %}
 {# Time-aware greeting — hour is read on the client so the user's local
-   timezone is respected without a server-side TZ assumption. #}
+   timezone is respected without a server-side TZ assumption. The username is
+   passed through a data attribute (HTML-autoescaped) and read via dataset,
+   not interpolated with |tojson: tojson would wrap it in literal double
+   quotes and terminate this double-quoted x-data attribute early. This
+   mirrors the data-raw pattern in viewer.html. #}
 <div x-data="{
        greetingHour: new Date().getHours(),
        morningLabel: '{{ labels.DASHBOARD_GREETING_MORNING }}',
@@ -15,13 +19,14 @@
          return this.eveningLabel;
        },
        get heading() {
-         const name = {{ (request.state.user.username if request.state and request.state.user else '')|tojson }};
+         const name = $el.dataset.username || '';
          const template = name
            ? '{{ labels.DASHBOARD_GREETING_WITH_NAME }}'
            : '{{ labels.DASHBOARD_GREETING_GUEST }}';
          return template.replace('{greeting}', this.greeting).replace('{name}', name);
        }
      }"
+     data-username="{{ request.state.user.username if request.state and request.state.user else '' }}"
      class="mb-6">
   <h1 class="text-2xl font-medium" x-text="heading">{{ labels.DASHBOARD_HEADER }}</h1>
 </div>

--- a/src/whisper_ui/web/templates/jobs.html
+++ b/src/whisper_ui/web/templates/jobs.html
@@ -8,21 +8,7 @@
    input filters by filename AND source URL — useful for YouTube-heavy
    workflows where the filename is just the video id. #}
 <div class="sticky top-0 z-10 bg-base-100 pt-1 pb-3 mb-4 -mx-4 sm:-mx-6 lg:-mx-8 px-4 sm:px-6 lg:px-8 border-b border-line">
-  <div class="flex flex-wrap gap-2 mb-3" x-data="{ activeFilter: {{ status|tojson }} }">
-    {# total_count is filtered by the active status, so it can't stand in for
-       the "全部" chip — sum the per-status counts for the true total. #}
-    {% set _all_count = status_counts.values()|sum %}
-    {% for value, label in [('', labels.JOBS_FILTER_ALL)] + labels.STATUS_LABELS.items()|list %}
-    {%- set _count = _all_count if value == '' else status_counts.get(value, 0) -%}
-    <button class="btn btn-sm gap-1.5"
-            :class="activeFilter === '{{ value }}' ? 'btn-primary' : 'btn-ghost border border-line'"
-            hx-get="/jobs/list?status={{ value }}" hx-target="#job-list-wrapper" hx-swap="outerHTML"
-            @click="activeFilter = '{{ value }}'">
-      <span>{{ label }}</span>
-      <span class="badge badge-sm">{{ _count }}</span>
-    </button>
-    {% endfor %}
-  </div>
+  {% include "_status_chips.html" %}
 
   {% include "_job_search.html" %}
 </div>

--- a/tests/unit/test_admin_routes.py
+++ b/tests/unit/test_admin_routes.py
@@ -316,6 +316,19 @@ def test_admin_jobs_list_fragment_blocks_non_admin(app, test_user):
     assert resp.status_code == 403
 
 
+def test_admin_jobs_list_fragment_emits_oob_status_counts(app, db, test_admin, test_user):
+    """The admin fragment must refresh the admin page's chip counts the same
+    way /jobs/list does — both render chips from _status_chips.html."""
+    db.insert_job(Job(filename="alices.mp3", status=JobStatus.COMPLETED, language="zh", owner_id=test_user.id))
+    client = authed_test_client(app, test_admin)
+
+    resp = client.get("/admin/jobs/list")
+
+    assert resp.status_code == 200
+    assert '<span id="status-count-all" class="badge badge-sm" hx-swap-oob="true">1</span>' in resp.text
+    assert '<span id="status-count-completed" class="badge badge-sm" hx-swap-oob="true">1</span>' in resp.text
+
+
 def test_admin_jobs_list_poll_wrapper_is_quiet(app, test_admin):
     """The admin list reuses _job_list.html; guard against the admin route
     ever switching to a template whose poll wrapper forgets the quiet

--- a/tests/unit/test_admin_routes.py
+++ b/tests/unit/test_admin_routes.py
@@ -56,6 +56,21 @@ def test_admin_users_page_has_v2_filter_and_reset_modal(app, db, test_admin, bob
     assert "resetPasswordDialog()" in resp.text
 
 
+def test_admin_reset_password_injects_username_via_dataset(app, db, test_admin, bob):
+    """Regression: |tojson wrapped the username in literal double quotes,
+    terminating the double-quoted @click attribute early and breaking the
+    reset-password dialog. The username must ride on a data attribute read
+    via dataset instead."""
+    client = authed_test_client(app, test_admin)
+
+    resp = client.get("/admin/users")
+
+    assert resp.status_code == 200
+    assert 'data-username="bob"' in resp.text
+    assert "username: $el.dataset.username" in resp.text
+    assert 'username: "' not in resp.text  # no inline |tojson interpolation
+
+
 def test_admin_users_page_uses_admin_users_active_value(app, test_admin):
     """The sidebar's Alpine :class binding compares activePage to the
     literal 'admin_users' (not 'admin'), so the route must set that

--- a/tests/unit/test_admin_routes.py
+++ b/tests/unit/test_admin_routes.py
@@ -316,6 +316,19 @@ def test_admin_jobs_list_fragment_blocks_non_admin(app, test_user):
     assert resp.status_code == 403
 
 
+def test_admin_jobs_list_poll_wrapper_is_quiet(app, test_admin):
+    """The admin list reuses _job_list.html; guard against the admin route
+    ever switching to a template whose poll wrapper forgets the quiet
+    opt-out (data-quiet-poll keeps polls off the global page loader)."""
+    client = authed_test_client(app, test_admin)
+
+    resp = client.get("/admin/jobs/list")
+
+    assert resp.status_code == 200
+    opening_tag = resp.text.split('id="job-list-wrapper"', 1)[1].split(">", 1)[0]
+    assert "data-quiet-poll" in opening_tag
+
+
 def test_admin_bulk_delete_operates_across_owners(app, db, test_admin, test_user):
     """Admin bulk actions reuse /jobs/bulk/* — owner_filter is None for admins,
     so they act on jobs owned by other users."""

--- a/tests/unit/test_web_routes.py
+++ b/tests/unit/test_web_routes.py
@@ -139,6 +139,15 @@ class TestDashboardRoutes:
         assert 'id="dashboard-active"' in resp.text
         assert 'hx-trigger="every 5s"' in resp.text
 
+    def test_dashboard_active_poll_wrapper_is_quiet(self, client):
+        """Regression: a background poll tick is not a user action, so the
+        wrapper must opt out of the global page loader via data-quiet-poll
+        (the loader animating every tick read as constant page reloads)."""
+        resp = client.get("/dashboard/active")
+        assert resp.status_code == 200
+        opening_tag = resp.text.split('id="dashboard-active"', 1)[1].split(">", 1)[0]
+        assert "data-quiet-poll" in opening_tag
+
 
 class TestUploadRoutes:
     def test_upload_page(self, client):
@@ -217,6 +226,37 @@ class TestJobsRoutes:
         resp = client.get("/jobs/list")
         assert resp.status_code == 200
         assert "job-list-wrapper" in resp.text
+
+    def test_jobs_list_poll_wrapper_is_quiet(self, client):
+        """Regression: the 3s poll must not animate the global page loader —
+        users read the every-tick animation as the whole page reloading. The
+        wrapper opts out via data-quiet-poll (guard lives in base.html)."""
+        resp = client.get("/jobs/list")
+        assert resp.status_code == 200
+        opening_tag = resp.text.split('id="job-list-wrapper"', 1)[1].split(">", 1)[0]
+        assert "data-quiet-poll" in opening_tag
+        assert "hx-trigger=" in opening_tag
+
+    def test_jobs_pagination_buttons_do_not_carry_quiet_attr(self, client, db):
+        """User-initiated requests from *inside* the polling wrapper (the
+        pagination buttons) must keep loader feedback: the quiet opt-out is
+        matched on the requesting element itself, never inherited."""
+        for i in range(21):  # one over DEFAULT_JOBS_PER_PAGE so pagination renders
+            db.insert_job(Job(filename=f"page{i}.mp3", status=JobStatus.COMPLETED, language="zh"))
+        resp = client.get("/jobs/list")
+        assert resp.status_code == 200
+        button_tags = [seg.split(">", 1)[0] for seg in resp.text.split("<button")[1:]]
+        pagination_tags = [tag for tag in button_tags if 'hx-target="#job-list-wrapper"' in tag]
+        assert pagination_tags  # pagination actually rendered
+        assert all("data-quiet-poll" not in tag for tag in pagination_tags)
+
+    def test_page_loader_guards_quiet_poll(self, client):
+        """The base layout's loader listeners must skip quiet-poll requests;
+        without the guard the data-quiet-poll attribute is inert."""
+        resp = client.get("/jobs")
+        assert resp.status_code == 200
+        assert "function isQuietPoll(evt)" in resp.text
+        assert "hasAttribute('data-quiet-poll')" in resp.text
 
     def test_jobs_all_chip_shows_unfiltered_total_when_filtered(self, client, db, filestore):
         """Finding F5: opening /jobs?status=failed must still show the true

--- a/tests/unit/test_web_routes.py
+++ b/tests/unit/test_web_routes.py
@@ -148,6 +148,27 @@ class TestDashboardRoutes:
         opening_tag = resp.text.split('id="dashboard-active"', 1)[1].split(">", 1)[0]
         assert "data-quiet-poll" in opening_tag
 
+    def test_dashboard_greeting_injects_username_via_dataset(self, client):
+        """Regression: |tojson wrapped the username in literal double quotes,
+        terminating the double-quoted x-data attribute early and breaking the
+        greeting heading. The username must ride on a data attribute read via
+        dataset instead."""
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert 'data-username="alice"' in resp.text
+        assert "const name = $el.dataset.username" in resp.text
+        assert 'const name = "' not in resp.text  # no inline tojson interpolation
+
+    def test_dashboard_active_created_at_is_valid_alpine(self, client, db):
+        """Regression: |tojson wrapped the ISO timestamp in literal double
+        quotes, terminating the double-quoted x-data attribute early. The
+        value must be a single-quoted JS literal instead."""
+        db.insert_job(Job(filename="active.mp3", status=JobStatus.PROCESSING, language="zh"))
+        resp = client.get("/dashboard/active")
+        assert resp.status_code == 200
+        assert "createdAt: '" in resp.text
+        assert 'createdAt: "' not in resp.text
+
 
 class TestUploadRoutes:
     def test_upload_page(self, client):
@@ -226,6 +247,15 @@ class TestJobsRoutes:
         resp = client.get("/jobs/list")
         assert resp.status_code == 200
         assert "job-list-wrapper" in resp.text
+
+    def test_status_chips_active_filter_is_valid_alpine(self, client):
+        """Regression: |tojson wraps the status in literal double quotes, which
+        terminate the double-quoted x-data attribute early and break Alpine.
+        The filter value must be a single-quoted JS literal instead."""
+        resp = client.get("/jobs?status=completed")
+        assert resp.status_code == 200
+        assert "activeFilter: 'completed'" in resp.text
+        assert 'activeFilter: "completed"' not in resp.text
 
     def test_jobs_list_wrapper_morph_swap_spec_has_no_whitespace(self, client):
         """Regression: htmx tokenizes hx-swap on whitespace, so a space inside

--- a/tests/unit/test_web_routes.py
+++ b/tests/unit/test_web_routes.py
@@ -270,6 +270,16 @@ class TestJobsRoutes:
         assert swap_value.startswith("morph:")
         assert " " not in swap_value
 
+    def test_jobs_list_fragment_resets_invalid_status(self, client):
+        """Parity with jobs_page and admin_jobs_list_fragment: an unknown
+        status is reset to empty so the poll does not keep re-requesting with
+        a bogus filter baked into the wrapper's hx-get URL."""
+        resp = client.get("/jobs/list?status=bogus")
+        assert resp.status_code == 200
+        assert "status=bogus" not in resp.text
+        opening_tag = resp.text.split('id="job-list-wrapper"', 1)[1].split(">", 1)[0]
+        assert "?status=&page=0" in opening_tag
+
     def test_jobs_list_poll_wrapper_is_quiet(self, client):
         """Regression: the 3s poll must not animate the global page loader —
         users read the every-tick animation as the whole page reloading. The

--- a/tests/unit/test_web_routes.py
+++ b/tests/unit/test_web_routes.py
@@ -316,6 +316,21 @@ class TestJobsRoutes:
         assert resp.status_code == 200
         assert "重新轉換版本" in resp.text
 
+    def test_export_dropdown_uses_focus_mechanism_only(self, client, db, filestore):
+        """Regression: the export dropdown must be driven by DaisyUI's
+        :focus-within CSS alone. A second Alpine x-show source of truth
+        desyncs whenever a swap or focus loss closes the menu while Alpine
+        still thinks it is open — reopening then takes two clicks."""
+        _create_completed_job(db, filestore)
+        resp = client.get("/jobs/list")
+        assert resp.status_code == 200
+        dropdown = resp.text.split('class="dropdown dropdown-end"', 1)[1].split("</ul>", 1)[0]
+        assert 'tabindex="0"' in dropdown
+        assert 'role="button"' in dropdown
+        assert "x-show" not in dropdown
+        assert "x-data" not in dropdown
+        assert "@click" not in dropdown
+
     def test_jobs_list_hides_download_media_when_reclaimed(self, client, db, filestore):
         """The inline export dropdown in _job_card.html must also gate
         Download Media on media availability — same regression as the

--- a/tests/unit/test_web_routes.py
+++ b/tests/unit/test_web_routes.py
@@ -227,6 +227,19 @@ class TestJobsRoutes:
         assert resp.status_code == 200
         assert "job-list-wrapper" in resp.text
 
+    def test_jobs_list_wrapper_morph_swap_spec_has_no_whitespace(self, client):
+        """Regression: htmx tokenizes hx-swap on whitespace, so a space inside
+        the morph config truncated the swap style — the morph extension never
+        matched it and htmx silently fell back to innerHTML, nesting a fresh
+        wrapper inside the old one and destroying every DOM state (open
+        dropdown, focus, scroll, text selection) on each 3s poll."""
+        resp = client.get("/jobs/list")
+        assert resp.status_code == 200
+        opening_tag = resp.text.split('id="job-list-wrapper"', 1)[1].split(">", 1)[0]
+        swap_value = opening_tag.split('hx-swap="', 1)[1].split('"', 1)[0]
+        assert swap_value.startswith("morph:")
+        assert " " not in swap_value
+
     def test_jobs_list_poll_wrapper_is_quiet(self, client):
         """Regression: the 3s poll must not animate the global page loader —
         users read the every-tick animation as the whole page reloading. The

--- a/tests/unit/test_web_routes.py
+++ b/tests/unit/test_web_routes.py
@@ -258,6 +258,17 @@ class TestJobsRoutes:
         assert "function isQuietPoll(evt)" in resp.text
         assert "hasAttribute('data-quiet-poll')" in resp.text
 
+    def test_error_toasts_guard_quiet_poll(self, client):
+        """A failed background poll retries on the next tick; toasting it
+        every 3s during a backend hiccup buries the user in error popups.
+        Both error handlers must skip quiet-poll requests."""
+        resp = client.get("/jobs")
+        assert resp.status_code == 200
+        send_error_handler = resp.text.split("htmx:sendError", 1)[1].split("});", 1)[0]
+        assert "if (isQuietPoll(evt)) return;" in send_error_handler
+        response_error_handler = resp.text.split("htmx:responseError", 1)[1].split("});", 1)[0]
+        assert "if (isQuietPoll(evt)) return;" in response_error_handler
+
     def test_jobs_all_chip_shows_unfiltered_total_when_filtered(self, client, db, filestore):
         """Finding F5: opening /jobs?status=failed must still show the true
         total on the 全部 chip, not the failed-only count."""

--- a/tests/unit/test_web_routes.py
+++ b/tests/unit/test_web_routes.py
@@ -279,7 +279,33 @@ class TestJobsRoutes:
 
         assert resp.status_code == 200
         # The 全部 chip badge must reflect both jobs, not just the 1 failed.
-        assert '<span class="badge badge-sm">2</span>' in resp.text
+        assert '<span id="status-count-all" class="badge badge-sm">2</span>' in resp.text
+
+    def test_jobs_list_fragment_emits_oob_status_counts(self, client, db, filestore):
+        """A poll that changes job states must also refresh the sticky-header
+        chips: the fragment carries hx-swap-oob count badges keyed to the
+        ids rendered by _status_chips.html."""
+        _create_completed_job(db, filestore)
+        _create_failed_job(db)
+
+        resp = client.get("/jobs/list")
+
+        assert resp.status_code == 200
+        assert '<span id="status-count-all" class="badge badge-sm" hx-swap-oob="true">2</span>' in resp.text
+        assert '<span id="status-count-completed" class="badge badge-sm" hx-swap-oob="true">1</span>' in resp.text
+        assert '<span id="status-count-failed" class="badge badge-sm" hx-swap-oob="true">1</span>' in resp.text
+
+    def test_jobs_full_page_renders_chips_without_oob_duplicates(self, client, db, filestore):
+        """jobs.html renders the chips itself; the _job_list.html include must
+        not emit the OOB spans there, or the badge ids would duplicate and
+        break the out-of-band targeting."""
+        _create_completed_job(db, filestore)
+
+        resp = client.get("/jobs")
+
+        assert resp.status_code == 200
+        assert resp.text.count('id="status-count-all"') == 1
+        assert "hx-swap-oob" not in resp.text
 
     def test_jobs_list_fragment_emits_stable_id_for_single_job(self, client, db, filestore):
         """Without a stable wrapper id Idiomorph falls back to positional


### PR DESCRIPTION
## Why

Users report the jobs page "keeps re-rendering the whole page" and interrupts whatever they are doing — open menus close, the top loading bar flashes nonstop, and during backend hiccups error toasts pile up every few seconds.

Browser-level verification against a dev instance (same templates as the deployed v2.9.0 / v2.11.0 images) showed the report is literally accurate: **the idiomorph swap introduced in v1.10.0 never actually ran on the jobs list.** htmx tokenizes `hx-swap` on whitespace, so the spaces inside `morph:{morphStyle:'outerHTML', ...}` truncated the swap style; the morph extension never matched it and htmx silently fell back to its default innerHTML swap. Every 3s poll therefore replaced the entire list — nesting a fresh `#job-list-wrapper` inside the old one — and destroyed all DOM state: open dropdowns, focus, scroll position, text selection. (The dashboard's spaceless `morph:outerHTML` parsed fine, which is why only the jobs page felt broken.)

Three further issues compounded the "constantly reloading" impression:

- the global top loading bar animated on every background poll tick,
- a failed poll popped a network-error toast every 3 seconds while the backend was restarting,
- the sticky-header status counts went stale until a manual reload.

## How

One commit per fix:

1. **Quiet polls for the loader** — polling wrappers (`_job_list.html`, `_dashboard_active.html`) carry `data-quiet-poll`; the loader listeners in `base.html` skip requests whose source element has it. Matched on the element itself (no `closest()`), so user-initiated requests from inside the wrapper — pagination, filters — keep their loader feedback.
2. **Quiet polls for error toasts** — the `htmx:sendError` / `htmx:responseError` handlers skip quiet polls; the next tick retries on its own. The 401 → `HX-Redirect` path is unchanged.
3. **Single-mechanism dropdown** — the export dropdown now follows DaisyUI's documented focus pattern (`div[role=button]` trigger; Safari does not focus buttons on click) instead of mixing Alpine `x-show` with `:focus-within` CSS, two sources of truth that desync into a needs-two-clicks menu.
4. **Live chip counts** — the list fragment emits the chip count badges as `hx-swap-oob` spans, so polls and filter swaps keep the sticky header in sync. The duplicated chip markup on `/jobs` and `/admin/jobs` moved into a shared `_status_chips.html` partial (the badge macro lives in a macro-only file because a Jinja import executes the source template's top-level body).
5. **Root cause** — the morph config is rewritten without whitespace so the swap spec survives htmx tokenization; a regression test asserts the attribute stays whitespace-free.

## Verification

- 989 unit tests pass; ruff + pre-commit clean. New regression tests cover every fix (wrapper attributes, guard wiring, swap-spec whitespace, OOB spans, no-OOB-on-full-page, dropdown structure, admin parity).
- Playwright against a local dev stack (frontend + redis, no worker, so an uploaded job stays queued and polls forever), 7/7 checks: polling continues; the loader stays silent across ticks but still animates on a filter-chip click; the export dropdown stays open across 2+ ticks (DOM node identity now survives the morph and the wrapper no longer nests); chip counts update live when a job's state changes server-side; zero toasts accumulate while the backend container is stopped, and polling resumes after restart.

No breaking changes. Found during verification, out of scope here: the dashboard greeting / ETA `x-data` attributes interpolate `|tojson` inside double-quoted HTML attributes, so Alpine fails to parse them (pre-existing; separate issue to follow).