### PR TITLE
chore: release v2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.14.0] - 2026-06-12
+
+Issue-sweep remediation (PR #121).
+
+### Fixed
+
+- whisper.cpp upgraded from v1.8.0 to v1.8.6, fixing a VAD buffer overflow
+  (upstream ggml-org/whisper.cpp#3558) that aborted transcription with heap
+  corruption on files whose VAD segment ends at the audio boundary (#119).
+- whisper-cli failure messages keep the tail of stderr instead of the
+  model-loading banner, so the actual crash cause reaches the UI (#120).
+- DOCX export strips XML-incompatible control characters instead of failing
+  the whole export when a segment carries one.
+
+### Changed
+
+- `uv.lock` records the current project version again (stale at 2.11.0
+  since the v2.12.0 release).
+
 ## [2.13.1] - 2026-06-11
 
 Full-codebase review remediation (PR #115). Highlights below; the PR

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.13.1"
+version = "2.14.0"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3955,7 +3955,7 @@ wheels = [
 
 [[package]]
 name = "whisper-ui"
-version = "2.11.0"
+version = "2.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Why

發布 PR #121 的修復批次：whisper.cpp v1.8.6（#119 VAD heap corruption 根治）、whisper-cli stderr 截尾（#120）、DOCX 控制字元 hardening。rocm image 只在 release tag 建置，部署 129/211 需要此版本。

## How

- pyproject `version = "2.14.0"`（whisper.cpp 引擎升級屬行為相關變更，採 minor bump）
- CHANGELOG `[2.14.0]` 條目
- `uv.lock` 自我版本欄位同步（自 v2.12.0 起 release 未跑 `uv lock`，停在 2.11.0；本次起納入 release 流程）

Merge 後將以 annotated tag `v2.14.0` 觸發 docker-publish 四個 image 建置，部署 129 驗收（#119 重現檔 + 18 分鐘基準檔）後同步 211。