### PR TITLE
fix: whisper.cpp VAD heap corruption, stderr truncation, DOCX control chars

### DIFF
--- a/docker/Dockerfile.worker.rocm
+++ b/docker/Dockerfile.worker.rocm
@@ -13,7 +13,7 @@
 
 ARG ROCM_BASE_IMAGE=rocm/dev-ubuntu-24.04:7.2.1-complete
 ARG AMDGPU_TARGETS=gfx1151
-ARG WHISPER_CPP_REF=v1.8.0
+ARG WHISPER_CPP_REF=v1.8.6
 
 # --- Stage 1: build whisper.cpp (HIP) ---
 FROM ${ROCM_BASE_IMAGE} AS whispercpp-build

--- a/src/whisper_ui/core/config.py
+++ b/src/whisper_ui/core/config.py
@@ -56,9 +56,9 @@ class Settings(BaseSettings):
     whispercpp_vad: bool = True
     # GGML Silero VAD model file, resolved like the main GGML model: a
     # pre-baked copy under the model dir wins, else fetched from the
-    # ggml-org/whisper-vad HF repo and cached under HF_HOME. v5.1.2 is the
-    # newest model the pinned whisper.cpp (v1.8.0) ships download support
-    # for; bump together with WHISPER_CPP_REF in Dockerfile.worker.rocm.
+    # ggml-org/whisper-vad HF repo and cached under HF_HOME. Must be loadable
+    # by the pinned whisper.cpp (WHISPER_CPP_REF in Dockerfile.worker.rocm);
+    # validated against the current pin, so revalidate when bumping either.
     whispercpp_vad_model: str = "ggml-silero-v5.1.2.bin"
     # Maximum text-context tokens carried across 30 s decode windows
     # (whisper-cli ``-mc``). 0 disables conditioning entirely — parity with

--- a/src/whisper_ui/export/docx_export.py
+++ b/src/whisper_ui/export/docx_export.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from whisper_ui.core.exceptions import ExportError
 from whisper_ui.core.messages import EXPORT_DOCX_HEADING
+from whisper_ui.export.utils import strip_control_chars
 
 if TYPE_CHECKING:
     from whisper_ui.core.models import TranscriptResult
@@ -41,7 +42,7 @@ class DocxExporter:
                 run.bold = True
                 run.font.size = Pt(11)
 
-            p = doc.add_paragraph(seg.text)
+            p = doc.add_paragraph(strip_control_chars(seg.text))
             p.style.font.size = Pt(10)
 
         buf = io.BytesIO()

--- a/src/whisper_ui/export/utils.py
+++ b/src/whisper_ui/export/utils.py
@@ -1,5 +1,22 @@
 from __future__ import annotations
 
+import re
+
+# C0 control characters that XML 1.0 forbids; tab / newline / carriage
+# return are XML-legal and excluded.
+_XML_INCOMPATIBLE_CHARS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
+
+
+def strip_control_chars(text: str) -> str:
+    """Drop control characters that python-docx (XML 1.0) rejects.
+
+    python-docx raises ``ValueError("All strings must be XML compatible")``
+    on these characters, turning one bad segment into a failed DOCX export.
+    Like the newline case in :func:`collapse_newlines`, the realistic source
+    is the optional LLM correction stage, not the ASR output itself.
+    """
+    return _XML_INCOMPATIBLE_CHARS.sub("", text)
+
 
 def format_timestamp(seconds: float, ms_separator: str = ",") -> str:
     h = int(seconds // 3600)

--- a/src/whisper_ui/pipeline/whispercpp_transcribe.py
+++ b/src/whisper_ui/pipeline/whispercpp_transcribe.py
@@ -203,7 +203,9 @@ class WhisperCppTranscribeStage:
             if proc.returncode != 0:
                 # Some builds emit diagnostics on stdout; fall back to it.
                 detail = proc.stderr.strip() or proc.stdout.strip()
-                raise TranscriptionError(f"whisper-cli failed (exit {proc.returncode}): {detail[:500]}")
+                # Keep the tail: stderr opens with a model-loading banner, so
+                # the actual cause of a late crash is at the end (#120).
+                raise TranscriptionError(f"whisper-cli failed (exit {proc.returncode}): {detail[-500:]}")
 
             json_path = Path(f"{out_prefix}.json")
             if not json_path.is_file():

--- a/tests/unit/test_export_docx.py
+++ b/tests/unit/test_export_docx.py
@@ -42,6 +42,20 @@ def test_docx_export_no_speakers():
     assert not any("SPEAKER" in t for t in texts)
 
 
+def test_docx_export_strips_control_chars():
+    # python-docx rejects XML-incompatible control characters outright, so a
+    # single polluted segment (realistically: LLM correction output) used to
+    # fail the whole export with ValueError.
+    result = TranscriptResult(
+        segments=[Segment(start=0.0, end=1.0, text="before\x08after")],
+    )
+    exporter = DocxExporter()
+    data = exporter.export(result)
+    doc = Document(io.BytesIO(data))
+    texts = [p.text for p in doc.paragraphs]
+    assert any("beforeafter" in t for t in texts)
+
+
 def test_docx_export_empty():
     result = TranscriptResult(segments=[])
     exporter = DocxExporter()

--- a/tests/unit/test_export_utils.py
+++ b/tests/unit/test_export_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from whisper_ui.export.utils import format_timestamp
+from whisper_ui.export.utils import format_timestamp, strip_control_chars
 
 
 def test_format_timestamp_comma():
@@ -17,3 +17,15 @@ def test_format_timestamp_dot():
 
 def test_format_timestamp_default_separator():
     assert format_timestamp(1.5) == "00:00:01,500"
+
+
+def test_strip_control_chars_removes_xml_incompatible():
+    assert strip_control_chars("a\x00b\x08c\x1fd") == "abcd"
+
+
+def test_strip_control_chars_keeps_legal_whitespace_and_text():
+    assert strip_control_chars("line1\nline2\ttab\rcr") == "line1\nline2\ttab\rcr"
+
+
+def test_strip_control_chars_preserves_cjk_and_fullwidth():
+    assert strip_control_chars("逐字稿。全形「測試」") == "逐字稿。全形「測試」"

--- a/tests/unit/test_whispercpp_transcribe.py
+++ b/tests/unit/test_whispercpp_transcribe.py
@@ -127,6 +127,19 @@ class TestExecute:
         ):
             stage.execute({"audio_path": "/tmp/a.wav"})
 
