### PR TITLE
chore: release v2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.12.0] - 2026-06-10
+
 ### Fixed
 
 - The jobs list poll now actually morphs the DOM instead of replacing it:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.11.0"
+version = "2.12.0"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"


### PR DESCRIPTION
Release v2.12.0 — bundles the two post-release-review remediation rounds (PR #109 and #110).

## Highlights (full detail in CHANGELOG)

**Fixed**
- Jobs list poll now truly morphs the DOM (the `morph:{...}` whitespace bug that silently fell back to innerHTML); background polls no longer flash the global loader or spam error toasts; sticky chip counts refresh via OOB; export dropdown driven by focus alone; several `|tojson`-in-attribute breakages (status chips, dashboard greeting/ETA, admin reset dialog); `/jobs/list` validates the status filter.
- URL jobs get a duration-scaled death-penalty once preprocess probes the audio; failed alignment no longer discards speaker labels; large batch submits no longer block the event loop. The timeout-resize / post-persist / completion-cleanup paths were hardened to be genuinely best-effort.

**Changed**
- Removed the unused `list_jobs_by_source` dead code; consolidated the jobs status-filter validation helper.

## Release mechanics
- `pyproject.toml` 2.11.0 → 2.12.0; CHANGELOG `[Unreleased]` promoted to `[2.12.0]`.
- Tagging `v2.12.0` after merge triggers the full image build incl. the ROCm worker (needed to deploy 192.168.51.129's GPU worker).

No code changes in this PR beyond the version bump + changelog; all functional changes already landed and passed CI on main.