### PR TITLE
chore: release v2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.13.0] - 2026-06-11
+
 ### Fixed
 
 - whisper.cpp transcriptions (ROCm profile) of recordings with long silence
@@ -18,6 +20,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   HF repo) and disables cross-window text conditioning
   (`WHISPERCPP_MAX_CONTEXT=0`), matching the protection the whisperx (CUDA)
   path already gets from its built-in VAD batching.
+- File-path checks across model resolution, result loading, media download
+  and source-audio copy now use `is_file()` instead of `exists()`, so a
+  same-named directory can no longer masquerade as a file and fail later
+  downstream; `get_source_media_path` also filters directories out of its
+  glob matches.
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.12.1"
+version = "2.13.0"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Why

發布 v2.13.0，將 PR #113 的 whisper.cpp 幻覺防護修復（VAD + auto 語言偵測 + 轉錄品質 gate）正式釋出。rocm worker image 只在 release tag 建置，發版後方可部署至 ROCm production 進行 e2e 驗收。

## How

- pyproject.toml 版本 2.12.1 → 2.13.0（新增功能，minor bump）
- CHANGELOG Unreleased 區段移至 [2.13.0] - 2026-06-11，並補上 is_file() 強健性修正條目

Merge 後將於 merge commit 上打 tag v2.13.0 觸發 image 建置。