+    def test_failure_detail_keeps_stderr_tail(self):
+        # whisper-cli opens stderr with a model-loading banner; a crash after
+        # init (e.g. the #119 VAD abort) lands at the very end. Truncation
+        # must keep the tail, or the UI reports "loading model" as the cause.
+        stderr = "loading-banner " * 50 + "malloc(): invalid size (unsorted)"
+        stage = WhisperCppTranscribeStage()
+        with (
+            _patched_model_paths(),
+            patch(f"{_MODULE}.subprocess.run", return_value=MagicMock(returncode=-6, stderr=stderr)),
+            pytest.raises(TranscriptionError, match=r"malloc\(\): invalid size"),
+        ):
+            stage.execute({"audio_path": "/tmp/a.wav"})
+
     def test_missing_json_raises(self):
         stage = WhisperCppTranscribeStage()
         with (


### PR DESCRIPTION
## Why

2026-06-12 issue 盤點定案的三項修復（單一 PR、三個 atomic commits）：

1. **#119**：whisper.cpp v1.8.0 的 VAD sample reduction loop 有 off-by-one buffer overflow（buffer 以 `n_samples - 1` 配置、複製卻用 `n_samples`），特定音檔 100% heap corruption crash。上游已於 ggml-org/whisper.cpp#3558 修復（v1.8.3 收錄）。
2. **#120**：whisper-cli 失敗訊息截 stderr 前 500 字，開頭永遠是模型載入 banner，真正死因（在尾端）被截掉——已造成一次「模型載入失敗」誤判。
3. **DOCX 匯出控制字元 crash**（上輪 review 待查項，已實證）：python-docx 對 C0 控制字元拋 `ValueError`，單一污染 segment（現實來源為 LLM 校正輸出）會讓整份 DOCX 匯出失敗。

## How

- `docker/Dockerfile.worker.rocm`：`WHISPER_CPP_REF` v1.8.0 → v1.8.6（最新 stable，全 repo 唯一引用點）。
- `whispercpp_transcribe.py`：`detail[:500]` → `detail[-500:]`，附 why 註解與截尾保留測試。
- `export/utils.py` 新增 `strip_control_chars`（移除 XML 1.0 禁用的 C0 字元、保留 `\t\n\r`），`docx_export.py` 寫入前套用；與既有 `escape_vtt_text` / `collapse_newlines` 同一 hardening 家族。

## 升級的 merge 前驗證（129 測試機，gfx1151）

| 驗證 | 結果 |
| --- | --- |
| HIP build stage（`--target whispercpp-build`，v1.8.6） | 編譯通過，`/artifacts` 佈局不變（whisper-cli + libggml-hip.so 等） |
| v1.8.6 HIP binary 於實際 GPU 對 #119 重現檔啟用 VAD | **exit 0、23 段、7 秒完成**；同組合 v1.8.0 production binary 100% SIGABRT |
| silero v5.1.2 VAD 模型於 v1.8.6 | 正常載入運作 |
| CPU-only 對照組（v1.8.0 vs v1.8.6） | 兩版皆不 crash（off-by-one 是否撞毀 heap 取決於配置佈局，CPU 後端不觸發）；段數 23 vs 24 一致 |

最終確認門檻：下一個 release tag 的 rocm image 部署 129 後，以重現檔 + 18 分鐘基準檔（431 段基線）驗收轉錄特性無回歸。

## 已評估、明確排除的項目

- exit -6 自動關 VAD 重試機制：根因已修，預建降級機制違反 YAGNI。
- gdown 檔名 sanitization：pinned 5.2.2 內建 `_sanitize_filename`（wheel 原始碼確認），無風險。
- re-transcribe 以 display filename 推導路徑：無 rename 功能，正常流程不可達。
- `device.py` compute_type fallback 警告：`logger.warning` 為設計意圖（API symmetry）。

Closes #119
Closes #120

## 已知狀況

claude-review check 因 GitHub App token 問題在所有 PR 上 fail（與本 PR 無關）；lint / test 應綠。