### PR TITLE
fix: ROCm worker SimpleWorker (release v2.12.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.12.1] - 2026-06-10
+
+### Fixed
+
+- Speaker diarization on AMD ROCm hosts failed with "Cannot re-initialize CUDA
+  in forked subprocess". The worker entrypoint only switched to RQ's
+  non-forking SimpleWorker for `DEVICE=cuda`, so the ROCm worker (`DEVICE=rocm`)
+  ran the default forking worker; because ROCm's PyTorch uses the `torch.cuda`
+  (HIP) API, GPU stages in a forked work-horse could not initialize the GPU
+  context. The guard now covers `cuda` and `rocm`. (Pre-existing since the
+  ROCm profile was added; not specific to a release.)
+
 ## [2.12.0] - 2026-06-10
 
 ### Fixed

--- a/docker/entrypoint-worker.sh
+++ b/docker/entrypoint-worker.sh
@@ -22,14 +22,21 @@ echo "Model cache directory: ${MODEL_DIR}"
 
 WORKER_QUEUES="${WORKER_QUEUES:-whisper:gpu whisper:io whisper:cpu whisper:llm default}"
 
-# CUDA cannot be re-initialised in a forked subprocess. When the device is
-# set to cuda, use SimpleWorker which runs jobs in the main process instead
-# of forking.
+# A GPU context cannot be re-initialised in a forked subprocess, so GPU
+# workers must run jobs in the main process via SimpleWorker (no per-job
+# fork) instead of RQ's default forking Worker. This applies to both cuda
+# and rocm: ROCm's PyTorch is a HIP build that still uses the torch.cuda API,
+# so it hits the identical "Cannot re-initialize CUDA in forked subprocess"
+# error (align/diarize fail). CPU workers keep the default forking Worker.
+# DEVICE is always set explicitly per worker in compose; "auto" is treated as
+# non-GPU here (no deployed worker uses it).
 WORKER_CLASS_ARG=""
-if [ "${DEVICE:-auto}" = "cuda" ]; then
+case "${DEVICE:-auto}" in
+cuda | rocm)
 	WORKER_CLASS_ARG="--worker-class rq.SimpleWorker"
-	echo "Using SimpleWorker to avoid CUDA fork issues"
-fi
+	echo "Using SimpleWorker (DEVICE=${DEVICE}) to avoid GPU fork-initialization errors"
+	;;
+esac
 
 echo "Starting RQ worker on queues: ${WORKER_QUEUES}"
 # shellcheck disable=SC2086

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.12.0"
+version = "2.12.1"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"


### PR DESCRIPTION
Patch release v2.12.1 — fixes speaker diarization on AMD ROCm hosts.

## Why
Diarization (and word-level alignment) failed on the ROCm worker with `Cannot re-initialize CUDA in forked subprocess`, failing jobs. Root cause: `docker/entrypoint-worker.sh` only switched to RQ's non-forking `SimpleWorker` when `DEVICE=cuda`, so the ROCm worker (`DEVICE=rocm`) ran the default **forking** Worker. ROCm's PyTorch is a HIP build that still uses the `torch.cuda` API, so a forked work-horse can't initialize the GPU context.

This is **pre-existing** since the ROCm profile was added — not introduced by v2.12.0 (that release didn't touch the entrypoint or compose). It surfaces whenever a diarization-enabled job runs on a ROCm host. The NVIDIA `cuda` worker was unaffected (its guard already fired).

## How
- `fix:` entrypoint guard changed from `DEVICE == cuda` to a `case` matching `cuda|rocm`, mirroring the proven CUDA path. CPU workers keep the default forking Worker. Verified the case logic for cuda/rocm/cpu/auto/unset; shellcheck + shfmt clean.
- `chore:` bump to 2.12.1, CHANGELOG `[2.12.1]`.

Tagging `v2.12.1` rebuilds all images incl. the ROCm worker; then 192.168.51.129 will be redeployed and a diarization job verified end-to-end.

Note: bash entrypoint logic has no unit-test harness in this repo (adding bats for one line would be over-engineering); shellcheck is the CI gate and the definitive check is the live diarization run after deploy.