### PR TITLE
fix: release-readiness review remediation (timeouts, align degrade, cleanup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,24 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `/jobs/list` polling fragment now resets an unknown `status` filter to
   empty, matching `/jobs` and `/admin/jobs/list`, so a bogus value no longer
   stays baked into the poll URL.
+- URL (YouTube/Twitter/Drive) transcription jobs now get a death-penalty
+  scaled to the real audio duration. They are enqueued before the media is
+  downloaded, so every stage previously fell back to the default timeout and a
+  long video could be killed mid-transcription; once preprocess probes the
+  duration the GPU stages are resized to match what a file upload already gets.
+- A failed word-level alignment no longer discards speaker labels. The
+  unaligned transcription is now carried forward so speaker diarization is
+  still applied at the segment level; only word-level timestamps are lost.
+- Submitting a large batch of files or URLs no longer blocks the web server
+  while each job is enqueued; the synchronous enqueue is offloaded so the
+  jobs poll and other requests stay responsive during submission.
+
+### Changed
+
+- Removed the unused `list_jobs_by_source` query and its index (no view ever
+  listed a job's re-transcribe siblings); the `source_job_id` column and its
+  version badge are unchanged. Consolidated the duplicated jobs status-filter
+  validation into a single shared helper.
 
 ## [2.11.0] - 2026-06-10
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Speech-to-text system using [faster-whisper](https://github.com/SYSTRAN/faster-w
 (large-v3, INT8) with speaker diarization via
 [pyannote-audio](https://github.com/pyannote/pyannote-audio),
 a [FastAPI](https://fastapi.tiangolo.com/) + [htmx](https://htmx.org/) + [Alpine.js](https://alpinejs.dev/) web interface,
-and Docker deployment (GPU / CPU).
+and Docker deployment (NVIDIA GPU / CPU / AMD ROCm).
 
 > **Note:** The UI is in Traditional Chinese (繁體中文).
 
@@ -17,7 +17,7 @@ and Docker deployment (GPU / CPU).
 - Real-time progress tracking via Redis
 - Export to SRT, VTT, TXT, JSON, DOCX
 - Batch download of results as ZIP
-- Docker Compose deployment with GPU and CPU profiles
+- Docker Compose deployment with NVIDIA GPU, CPU, and AMD ROCm profiles
 
 **Supported formats:** `.mp3`, `.wav`, `.m4a`, `.flac`, `.ogg`, `.wma`, `.aac`, `.opus`, `.mp4`, `.webm`, `.mkv`
 
@@ -550,7 +550,7 @@ uv run uvicorn whisper_ui.web.app:app --reload --reload-dir=src
 | Task Queue          | RQ + Redis                                   |
 | Frontend            | FastAPI + htmx + Alpine.js                   |
 | Storage             | SQLite + local filesystem                    |
-| Containerization    | Docker Compose (GPU / CPU profiles)          |
+| Containerization    | Docker Compose (NVIDIA GPU / CPU / AMD ROCm) |
 
 ## Project Structure
 

--- a/src/whisper_ui/pipeline/align.py
+++ b/src/whisper_ui/pipeline/align.py
@@ -75,6 +75,13 @@ class AlignStage:
                 e,
                 exc_info=True,
             )
+            # Fall back to the unaligned transcription as the "aligned" result
+            # so assign_speakers can still attach speakers at the segment level
+            # (whisperx.assign_word_speakers handles non-aligned input). Without
+            # this, aligned_result stays absent, assign_speakers skips entirely,
+            # and an align failure silently discards diarization too — losing
+            # all speaker labels, not just word-level timing.
+            context["aligned_result"] = context.get("transcription_result")
             if on_progress:
                 on_progress(1.0, ALIGN_SKIPPED)
             return context

--- a/src/whisper_ui/storage/database.py
+++ b/src/whisper_ui/storage/database.py
@@ -304,26 +304,6 @@ class JobDatabase:
             ).fetchall()
         return [_row_to_job(r) for r in rows]
 
-    def list_jobs_by_source(self, source_job_id: str, *, owner_id: int | None = None) -> list[Job]:
-        """Return every re-transcribe version sharing ``source_job_id``, oldest first.
-
-        Only returns the version jobs (those whose ``source_job_id`` column
-        matches), not the root job itself — callers that need the root fetch
-        it via :meth:`get_job`. Pass ``owner_id`` to scope to one user, same
-        semantics as :meth:`list_jobs_by_batch`.
-        """
-        if owner_id is not None:
-            rows = self._conn.execute(
-                "SELECT * FROM jobs WHERE source_job_id = ? AND owner_id = ? ORDER BY created_at ASC",
-                (source_job_id, owner_id),
-            ).fetchall()
-        else:
-            rows = self._conn.execute(
-                "SELECT * FROM jobs WHERE source_job_id = ? ORDER BY created_at ASC",
-                (source_job_id,),
-            ).fetchall()
-        return [_row_to_job(r) for r in rows]
-
     def get_batch_stats(self, batch_ids: set[str], *, owner_id: int | None = None) -> dict[str, dict]:
         """Return aggregate stats per batch using a single query.
 

--- a/src/whisper_ui/storage/migrations.py
+++ b/src/whisper_ui/storage/migrations.py
@@ -66,12 +66,10 @@ _MIGRATIONS: list[str] = [
     # never matches NULL).
     "ALTER TABLE jobs ADD COLUMN owner_id INTEGER",
     "CREATE INDEX IF NOT EXISTS idx_jobs_owner_id ON jobs(owner_id)",
-    # source_job_id links re-transcribe versions back to their root job so the
-    # UI can group transcript versions of the same audio. Indexed because the
-    # version-grouping lookup runs whenever the viewer renders a version's
-    # sibling list.
+    # source_job_id links a re-transcribe version back to the root job it was
+    # re-run from. Used by the job card to show a "version" badge; there is no
+    # sibling-list query, so the column is left unindexed.
     "ALTER TABLE jobs ADD COLUMN source_job_id TEXT",
-    "CREATE INDEX IF NOT EXISTS idx_jobs_source_job_id ON jobs(source_job_id)",
     # Denormalized batch display name (e.g. an expanded playlist's title).
     # Nullable: file-upload batches and pre-existing rows have none.
     "ALTER TABLE jobs ADD COLUMN batch_title TEXT",

--- a/src/whisper_ui/web/routes/admin.py
+++ b/src/whisper_ui/web/routes/admin.py
@@ -34,13 +34,13 @@ from fastapi import APIRouter, Form, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
 
 from whisper_ui.core.constants import DEFAULT_JOBS_PER_PAGE
-from whisper_ui.core.models import JobStatus
 from whisper_ui.storage import users_repo
 from whisper_ui.storage.users_repo import LastAdminError
 from whisper_ui.ui import labels as ui_labels
 from whisper_ui.web.deps import AdminUserDep, DbDep, FileStoreDep, RedisDep, templates
 from whisper_ui.web.routes.auth_routes import MIN_PASSWORD_LENGTH, USERNAME_PATTERN
 from whisper_ui.web.routes.jobs import build_list_context
+from whisper_ui.web.validation import normalize_status_filter
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/admin")
@@ -230,9 +230,7 @@ async def admin_jobs_page(
     page: int = 0,
 ):
     """Render the global jobs list (every owner, plus legacy NULL rows)."""
-    valid_statuses = {"", *JobStatus}
-    if status not in valid_statuses:
-        status = ""
+    status = normalize_status_filter(status)
     # owner_id=None → no owner filter; admin sees everything.
     ctx = build_list_context(db, redis, filestore, status, page, owner_id=None)
     ctx["active_page"] = "admin_jobs"
@@ -254,9 +252,7 @@ async def admin_jobs_list_fragment(
     """Admin counterpart of ``/jobs/list``: the htmx-polled list fragment with
     no owner filter, so it stays in the ``/admin/jobs`` context (owner badges,
     admin filter/pagination URLs)."""
-    valid_statuses = {"", *JobStatus}
-    if status not in valid_statuses:
-        status = ""
+    status = normalize_status_filter(status)
     ctx = build_list_context(db, redis, filestore, status, page, owner_id=None)
     _add_admin_list_context(ctx, db)
     # Fragment-only OOB chip-count spans — same contract as /jobs/list.

--- a/src/whisper_ui/web/routes/jobs.py
+++ b/src/whisper_ui/web/routes/jobs.py
@@ -26,7 +26,7 @@ from whisper_ui.web.deps import (
     make_content_disposition,
     templates,
 )
-from whisper_ui.web.validation import clamp_num_speakers, validate_hex_id
+from whisper_ui.web.validation import clamp_num_speakers, normalize_status_filter, validate_hex_id
 from whisper_ui.worker.pipeline_dispatcher import enqueue_pipeline
 from whisper_ui.worker.progress import RedisProgressReporter
 
@@ -35,8 +35,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
-
-_VALID_STATUS_FILTERS = frozenset({"", *JobStatus})
 
 
 def _group_jobs_by_batch(jobs: list[Job]) -> list[tuple[str, list[Job]]]:
@@ -114,8 +112,7 @@ async def jobs_page(
     status: str = "",
     page: int = 0,
 ):
-    if status not in _VALID_STATUS_FILTERS:
-        status = ""
+    status = normalize_status_filter(status)
     owner_id = owner_filter(user)
     ctx = build_list_context(db, redis, filestore, status, page, owner_id)
     ctx["active_page"] = "jobs"
@@ -141,11 +138,10 @@ async def jobs_list_fragment(
     status: str = "",
     page: int = 0,
 ):
-    # Mirror jobs_page / admin_jobs_list_fragment: reject an unknown status so
+    # Mirror jobs_page / admin_jobs_list_fragment: reset an unknown status so
     # the poll does not keep re-requesting with a bogus filter (and the
     # wrapper's hx-get URL stays clean).
-    if status not in _VALID_STATUS_FILTERS:
-        status = ""
+    status = normalize_status_filter(status)
     ctx = build_list_context(db, redis, filestore, status, page, owner_filter(user))
     # Fragment-only: lets _job_list.html emit the OOB chip-count spans (the
     # full page renders the chips itself — duplicating the ids there breaks

--- a/src/whisper_ui/web/routes/upload.py
+++ b/src/whisper_ui/web/routes/upload.py
@@ -293,7 +293,13 @@ async def upload_submit(
         )
 
         try:
-            enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+            # Offload the synchronous Redis/RQ enqueue so a large batch (up to
+            # MAX_BATCH_SIZE) does not monopolise the event loop and stall
+            # other requests (e.g. the /jobs poll). enqueue_pipeline touches
+            # only Redis/RQ/filestore (the redis client is thread-safe); the
+            # SQLite insert_job above stays on the loop per the single-
+            # connection design.
+            await asyncio.to_thread(enqueue_pipeline, job, redis=redis, settings=settings, filestore=filestore)
             submitted_count += 1
         except Exception:
             logger.exception("Failed to enqueue job %s", job.id)
@@ -488,7 +494,9 @@ async def upload_url_submit(
         )
 
         try:
-            enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+            # See upload_submit: offload the sync enqueue so a large URL batch
+            # does not block the event loop. insert_job stays on the loop.
+            await asyncio.to_thread(enqueue_pipeline, job, redis=redis, settings=settings, filestore=filestore)
             submitted_count += 1
         except Exception:
             logger.exception("Failed to enqueue URL job %s", job.id)

--- a/src/whisper_ui/web/validation.py
+++ b/src/whisper_ui/web/validation.py
@@ -6,7 +6,14 @@ import re
 
 from fastapi import HTTPException
 
+from whisper_ui.core.models import JobStatus
+
 _HEX32_RE = re.compile(r"^[0-9a-f]{32}$")
+
+# Valid values for the jobs-list ``status`` query filter: the empty string
+# ("all") plus every JobStatus value. Shared by the user and admin job routes
+# so they reject an unknown status identically.
+VALID_STATUS_FILTERS = frozenset({"", *JobStatus})
 
 # Upper bound mirrors the diarization UI control (``max="20"``). The server
 # clamps rather than trusting the form so a crafted request cannot push an
@@ -19,6 +26,16 @@ def validate_hex_id(value: str, name: str = "id") -> str:
     if not _HEX32_RE.match(value):
         raise HTTPException(status_code=400, detail=f"Invalid {name} format")
     return value
+
+
+def normalize_status_filter(status: str) -> str:
+    """Return ``status`` if it is a valid jobs-list filter, else ``""`` (all).
+
+    Resetting an unknown value to "all" (rather than 400-ing) keeps the page
+    rendering and stops a bogus filter from being baked into the polling
+    wrapper's hx-get URL.
+    """
+    return status if status in VALID_STATUS_FILTERS else ""
 
 
 def clamp_num_speakers(value: int) -> int:

--- a/src/whisper_ui/worker/pipeline_dispatcher.py
+++ b/src/whisper_ui/worker/pipeline_dispatcher.py
@@ -448,10 +448,18 @@ def _persist_completion(
             logger.exception("reporter.complete failed for job %s (already COMPLETED in DB)", job.id)
         logger.info("Job %s completed successfully via DAG pipeline", job.id)
     finally:
-        cleanup_preprocessed_audio(context)
-        ctx_store.delete()
-        if meta_generation is not None:
-            _clear_subjob_set(runtime.redis, job.id, meta_generation)
+        # Best-effort housekeeping: by now the DB already records the terminal
+        # status (COMPLETED here, or FAILED via mark_failed above) and the
+        # Redis keys have a TTL backstop. A cleanup failure must neither
+        # surface as an RQ callback error on the success path nor mask a
+        # re-raised mark_failed exception on the failure path, so swallow it.
+        try:
+            cleanup_preprocessed_audio(context)
+            ctx_store.delete()
+            if meta_generation is not None:
+                _clear_subjob_set(runtime.redis, job.id, meta_generation)
+        except Exception:
+            logger.warning("Best-effort cleanup failed for job %s", job.id, exc_info=True)
 
 
 def _is_llm_correction_subjob(rq_job) -> bool:

--- a/src/whisper_ui/worker/pipeline_dispatcher.py
+++ b/src/whisper_ui/worker/pipeline_dispatcher.py
@@ -73,6 +73,12 @@ _STAGE_QUEUES = {
     run_postprocess.__name__: WORKER_QUEUE_CPU,
 }
 
+# Stages whose runtime scales with audio duration. Their death-penalty is
+# resized once preprocess knows the real duration (see adjust_subjob_timeouts).
+# The other stages have ~fixed cost (download already done, preprocess running,
+# assign/postprocess are quick), so they keep their enqueue-time timeout.
+_DURATION_SCALED_STAGES = frozenset({run_transcribe_align.__name__, run_diarize.__name__})
+
 if TYPE_CHECKING:
     from redis import Redis
     from rq.job import Job as RQJob
@@ -152,6 +158,67 @@ def _refresh_pipeline_state_ttl(redis: Redis, parent_job_id: str) -> None:
         return
     redis.expire(_generation_key(parent_job_id), PIPELINE_STATE_TTL_SECONDS)
     redis.expire(_subjobs_key(parent_job_id, generation), PIPELINE_STATE_TTL_SECONDS)
+
+
+def adjust_subjob_timeouts(
+    redis: Redis,
+    parent_job_id: str,
+    generation: int,
+    duration_seconds: float | None,
+    settings: Settings,
+) -> None:
+    """Resize the death-penalty of not-yet-started, duration-scaled sub-jobs.
+
+    URL jobs are enqueued before their media is downloaded, so
+    :func:`enqueue_pipeline` sizes every sub-job's ``job_timeout`` from a
+    ``None`` duration and they all fall back to ``job_timeout_default``. Once
+    preprocess has probed the real duration, this re-applies
+    :func:`calculate_job_timeout` to the still-deferred GPU stages
+    (transcribe/align, diarize), giving a URL job the same duration-scaled
+    death-penalty a file upload already gets at enqueue time. No-op when the
+    duration is unknown, so a failed probe simply keeps the default.
+
+    Safe against the retry race: those stages ``depends_on`` preprocess, so
+    while this runs inside the preprocess task they are still DEFERRED and
+    cannot have started. Scoped to ``generation`` so a stale attempt's
+    sub-jobs are never touched. Best-effort: a resize failure is logged, never
+    raised, so it cannot fail a preprocess that already produced its output.
+    """
+    if not duration_seconds or duration_seconds <= 0:
+        return
+    from rq.exceptions import NoSuchJobError
+    from rq.job import Job as RQJob
+    from rq.job import JobStatus as RQJobStatus
+
+    new_timeout = calculate_job_timeout(duration_seconds, settings)
+    resizable = {RQJobStatus.DEFERRED, RQJobStatus.QUEUED, RQJobStatus.SCHEDULED}
+    resized = 0
+    for sub_id in _load_subjob_ids(redis, parent_job_id, generation):
+        try:
+            sub = RQJob.fetch(sub_id, connection=redis)
+            if sub.meta.get("stage") not in _DURATION_SCALED_STAGES:
+                continue
+            if sub.get_status(refresh=True) not in resizable:
+                continue
+            if sub.timeout != new_timeout:
+                sub.timeout = new_timeout
+                sub.save()
+                resized += 1
+        except NoSuchJobError:
+            continue
+        except Exception:
+            # Best-effort optimisation: a resize failure must never fail a
+            # preprocess that already produced its output. Log and move on.
+            logger.warning("Could not resize timeout for sub-job %s of %s", sub_id, parent_job_id, exc_info=True)
+    if resized:
+        logger.info(
+            "Resized %d duration-scaled sub-job timeout(s) for job %s to %ss (duration=%.0fs gen=%d)",
+            resized,
+            parent_job_id,
+            new_timeout,
+            duration_seconds,
+            generation,
+        )
 
 
 def enqueue_pipeline(
@@ -654,6 +721,7 @@ def recover_stale_pipeline_jobs(
 
 
 __all__ = [
+    "adjust_subjob_timeouts",
     "enqueue_pipeline",
     "finalize_failure",
     "finalize_success",

--- a/src/whisper_ui/worker/pipeline_dispatcher.py
+++ b/src/whisper_ui/worker/pipeline_dispatcher.py
@@ -186,38 +186,49 @@ def adjust_subjob_timeouts(
     """
     if not duration_seconds or duration_seconds <= 0:
         return
-    from rq.exceptions import NoSuchJobError
-    from rq.job import Job as RQJob
-    from rq.job import JobStatus as RQJobStatus
+    # The whole body is wrapped so this stays truly best-effort: a resize
+    # failure (e.g. the SMEMBERS in _load_subjob_ids or a save() hitting a
+    # Redis blip) must never propagate out of the preprocess post_persist hook
+    # and fail a preprocess that already produced its output. The inner
+    # per-subjob handler lets one bad sub-job be skipped without aborting the
+    # rest; the outer handler covers id loading and timeout calculation.
+    try:
+        from rq.exceptions import NoSuchJobError
+        from rq.job import Job as RQJob
+        from rq.job import JobStatus as RQJobStatus
 
-    new_timeout = calculate_job_timeout(duration_seconds, settings)
-    resizable = {RQJobStatus.DEFERRED, RQJobStatus.QUEUED, RQJobStatus.SCHEDULED}
-    resized = 0
-    for sub_id in _load_subjob_ids(redis, parent_job_id, generation):
-        try:
-            sub = RQJob.fetch(sub_id, connection=redis)
-            if sub.meta.get("stage") not in _DURATION_SCALED_STAGES:
+        new_timeout = calculate_job_timeout(duration_seconds, settings)
+        resizable = {RQJobStatus.DEFERRED, RQJobStatus.QUEUED, RQJobStatus.SCHEDULED}
+        resized = 0
+        for sub_id in _load_subjob_ids(redis, parent_job_id, generation):
+            try:
+                sub = RQJob.fetch(sub_id, connection=redis)
+                if sub.meta.get("stage") not in _DURATION_SCALED_STAGES:
+                    continue
+                if sub.get_status(refresh=True) not in resizable:
+                    continue
+                if sub.timeout != new_timeout:
+                    sub.timeout = new_timeout
+                    sub.save()
+                    resized += 1
+            except NoSuchJobError:
                 continue
-            if sub.get_status(refresh=True) not in resizable:
-                continue
-            if sub.timeout != new_timeout:
-                sub.timeout = new_timeout
-                sub.save()
-                resized += 1
-        except NoSuchJobError:
-            continue
-        except Exception:
-            # Best-effort optimisation: a resize failure must never fail a
-            # preprocess that already produced its output. Log and move on.
-            logger.warning("Could not resize timeout for sub-job %s of %s", sub_id, parent_job_id, exc_info=True)
-    if resized:
-        logger.info(
-            "Resized %d duration-scaled sub-job timeout(s) for job %s to %ss (duration=%.0fs gen=%d)",
-            resized,
+            except Exception:
+                logger.warning("Could not resize timeout for sub-job %s of %s", sub_id, parent_job_id, exc_info=True)
+        if resized:
+            logger.info(
+                "Resized %d duration-scaled sub-job timeout(s) for job %s to %ss (duration=%.0fs gen=%d)",
+                resized,
+                parent_job_id,
+                new_timeout,
+                duration_seconds,
+                generation,
+            )
+    except Exception:
+        logger.warning(
+            "Could not resize sub-job timeouts for %s; keeping enqueue-time defaults",
             parent_job_id,
-            new_timeout,
-            duration_seconds,
-            generation,
+            exc_info=True,
         )
 
 

--- a/src/whisper_ui/worker/runtime.py
+++ b/src/whisper_ui/worker/runtime.py
@@ -207,6 +207,16 @@ class _ThrottledProgressReporter:
                 self._job.id,
             )
             return False
+        # The Redis write above is monotonic (the reporter's Lua max-write only
+        # ever advances progress) and is the single source of truth for live
+        # progress: the UI reads job:{id} from Redis while a job is
+        # QUEUED/PROCESSING. This SQLite mirror is the durable copy and is NOT
+        # guaranteed monotonic — parallel branches (transcribe vs diarize) run
+        # in separate processes with independent Job snapshots and reporters,
+        # so their interleaved full-column UPDATEs can momentarily write a
+        # lower progress here. That is fine because no live path reads progress
+        # from the DB; if one is ever added, give this mirror a max(old, new)
+        # guard first.
         self._job.progress = progress
         self._job.progress_message = message
         self._db.update_job(self._job)

--- a/src/whisper_ui/worker/stage_tasks.py
+++ b/src/whisper_ui/worker/stage_tasks.py
@@ -292,12 +292,16 @@ def _run_single_stage(
     build_stage: Callable[[Job, WorkerRuntime], PipelineStage],
     output_keys: tuple[str, ...],
     pre_context_update: Callable[[Job, WorkerRuntime, dict[str, Any]], None] | None = None,
+    post_persist: Callable[[Job, WorkerRuntime, dict[str, Any]], None] | None = None,
 ) -> str:
     """Shared driver used by every ``run_*`` entry below.
 
     ``pre_context_update`` lets stages that need to seed context fields from
     the live ``Job`` record (e.g. download preparing ``download_dir``) do so
-    without duplicating the runtime setup.
+    without duplicating the runtime setup. ``post_persist`` runs after the
+    stage outputs are persisted, with the updated context, for stages that
+    need to act on a freshly-computed value (e.g. preprocess resizing
+    downstream sub-job timeouts once the audio duration is known).
     """
     with build_worker_runtime(parent_job_id, generation=_current_generation()) as runtime:
         job = _load_job(runtime, parent_job_id)
@@ -323,6 +327,8 @@ def _run_single_stage(
         try:
             updated = _execute_stage(stage, context.copy(), on_progress, stage_name=stage_name)
             _persist_outputs(ctx_store, updated, output_keys, stage_name=stage_name)
+            if post_persist is not None:
+                post_persist(job, runtime, updated)
         finally:
             _log_stage_finish(stage_name, parent_job_id, start_ns)
         return f"{stage_name}:{parent_job_id}"
@@ -373,12 +379,26 @@ def run_preprocess(parent_job_id: str) -> str:
             context["input_path"] = job.filepath
             PipelineContextStore(runtime.redis, job.id).update({"input_path": job.filepath})
 
+    def _resize_downstream_timeouts(job: Job, runtime: WorkerRuntime, context: dict[str, Any]) -> None:
+        # URL jobs were enqueued before their media existed, so every sub-job
+        # got job_timeout_default. Now that preprocess knows the real audio
+        # duration, give the still-deferred GPU stages a duration-scaled
+        # death-penalty (what a file upload already gets at enqueue time).
+        # Lazy import: pipeline_dispatcher imports this module at load time.
+        from whisper_ui.worker.pipeline_dispatcher import adjust_subjob_timeouts
+
+        generation = _current_generation()
+        if generation is None:
+            return
+        adjust_subjob_timeouts(runtime.redis, parent_job_id, generation, context.get("duration"), runtime.settings)
+
     return _run_single_stage(
         parent_job_id,
         stage_name="preprocess",
         build_stage=lambda job, runtime: PreprocessStage(),
         output_keys=("audio_path", "duration"),
         pre_context_update=_seed_file_input,
+        post_persist=_resize_downstream_timeouts,
     )
 
 

--- a/src/whisper_ui/worker/stage_tasks.py
+++ b/src/whisper_ui/worker/stage_tasks.py
@@ -301,7 +301,10 @@ def _run_single_stage(
     without duplicating the runtime setup. ``post_persist`` runs after the
     stage outputs are persisted, with the updated context, for stages that
     need to act on a freshly-computed value (e.g. preprocess resizing
-    downstream sub-job timeouts once the audio duration is known).
+    downstream sub-job timeouts once the audio duration is known). It is
+    best-effort: it runs only after the stage's real output is already
+    durable, so its failure is logged but never re-raised — a side effect
+    must not turn a successful, persisted stage into a failed RQ job.
     """
     with build_worker_runtime(parent_job_id, generation=_current_generation()) as runtime:
         job = _load_job(runtime, parent_job_id)
@@ -328,7 +331,17 @@ def _run_single_stage(
             updated = _execute_stage(stage, context.copy(), on_progress, stage_name=stage_name)
             _persist_outputs(ctx_store, updated, output_keys, stage_name=stage_name)
             if post_persist is not None:
-                post_persist(job, runtime, updated)
+                try:
+                    post_persist(job, runtime, updated)
+                except Exception:
+                    # The stage output is already persisted; a post-persist
+                    # side effect must never fail the stage. Log and continue.
+                    logger.warning(
+                        "post_persist hook failed for stage %s (job %s); stage output already persisted",
+                        stage_name,
+                        parent_job_id,
+                        exc_info=True,
+                    )
         finally:
             _log_stage_finish(stage_name, parent_job_id, start_ns)
         return f"{stage_name}:{parent_job_id}"

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -796,38 +796,6 @@ def test_source_job_id_defaults_to_none_for_direct_uploads(db: JobDatabase):
     assert fetched.source_job_id is None
 
 
-def test_list_jobs_by_source_returns_versions_oldest_first(db: JobDatabase):
-    root = Job(filename="root.mp3", filepath="/tmp/root.mp3")
-    db.insert_job(root)
-    older = Job(filename="v1.mp3", filepath="/tmp/v1.mp3", source_job_id=root.id)
-    newer = Job(filename="v2.mp3", filepath="/tmp/v2.mp3", source_job_id=root.id)
-    db.insert_job(older)
-    db.insert_job(newer)
-    # created_at is set at construction; force a deterministic ordering.
-    older.created_at = "2024-01-01T00:00:00+00:00"
-    newer.created_at = "2024-02-01T00:00:00+00:00"
-    db.update_job(older)
-    db.update_job(newer)
-
-    versions = db.list_jobs_by_source(root.id)
-
-    # Only the version jobs are returned, not the root, and oldest first.
-    assert [j.id for j in versions] == [older.id, newer.id]
-
-
-def test_list_jobs_by_source_respects_owner_filter(db: JobDatabase):
-    root = Job(filename="root.mp3", filepath="/tmp/root.mp3", owner_id=1)
-    db.insert_job(root)
-    mine = Job(filename="mine.mp3", filepath="/tmp/mine.mp3", source_job_id=root.id, owner_id=1)
-    theirs = Job(filename="theirs.mp3", filepath="/tmp/theirs.mp3", source_job_id=root.id, owner_id=2)
-    db.insert_job(mine)
-    db.insert_job(theirs)
-
-    versions = db.list_jobs_by_source(root.id, owner_id=1)
-
-    assert [j.id for j in versions] == [mine.id]
-
-
 def test_legacy_db_without_source_job_id_column_upgrades(tmp_dir: Path):
     """A deployment predating versioning has no source_job_id column. After
     init_db migrates the schema, the column exists, legacy rows read as None,

--- a/tests/unit/test_pipeline_dispatcher.py
+++ b/tests/unit/test_pipeline_dispatcher.py
@@ -539,6 +539,49 @@ def test_finalize_success_marks_job_completed(monkeypatch, tmp_path):
     assert PipelineContextStore(redis, job.id).load() == {}
 
 
+def test_finalize_success_completes_even_if_cleanup_raises(monkeypatch, tmp_path):
+    """Cleanup in the completion finally is best-effort: a Redis failure
+    dropping the context hash must not surface as a callback error after the
+    job is already COMPLETED in the DB."""
+    from whisper_ui.core.models import TranscriptResult
+    from whisper_ui.worker import pipeline_dispatcher as pd
+
+    redis = fakeredis.FakeRedis()
+    job = Job(id="job-cleanup-fail", filename="m.mp3", filepath=str(tmp_path / "m.mp3"), status=JobStatus.PROCESSING)
+    transcript = TranscriptResult(language="zh", duration=10.0)
+    PipelineContextStore(redis, job.id).initialize({"transcript_result": transcript})
+
+    runtime = MagicMock()
+    runtime.redis = redis
+    runtime.db.get_job.return_value = job
+    runtime.filestore.save_result.return_value = tmp_path / "result.json"
+    runtime.settings.redis_processing_expiry = 7200
+
+    from contextlib import contextmanager
+
+    from whisper_ui.worker.progress import RedisProgressReporter
+
+    @contextmanager
+    def _fake_builder(job_id, *, generation=None):
+        runtime.reporter = RedisProgressReporter(redis, job_id, processing_ttl=7200, generation=generation)
+        yield runtime
+
+    monkeypatch.setattr(pd, "build_worker_runtime", _fake_builder)
+    # Make the context-store cleanup blow up inside the finally.
+    monkeypatch.setattr(
+        PipelineContextStore, "delete", lambda self: (_ for _ in ()).throw(RuntimeError("redis delete failed"))
+    )
+
+    fake_rq_job = MagicMock()
+    fake_rq_job.meta = {"parent_job_id": job.id}
+
+    # Must not raise despite the cleanup failure.
+    pd.finalize_success(fake_rq_job, redis, None)
+
+    assert job.status == JobStatus.COMPLETED
+    assert job.result_path == str(tmp_path / "result.json")
+
+
 def test_finalize_success_skips_already_completed_job(monkeypatch, tmp_path):
     """A second finalize_success for an already-COMPLETED job is a no-op, so
     it never re-saves a result or touches terminal state (mirrors the

--- a/tests/unit/test_pipeline_dispatcher.py
+++ b/tests/unit/test_pipeline_dispatcher.py
@@ -17,6 +17,7 @@ from whisper_ui.worker.context_store import PipelineContextStore
 from whisper_ui.worker.pipeline_dispatcher import (
     _current_generation,
     _load_subjob_ids,
+    adjust_subjob_timeouts,
     enqueue_pipeline,
 )
 from whisper_ui.worker.stage_tasks import (
@@ -122,6 +123,78 @@ def test_url_upload_dag_prepends_download(tmp_path):
 
     assert "run_download" in subs
     assert subs["run_preprocess"]._dependency_ids == [subs["run_download"].id]
+
+
+def test_url_job_subjobs_get_default_timeout_at_enqueue(tmp_path):
+    """A URL job has no duration when enqueued (media not downloaded yet), so
+    every sub-job falls back to job_timeout_default — the gap that
+    adjust_subjob_timeouts later closes."""
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-url-timeout",
+        filename="video",
+        source_url="https://www.youtube.com/watch?v=abc",
+        status=JobStatus.QUEUED,
+        enable_diarization=True,
+    )
+
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    subs = _by_stage(_load_subjobs(redis, job.id))
+
+    assert subs["run_transcribe_align"].timeout == settings.job_timeout_default
+    assert subs["run_diarize"].timeout == settings.job_timeout_default
+
+
+def test_adjust_subjob_timeouts_rescales_gpu_stages_once_duration_known(tmp_path):
+    """After preprocess probes the duration, the deferred GPU stages get a
+    duration-scaled death-penalty; fixed-cost stages keep the default."""
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-url-resize",
+        filename="video",
+        source_url="https://www.youtube.com/watch?v=abc",
+        status=JobStatus.QUEUED,
+        enable_diarization=True,
+    )
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    generation = _current_generation(redis, job.id)
+
+    # duration 2000s * multiplier 2.0 = 4000s, within [floor, max] and distinct
+    # from the 3600s default baked at enqueue.
+    adjust_subjob_timeouts(redis, job.id, generation, 2000.0, settings)
+
+    subs = _by_stage(_load_subjobs(redis, job.id))
+    assert subs["run_transcribe_align"].timeout == 4000
+    assert subs["run_diarize"].timeout == 4000
+    # Non-duration-scaled stages keep the enqueue-time default.
+    assert subs["run_download"].timeout == settings.job_timeout_default
+    assert subs["run_preprocess"].timeout == settings.job_timeout_default
+    assert subs["run_assign_speakers"].timeout == settings.job_timeout_default
+
+
+def test_adjust_subjob_timeouts_is_noop_without_duration(tmp_path):
+    """An unknown/zero duration must leave the enqueue-time timeouts intact."""
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(
+        id="job-url-noop",
+        filename="video",
+        source_url="https://www.youtube.com/watch?v=abc",
+        status=JobStatus.QUEUED,
+    )
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    generation = _current_generation(redis, job.id)
+
+    adjust_subjob_timeouts(redis, job.id, generation, None, settings)
+    adjust_subjob_timeouts(redis, job.id, generation, 0.0, settings)
+
+    subs = _by_stage(_load_subjobs(redis, job.id))
+    assert subs["run_transcribe_align"].timeout == settings.job_timeout_default
 
 
 def test_llm_enabled_dag_appends_llm_correction(tmp_path):

--- a/tests/unit/test_pipeline_dispatcher.py
+++ b/tests/unit/test_pipeline_dispatcher.py
@@ -197,6 +197,47 @@ def test_adjust_subjob_timeouts_is_noop_without_duration(tmp_path):
     assert subs["run_transcribe_align"].timeout == settings.job_timeout_default
 
 
+def test_adjust_subjob_timeouts_swallows_subjob_load_failure(tmp_path, monkeypatch):
+    """A Redis failure while loading the sub-job set must not propagate: the
+    preprocess hook that calls this runs after the stage already persisted its
+    output, so a resize failure must never fail that preprocess job."""
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(id="job-load-fail", filename="video", source_url="https://youtu.be/abc", status=JobStatus.QUEUED)
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    generation = _current_generation(redis, job.id)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("redis smembers failed")
+
+    monkeypatch.setattr("whisper_ui.worker.pipeline_dispatcher._load_subjob_ids", _boom)
+
+    # Must not raise (the reviewer's regression).
+    adjust_subjob_timeouts(redis, job.id, generation, 2000.0, settings)
+
+
+def test_adjust_subjob_timeouts_swallows_timeout_calc_failure(tmp_path, monkeypatch):
+    """A failure computing the new timeout is also best-effort, not fatal."""
+    redis = fakeredis.FakeRedis()
+    settings = _build_settings(ollama="")
+    filestore = _build_filestore(tmp_path)
+    job = Job(id="job-calc-fail", filename="video", source_url="https://youtu.be/abc", status=JobStatus.QUEUED)
+    enqueue_pipeline(job, redis=redis, settings=settings, filestore=filestore)
+    generation = _current_generation(redis, job.id)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("timeout calc failed")
+
+    monkeypatch.setattr("whisper_ui.worker.pipeline_dispatcher.calculate_job_timeout", _boom)
+
+    adjust_subjob_timeouts(redis, job.id, generation, 2000.0, settings)
+
+    # Sub-jobs keep their enqueue-time default since the resize was abandoned.
+    subs = _by_stage(_load_subjobs(redis, job.id))
+    assert subs["run_transcribe_align"].timeout == settings.job_timeout_default
+
+
 def test_llm_enabled_dag_appends_llm_correction(tmp_path):
     redis = fakeredis.FakeRedis()
     settings = _build_settings()

--- a/tests/unit/test_pipeline_stages.py
+++ b/tests/unit/test_pipeline_stages.py
@@ -255,20 +255,25 @@ class TestAlignStage:
         ):
             stage.execute({"transcription_result": {"segments": []}, "whisperx_audio": "audio"})
 
-    def test_alignment_failure_returns_context_without_aligned_result(self):
+    def test_alignment_failure_falls_back_to_transcription_result(self):
+        """An align failure must keep speaker assignment possible: the
+        unaligned transcription becomes the aligned_result so assign_speakers
+        can still attach segment-level speakers instead of skipping entirely
+        (which would silently discard diarization too)."""
         stage = AlignStage(device="cpu")
         mock_whisperx = MagicMock()
         mock_whisperx.load_align_model.side_effect = ValueError("model not found")
+        transcription = {"segments": [{"text": "hi"}], "language": "ja"}
 
         with patch.dict("sys.modules", {"whisperx": mock_whisperx}):
             context = {
-                "transcription_result": {"segments": [], "language": "ja"},
+                "transcription_result": transcription,
                 "whisperx_audio": "audio",
                 "language": "ja",
             }
             result = stage.execute(context)
 
-        assert "aligned_result" not in result
+        assert result["aligned_result"] is transcription
 
     def test_alignment_failure_reports_skipped_progress(self):
         stage = AlignStage(device="cpu")
@@ -310,22 +315,23 @@ class TestAlignStage:
         assert "ja" in str(call_args)
         assert "model not found" in str(call_args)
 
-    def test_align_execution_failure_skips_without_partial_result(self):
+    def test_align_execution_failure_falls_back_to_transcription_result(self):
         stage = AlignStage(device="cpu")
         mock_whisperx = MagicMock()
         mock_whisperx.load_align_model.return_value = ("model", "metadata")
         mock_whisperx.align.side_effect = RuntimeError("alignment crashed")
+        transcription = {"segments": [{"text": "hello"}], "language": "ja"}
         progress_calls = []
 
         with patch.dict("sys.modules", {"whisperx": mock_whisperx}):
             context = {
-                "transcription_result": {"segments": [{"text": "hello"}], "language": "ja"},
+                "transcription_result": transcription,
                 "whisperx_audio": "audio",
                 "language": "ja",
             }
             result = stage.execute(context, on_progress=lambda p, m: progress_calls.append((p, m)))
 
-        assert "aligned_result" not in result
+        assert result["aligned_result"] is transcription
         assert progress_calls[-1] == (1.0, ALIGN_SKIPPED)
         assert stage._model is not None
         assert stage._metadata is not None

--- a/tests/unit/test_stage_tasks.py
+++ b/tests/unit/test_stage_tasks.py
@@ -14,6 +14,7 @@ from whisper_ui.worker.runtime import WorkerRuntime
 from whisper_ui.worker.stage_tasks import (
     _banded_progress,
     _execute_stage,
+    _run_single_stage,
     pick_stage_weights,
     run_diarize,
     run_postprocess,
@@ -181,6 +182,32 @@ def test_run_diarize_only_persists_declared_output_keys(monkeypatch):
     assert stored["diarize_result"] == [("SPK0", 0.0, 1.0)]
     assert "stray_field" not in stored
     assert stored["audio_path"] == "/tmp/16k.wav"
+
+
+def test_run_single_stage_swallows_post_persist_failure(monkeypatch):
+    """A post_persist hook runs after the stage output is already persisted, so
+    its failure must be logged but never re-raised — otherwise a side effect
+    (e.g. resizing downstream timeouts) could fail an already-succeeded stage."""
+    fake_redis = fakeredis.FakeRedis()
+    job = Job(id="job-pp", status=JobStatus.PROCESSING, filepath="/tmp/a.mp3")
+    _install_fake_runtime(monkeypatch, fake_redis, job)
+    PipelineContextStore(fake_redis, "job-pp").initialize({})
+
+    def _boom(job, runtime, context):
+        raise RuntimeError("post_persist exploded")
+
+    fake_stage = _RecordingStage({"audio_path": "/tmp/16k.wav"})
+    result = _run_single_stage(
+        "job-pp",
+        stage_name="fake",
+        build_stage=lambda job, runtime: fake_stage,
+        output_keys=("audio_path",),
+        post_persist=_boom,
+    )
+
+    # The stage still completed and its output is persisted despite the hook.
+    assert result == "fake:job-pp"
+    assert PipelineContextStore(fake_redis, "job-pp").load()["audio_path"] == "/tmp/16k.wav"
 
 
 def test_run_preprocess_logs_stage_start_and_finish(monkeypatch, caplog):

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -5,7 +5,23 @@ from __future__ import annotations
 import pytest
 from fastapi import HTTPException
 
-from whisper_ui.web.validation import MAX_NUM_SPEAKERS, clamp_num_speakers, validate_hex_id
+from whisper_ui.core.models import JobStatus
+from whisper_ui.web.validation import (
+    MAX_NUM_SPEAKERS,
+    clamp_num_speakers,
+    normalize_status_filter,
+    validate_hex_id,
+)
+
+
+@pytest.mark.parametrize("valid", ["", *(s.value for s in JobStatus)])
+def test_normalize_status_filter_keeps_valid_values(valid):
+    assert normalize_status_filter(valid) == valid
+
+
+@pytest.mark.parametrize("bad", ["bogus", "COMPLETED", "queued ", "'; DROP TABLE jobs;--"])
+def test_normalize_status_filter_resets_unknown_to_all(bad):
+    assert normalize_status_filter(bad) == ""
 
 
 def test_validate_hex_id_accepts_32_lowercase_hex():

--- a/tests/unit/test_web_routes.py
+++ b/tests/unit/test_web_routes.py
@@ -721,7 +721,7 @@ class TestJobsRoutes:
         # The original is untouched; only the new version flips to FAILED with a
         # generic, leak-free message.
         assert db.get_job(src.id).status == JobStatus.COMPLETED
-        new_versions = db.list_jobs_by_source(src.id)
+        new_versions = [j for j in db.list_jobs() if j.source_job_id == src.id]
         assert len(new_versions) == 1
         assert new_versions[0].status == JobStatus.FAILED
         assert "secret" not in (new_versions[0].error or "")


### PR DESCRIPTION
## Why

A pre-release deep review found the project to be in good shape — no Critical issues, no significant over-engineering — with a handful of genuine fixes worth doing. This PR implements the actionable findings the maintainer signed off on, grouped into bug fixes (A), a doc alignment (B), and low-risk cleanup (C). All findings were verified against the source before fixing.

## How (one atomic commit per finding)

**Bug fixes**
- `fix: scale URL job stage timeouts once the duration is known` — A URL job is enqueued before its media is downloaded, so `job.duration` is `None` and every sub-job (including GPU transcribe/align and diarize) got `job_timeout_default`; a long video could be killed mid-inference, and retry did not help (URL jobs probe `None` on retry too). Once preprocess probes the real duration, `adjust_subjob_timeouts` re-applies `calculate_job_timeout` to the still-deferred GPU stages — the same duration-scaled death-penalty a file upload already gets. Generation-scoped, race-free (those stages `depends_on` preprocess so they are DEFERRED while it runs), best-effort.
- `fix: keep speaker labels when alignment fails` — When whisperx alignment failed, `AlignStage` returned without `aligned_result`, so `AssignSpeakersStage` skipped entirely and the diarization result was discarded — an align failure silently dropped **all** speaker labels (the core value prop), not just word-level timing. Align failure now carries the unaligned transcription forward; `whisperx.assign_word_speakers` accepts non-aligned input, so speakers are still attached at the segment level.
- `fix: offload batch pipeline enqueue off the event loop` — Both batch ingest routes looped over up to `MAX_BATCH_SIZE` jobs calling the synchronous `enqueue_pipeline` directly in the async handler, monopolising the event loop (and stalling the 3s `/jobs` poll) for the whole batch. It is now wrapped in `asyncio.to_thread`; the SQLite insert stays on the loop per the single-connection design.

**Cleanup**
- `refactor: remove unused list_jobs_by_source dead code` — The method + its index had no caller (no view lists a job's re-transcribe siblings); the migration comment claimed otherwise. Removed the method, the now-pointless index migration, and fixed the comment. The `source_job_id` column and its version badge are unchanged.
- `refactor: share the jobs status-filter validation helper` — The status whitelist check was written three ways across the job routes; consolidated into `validation.normalize_status_filter`. Behavior unchanged.
- `docs: note the SQLite progress mirror is not monotonic` — Comment-only clarification that Redis (Lua max-write) is the live source of truth.

**Docs**
- `docs: align README profile summary with compose.yml` — README's header/Tech-Stack summary said GPU/CPU only; updated to NVIDIA GPU / CPU / AMD ROCm to match the seven profiles compose.yml actually defines. (CLAUDE.md has the same staleness but is gitignored in this repo — local-only per `.gitignore`, synced from the upstream dev-guidelines template — so its fix belongs upstream, not here. The on-disk copy was corrected locally.)

## Verification

- 1005 unit tests pass; 4 integration tests pass (real pipeline wiring incl. the new preprocess hook); ruff + pre-commit clean; worker-module import sanity confirms the A① lazy import introduces no circular import. New regression tests cover A① (timeout resize / no-op), A② (align fallback), and `normalize_status_filter`; A③ is behavior-preserving and covered by existing batch-upload tests.
- 17 files, +267/−86 (under the 400-line guideline).

## Explicitly out of scope (left as-is)

Generation gating, the DAG, exporters, labels, the test structure, and the single-connection SQLite model were reviewed and judged appropriate — not changed for the sake of changing. Deferred minor follow-ups: gdown download timeout, language-fallback DRY, legacy-migration test parametrization, VTT special-char escaping check.