### PR TITLE
feat: release idle GPU worker resources via WORKER_MAX_IDLE_TIME

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,12 @@ BATCH_SIZE=4
 #   WORKER_IO_QUEUES="whisper:io whisper:cpu default"
 #   WORKER_LLM_QUEUES="whisper:llm default"
 #   docker compose --profile rocm --profile io --profile llm-worker up -d --scale worker-io=2
+# WORKER_MAX_IDLE_TIME: seconds a GPU worker (cuda/rocm SimpleWorker) stays alive
+# with no job before exiting so its restart policy respawns a fresh process,
+# freeing the resident GPU context + RSS. Defaulted to 300 for worker-gpu/
+# worker-rocm; 0 disables (always-resident). Lower = release sooner / reload on
+# next job; higher = stay warm. CPU/io/llm workers fork per job and ignore it.
+# WORKER_MAX_IDLE_TIME=300
 
 # Language
 LANGUAGE=zh

--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,7 @@ BATCH_SIZE=4
 # freeing the resident GPU context + RSS. Defaulted to 300 for worker-gpu/
 # worker-rocm; 0 disables (always-resident). Lower = release sooner / reload on
 # next job; higher = stay warm. CPU/io/llm workers fork per job and ignore it.
+# Must be a non-negative integer; an invalid value is ignored with a warning.
 # WORKER_MAX_IDLE_TIME=300
 
 # Language

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   inject commands or extra CLI tokens: `WORKER_MAX_IDLE_TIME` is validated in the
   entrypoint; the `ollama-pull` sidecar runs `ollama pull` in exec form and the
   redis healthcheck references `REDIS_PASSWORD` as a runtime env var (rather than
-  interpolating either into a `sh -c` string); `REDIS_MAXMEMORY` is quoted in the
-  redis command string so a malformed value fails loudly instead of injecting.
+  interpolating either into a `sh -c` string); and the redis server command is
+  built in list form so `REDIS_MAXMEMORY` / `REDIS_PASSWORD` are literal argv
+  elements that cannot re-tokenize into extra redis options.
 
 ## [2.14.0] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `SimpleWorker`) self-exit after a spell with no job so the
   `restart: unless-stopped` policy respawns a fresh process, returning the
   resident GPU context and host RSS to the OS. Defaulted to `300` seconds for
-  `worker-gpu` / `worker-rocm`; `0` disables. See README "GPU worker resource
-  lifecycle".
+  `worker-gpu` / `worker-rocm`; `0` disables, and a non-integer/negative value
+  is ignored with a warning. See README "GPU worker resource lifecycle".
 
 ### Changed
 
@@ -22,6 +22,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   process after `WORKER_MAX_IDLE_TIME` seconds of inactivity, instead of holding
   the CUDA/HIP context for the lifetime of the container. Set
   `WORKER_MAX_IDLE_TIME=0` to keep the previous always-resident behaviour.
+- Operator-set values interpolated into container command strings are quoted /
+  validated so a malformed value cannot word-split extra CLI tokens into the
+  command: `WORKER_MAX_IDLE_TIME` (entrypoint), and `OLLAMA_MODEL` /
+  `REDIS_MAXMEMORY` (compose command strings).
 
 ## [2.14.0] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   process after `WORKER_MAX_IDLE_TIME` seconds of inactivity, instead of holding
   the CUDA/HIP context for the lifetime of the container. Set
   `WORKER_MAX_IDLE_TIME=0` to keep the previous always-resident behaviour.
-- Operator-set values interpolated into container command strings are quoted /
-  validated so a malformed value cannot word-split extra CLI tokens into the
-  command: `WORKER_MAX_IDLE_TIME` (entrypoint), and `OLLAMA_MODEL` /
-  `REDIS_MAXMEMORY` (compose command strings).
+- Operator-set values are kept out of shell parsing so a malformed value cannot
+  inject commands or extra CLI tokens: `WORKER_MAX_IDLE_TIME` is validated in the
+  entrypoint; the `ollama-pull` sidecar runs `ollama pull` in exec form and the
+  redis healthcheck references `REDIS_PASSWORD` as a runtime env var (rather than
+  interpolating either into a `sh -c` string); `REDIS_MAXMEMORY` is quoted in the
+  redis command string so a malformed value fails loudly instead of injecting.
 
 ## [2.14.0] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- `WORKER_MAX_IDLE_TIME` lets GPU workers (cuda/rocm, which run the non-forking
+  `SimpleWorker`) self-exit after a spell with no job so the
+  `restart: unless-stopped` policy respawns a fresh process, returning the
+  resident GPU context and host RSS to the OS. Defaulted to `300` seconds for
+  `worker-gpu` / `worker-rocm`; `0` disables. See README "GPU worker resource
+  lifecycle".
+
+### Changed
+
+- GPU/ROCm workers now release idle GPU memory and RSS by recycling the worker
+  process after `WORKER_MAX_IDLE_TIME` seconds of inactivity, instead of holding
+  the CUDA/HIP context for the lifetime of the container. Set
+  `WORKER_MAX_IDLE_TIME=0` to keep the previous always-resident behaviour.
+
 ## [2.14.0] - 2026-06-12
 
 Issue-sweep remediation (PR #121).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `SimpleWorker`) self-exit after a spell with no job so the
   `restart: unless-stopped` policy respawns a fresh process, returning the
   resident GPU context and host RSS to the OS. Defaulted to `300` seconds for
-  `worker-gpu` / `worker-rocm`; `0` disables, and a non-integer/negative value
-  is ignored with a warning. See README "GPU worker resource lifecycle".
+  `worker-gpu` / `worker-rocm`; `0` disables, and a non-integer/negative/overlong
+  value is ignored with a warning. See README "GPU worker resource lifecycle".
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -339,9 +339,9 @@ no work, and `restart: unless-stopped` respawns a fresh process, handing the
 context and RSS back to the OS. It triggers only while idle, so a running job is
 never interrupted and back-to-back jobs stay warm.
 
-| Variable               | Default | Description                                                                                                                                                                                                                                                                 |
-| ---------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `WORKER_MAX_IDLE_TIME` | `300`   | Seconds a GPU worker stays alive with no job before exiting so its `restart` policy respawns a fresh process and frees VRAM + RSS. `0` disables (always-resident). Defaulted on only for `worker-gpu` / `worker-rocm`; CPU/io/llm workers fork per job and release on exit. |
+| Variable               | Default | Description                                                                                                                                                                                                                                                                                                                                             |
+| ---------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `WORKER_MAX_IDLE_TIME` | `300`   | Seconds a GPU worker stays alive with no job before exiting so its `restart` policy respawns a fresh process and frees VRAM + RSS. `0` disables (always-resident). Must be a non-negative integer; an invalid value is ignored with a warning. Defaulted on only for `worker-gpu` / `worker-rocm`; CPU/io/llm workers fork per job and release on exit. |
 
 > A low value (e.g. `60`) releases resources quickly after each session at the
 > cost of reloading models on the next job; a high value keeps the worker warm

--- a/README.md
+++ b/README.md
@@ -318,6 +318,39 @@ manually before restart: `redis-cli -n 0 FLUSHDB` against the
 `REDIS_URL` Redis only clears RQ state (uploads, the SQLite DB, and
 saved transcripts are untouched).
 
+### GPU worker resource lifecycle (advanced)
+
+GPU workers (`cuda` / `rocm`) run RQ's non-forking `SimpleWorker`: every job
+executes in one long-lived process, because a CUDA/HIP context cannot be
+re-initialised in a forked child. CPU workers keep RQ's default forking
+`Worker`, where each job runs in a work-horse child that exits on completion, so
+the OS reclaims its memory automatically.
+
+The trade-off is that a `SimpleWorker` never exits on its own. Each pipeline
+stage releases its model after running (`del` + `gc.collect()` +
+`torch.cuda.empty_cache()`), which returns the model weights to the driver's
+free pool — but `empty_cache()` cannot destroy the process's CUDA/HIP context or
+the mapped GPU runtime libraries (cuBLAS / MIOpen / rocBLAS, etc.). Those stay
+resident, so a GPU worker holds a baseline of VRAM and host RSS between jobs
+until the process restarts.
+
+`WORKER_MAX_IDLE_TIME` closes that gap: the worker self-exits after a spell with
+no work, and `restart: unless-stopped` respawns a fresh process, handing the
+context and RSS back to the OS. It triggers only while idle, so a running job is
+never interrupted and back-to-back jobs stay warm.
+
+| Variable               | Default | Description                                                                                                                                                                                                                                                                 |
+| ---------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `WORKER_MAX_IDLE_TIME` | `300`   | Seconds a GPU worker stays alive with no job before exiting so its `restart` policy respawns a fresh process and frees VRAM + RSS. `0` disables (always-resident). Defaulted on only for `worker-gpu` / `worker-rocm`; CPU/io/llm workers fork per job and release on exit. |
+
+> A low value (e.g. `60`) releases resources quickly after each session at the
+> cost of reloading models on the next job; a high value keeps the worker warm
+> for longer. Within a single pipeline run the GPU sub-jobs (transcribe/align
+> and diarize) run back-to-back with no idle gap, so the default `300` never
+> restarts mid-run. On AMD/ROCm only diarization and alignment run in-process
+> (transcription shells out to whisper.cpp, which already frees on exit), so the
+> resident baseline is smaller than on CUDA.
+
 ### Queue / Timeout tuning (advanced)
 
 The RQ job timeout is derived from the probed audio duration
@@ -417,6 +450,13 @@ Override either variable in `.env` if your topology differs.
 GPU to stay resident. On an 8 GB or shared GPU (e.g. running Whisper on the same
 card), use `gemma4:e2b` (~7.2 GB), point `OLLAMA_BASE_URL` at an external Ollama
 server, or split Whisper and Ollama onto separate GPUs as above.
+
+> **VRAM retention vs reload latency:** `OLLAMA_KEEP_ALIVE` (default `30m`) sets
+> how long Ollama keeps the model resident in VRAM after the last correction
+> request. On a GPU shared with Whisper, a long keep-alive holds several GB
+> hostage between jobs — lower it (e.g. `5m`, or `0` to unload immediately) to
+> free VRAM for transcription; raise it only on a dedicated LLM GPU where reload
+> latency matters more than footprint.
 
 **Tuning (all optional):**
 

--- a/compose.yml
+++ b/compose.yml
@@ -58,6 +58,17 @@ x-download-env: &download-env
   YOUTUBE_MAX_DURATION: ${YOUTUBE_MAX_DURATION:-14400}
   TWITTER_MAX_DURATION: ${TWITTER_MAX_DURATION:-14400}
   TWITTER_COOKIES_FILE: ${TWITTER_COOKIES_FILE:-}
+# GPU worker resource lifecycle. cuda / rocm workers run rq.SimpleWorker in one
+# long-lived process, so the GPU context and mapped runtime libraries stay
+# resident until that process exits (per-stage cleanup frees model weights via
+# torch.cuda.empty_cache(), but never the context itself). WORKER_MAX_IDLE_TIME
+# (seconds) makes the worker self-exit after idling that long; the worker's
+# `restart: unless-stopped` then respawns a fresh process, handing the GPU
+# memory + RSS back to the OS. 0 disables (the always-resident behaviour). Only
+# the GPU workers default it on — CPU/io/llm workers fork per job and already
+# release on exit. See README "GPU worker resource lifecycle".
+x-gpu-lifecycle-env: &gpu-lifecycle-env
+  WORKER_MAX_IDLE_TIME: ${WORKER_MAX_IDLE_TIME:-300}
 services:
   frontend:
     image: ghcr.io/fdff87554/whisper-ui-frontend:${WHISPER_UI_VERSION:-latest}
@@ -152,7 +163,7 @@ services:
         PIP_INDEX_URL: ${PIP_INDEX_URL:-}
         DENO_VERSION: ${DENO_VERSION:-2.8.3}
     environment:
-      !!merge <<: [*core-env, *timeout-env, *llm-env, *download-env]
+      !!merge <<: [*core-env, *timeout-env, *llm-env, *download-env, *gpu-lifecycle-env]
       # Queues this worker listens on. The default includes every queue so a
       # single-profile `docker compose --profile gpu up` still runs the full
       # pipeline end-to-end. For the scaled topology, set
@@ -224,7 +235,7 @@ services:
         AMDGPU_TARGETS: ${AMDGPU_TARGETS:-gfx1151}
         DENO_VERSION: ${DENO_VERSION:-2.8.3}
     environment:
-      !!merge <<: [*core-env, *timeout-env, *llm-env, *download-env]
+      !!merge <<: [*core-env, *timeout-env, *llm-env, *download-env, *gpu-lifecycle-env]
       WORKER_QUEUES: ${WORKER_ROCM_QUEUES:-whisper:gpu whisper:io whisper:cpu whisper:llm default}
       WHISPER_MODEL: ${WHISPER_MODEL:-large-v3}
       DEVICE: rocm

--- a/compose.yml
+++ b/compose.yml
@@ -117,7 +117,23 @@ services:
     # only work-queue / DAG state (RQ registries, generation counters, sub-job
     # sets, pipeline context) — none of it is safe to evict, so an eviction
     # policy would silently corrupt the pipeline. Only the cap VALUE is tunable.
-    command: redis-server --appendonly yes --maxmemory "${REDIS_MAXMEMORY:-0}" --maxmemory-policy noeviction ${REDIS_PASSWORD:+--requirepass "${REDIS_PASSWORD}"}
+    # List form (not a shell string): each element is a literal argv token, so an
+    # operator value containing quotes/spaces cannot re-tokenize into extra redis
+    # options — a balanced-quote string command does inject (e.g. a password
+    # `pw" --port 9999 "` would add `--port`). Keeping `redis-server` as argv[0]
+    # lets the official entrypoint still chown /data and drop to the `redis` user.
+    # `--requirepass ""` (empty, when REDIS_PASSWORD is unset) means no auth,
+    # matching the previous omit-when-unset behaviour.
+    command:
+      - redis-server
+      - --appendonly
+      - "yes"
+      - --maxmemory
+      - "${REDIS_MAXMEMORY:-0}"
+      - --maxmemory-policy
+      - noeviction
+      - --requirepass
+      - "${REDIS_PASSWORD:-}"
     # Pass the password as a container env so the healthcheck references it as a
     # runtime shell variable (the `$$` is compose-escaped to a literal `$`), kept
     # in double quotes. The value is then data the container shell expands, never

--- a/compose.yml
+++ b/compose.yml
@@ -353,10 +353,14 @@ services:
   ollama-pull:
     profiles: [llm]
     image: ollama/ollama:latest
-    entrypoint: /bin/sh
-    command:
-      - -c
-      - 'OLLAMA_HOST=http://ollama:11434 ollama pull "${OLLAMA_MODEL:-gemma4:e4b}"'
+    # Exec form (no shell): OLLAMA_MODEL reaches `ollama pull` as a single literal
+    # argv element, so a model name containing shell metacharacters cannot be
+    # parsed as a command. (Quoting it inside a `sh -c` string would not — an
+    # embedded `"` closes the quote and injects.)
+    environment:
+      OLLAMA_HOST: http://ollama:11434
+    entrypoint: ["ollama"]
+    command: ["pull", "${OLLAMA_MODEL:-gemma4:e4b}"]
     depends_on:
       ollama:
         condition: service_healthy

--- a/compose.yml
+++ b/compose.yml
@@ -117,7 +117,7 @@ services:
     # only work-queue / DAG state (RQ registries, generation counters, sub-job
     # sets, pipeline context) — none of it is safe to evict, so an eviction
     # policy would silently corrupt the pipeline. Only the cap VALUE is tunable.
-    command: redis-server --appendonly yes --maxmemory ${REDIS_MAXMEMORY:-0} --maxmemory-policy noeviction ${REDIS_PASSWORD:+--requirepass "${REDIS_PASSWORD}"}
+    command: redis-server --appendonly yes --maxmemory "${REDIS_MAXMEMORY:-0}" --maxmemory-policy noeviction ${REDIS_PASSWORD:+--requirepass "${REDIS_PASSWORD}"}
     volumes:
       - redis-data:/data
     healthcheck:
@@ -356,7 +356,7 @@ services:
     entrypoint: /bin/sh
     command:
       - -c
-      - 'OLLAMA_HOST=http://ollama:11434 ollama pull ${OLLAMA_MODEL:-gemma4:e4b}'
+      - 'OLLAMA_HOST=http://ollama:11434 ollama pull "${OLLAMA_MODEL:-gemma4:e4b}"'
     depends_on:
       ollama:
         condition: service_healthy

--- a/compose.yml
+++ b/compose.yml
@@ -118,10 +118,17 @@ services:
     # sets, pipeline context) — none of it is safe to evict, so an eviction
     # policy would silently corrupt the pipeline. Only the cap VALUE is tunable.
     command: redis-server --appendonly yes --maxmemory "${REDIS_MAXMEMORY:-0}" --maxmemory-policy noeviction ${REDIS_PASSWORD:+--requirepass "${REDIS_PASSWORD}"}
+    # Pass the password as a container env so the healthcheck references it as a
+    # runtime shell variable (the `$$` is compose-escaped to a literal `$`), kept
+    # in double quotes. The value is then data the container shell expands, never
+    # interpolated into the script text — so a password with shell metacharacters
+    # cannot break out (unlike compose-interpolating it into the sh -c string).
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
     volumes:
       - redis-data:/data
     healthcheck:
-      test: ["CMD-SHELL", "${REDIS_PASSWORD:+REDISCLI_AUTH=\"${REDIS_PASSWORD}\"} redis-cli ping"]
+      test: ["CMD-SHELL", "[ -z \"$$REDIS_PASSWORD\" ] || export REDISCLI_AUTH=\"$$REDIS_PASSWORD\"; redis-cli ping"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker/entrypoint-worker.sh
+++ b/docker/entrypoint-worker.sh
@@ -38,10 +38,22 @@ cuda | rocm)
 	;;
 esac
 
+# Optional idle self-exit. When WORKER_MAX_IDLE_TIME (seconds) is >0 the worker
+# quits after that long without a job; paired with compose `restart:
+# unless-stopped` a fresh process respawns. This is the only way a long-lived
+# SimpleWorker (cuda/rocm) hands its GPU context + RSS back to the OS between
+# sessions — torch.cuda.empty_cache() frees model weights but never the context.
+WORKER_MAX_IDLE_ARG=""
+if [ -n "${WORKER_MAX_IDLE_TIME:-}" ] && [ "${WORKER_MAX_IDLE_TIME}" != "0" ]; then
+	WORKER_MAX_IDLE_ARG="--max-idle-time ${WORKER_MAX_IDLE_TIME}"
+	echo "Worker will exit after ${WORKER_MAX_IDLE_TIME}s idle (restart policy reclaims GPU/RSS)"
+fi
+
 echo "Starting RQ worker on queues: ${WORKER_QUEUES}"
 # shellcheck disable=SC2086
 exec python -m whisper_ui.worker worker \
 	--url "${REDIS_URL:-redis://redis:6379/0}" \
 	--name "whisper-worker-$(hostname)" \
 	${WORKER_CLASS_ARG} \
+	${WORKER_MAX_IDLE_ARG} \
 	${WORKER_QUEUES}

--- a/docker/entrypoint-worker.sh
+++ b/docker/entrypoint-worker.sh
@@ -54,13 +54,21 @@ case "${WORKER_MAX_IDLE_TIME:-}" in
 	echo "WARNING: ignoring WORKER_MAX_IDLE_TIME='${WORKER_MAX_IDLE_TIME}' — must be a non-negative integer; worker will stay resident" >&2
 	;;
 *)
-	# All digits: normalize with 10# (avoids octal interpretation, strips leading
-	# zeros) so "00" → 0 and "0300" → 300. 0 means disabled, so only pass the flag
-	# when the value is greater than zero.
-	worker_idle_seconds=$((10#${WORKER_MAX_IDLE_TIME}))
-	if [ "${worker_idle_seconds}" -gt 0 ]; then
-		WORKER_MAX_IDLE_ARG="--max-idle-time ${worker_idle_seconds}"
-		echo "Worker will exit after ${worker_idle_seconds}s idle (restart policy reclaims GPU/RSS)"
+	# All digits. bash arithmetic is signed 64-bit, so a value with more than 18
+	# digits can overflow and wrap to a negative or wrong-positive number; reject
+	# it up front (no real idle timeout needs 19+ digits, and any value of ≤ 18
+	# digits is < 10^18 < 2^63, so it never overflows).
+	if [ "${#WORKER_MAX_IDLE_TIME}" -gt 18 ]; then
+		echo "WARNING: ignoring WORKER_MAX_IDLE_TIME='${WORKER_MAX_IDLE_TIME}' — value too large; worker will stay resident" >&2
+	else
+		# Normalize with 10# (avoids octal interpretation, strips leading zeros) so
+		# "00" → 0 and "0300" → 300. 0 means disabled, so only pass the flag when
+		# the value is greater than zero.
+		worker_idle_seconds=$((10#${WORKER_MAX_IDLE_TIME}))
+		if [ "${worker_idle_seconds}" -gt 0 ]; then
+			WORKER_MAX_IDLE_ARG="--max-idle-time ${worker_idle_seconds}"
+			echo "Worker will exit after ${worker_idle_seconds}s idle (restart policy reclaims GPU/RSS)"
+		fi
 	fi
 	;;
 esac

--- a/docker/entrypoint-worker.sh
+++ b/docker/entrypoint-worker.sh
@@ -44,10 +44,26 @@ esac
 # SimpleWorker (cuda/rocm) hands its GPU context + RSS back to the OS between
 # sessions — torch.cuda.empty_cache() frees model weights but never the context.
 WORKER_MAX_IDLE_ARG=""
-if [ -n "${WORKER_MAX_IDLE_TIME:-}" ] && [ "${WORKER_MAX_IDLE_TIME}" != "0" ]; then
-	WORKER_MAX_IDLE_ARG="--max-idle-time ${WORKER_MAX_IDLE_TIME}"
-	echo "Worker will exit after ${WORKER_MAX_IDLE_TIME}s idle (restart policy reclaims GPU/RSS)"
-fi
+case "${WORKER_MAX_IDLE_TIME:-}" in
+"") ;; # unset → idle self-exit disabled (worker stays resident)
+*[!0-9]*)
+	# Non-digit, negative, or whitespace-containing value. Ignore it (rather than
+	# crash-loop the worker on an invalid rq arg, or word-split an extra token into
+	# the command) and fall back to the resident default. The value is logged so a
+	# misconfiguration is still visible at startup.
+	echo "WARNING: ignoring WORKER_MAX_IDLE_TIME='${WORKER_MAX_IDLE_TIME}' — must be a non-negative integer; worker will stay resident" >&2
+	;;
+*)
+	# All digits: normalize with 10# (avoids octal interpretation, strips leading
+	# zeros) so "00" → 0 and "0300" → 300. 0 means disabled, so only pass the flag
+	# when the value is greater than zero.
+	worker_idle_seconds=$((10#${WORKER_MAX_IDLE_TIME}))
+	if [ "${worker_idle_seconds}" -gt 0 ]; then
+		WORKER_MAX_IDLE_ARG="--max-idle-time ${worker_idle_seconds}"
+		echo "Worker will exit after ${worker_idle_seconds}s idle (restart policy reclaims GPU/RSS)"
+	fi
+	;;
+esac
 
 echo "Starting RQ worker on queues: ${WORKER_QUEUES}"
 # shellcheck disable=SC2086

--- a/tests/unit/test_entrypoint_worker.py
+++ b/tests/unit/test_entrypoint_worker.py
@@ -94,7 +94,7 @@ def test_idle_flag_is_device_agnostic_but_simpleworker_is_gpu_only(tmp_path: Pat
     assert "--worker-class rq.SimpleWorker" not in argv
 
 
-@pytest.mark.parametrize("bad", ["abc", "-5", "+5", "1e3", "0x10", "300 foo", "  "])
+@pytest.mark.parametrize("bad", ["abc", "-5", "+5", "1e3", "0x10", "300 foo", "  ", "99999999999999999999"])
 def test_invalid_idle_time_is_ignored_with_warning(tmp_path: Path, bad: str) -> None:
     result = _run_entrypoint(tmp_path, {"DEVICE": "rocm", "WORKER_MAX_IDLE_TIME": bad})
     argv = _argv_line(result)

--- a/tests/unit/test_entrypoint_worker.py
+++ b/tests/unit/test_entrypoint_worker.py
@@ -1,0 +1,77 @@
+"""Behavioural tests for ``docker/entrypoint-worker.sh`` argument assembly.
+
+The entrypoint builds the RQ worker invocation from environment variables
+(``DEVICE`` selects ``SimpleWorker``; ``WORKER_MAX_IDLE_TIME`` adds
+``--max-idle-time``). These tests run the real script with a stub ``python`` on
+``PATH`` that prints the argv it was ``exec``'d with, so we assert on the exact
+flags the worker would receive without launching RQ or a container.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_ENTRYPOINT = Path(__file__).resolve().parents[2] / "docker" / "entrypoint-worker.sh"
+_STUB_PREFIX = "STUB_PYTHON_ARGS:"
+
+
+def _run_entrypoint(tmp_path: Path, env_overrides: dict[str, str]) -> str:
+    """Run the entrypoint with a stub ``python`` and return the exec'd argv line.
+
+    The stub shadows the real interpreter via ``PATH`` and echoes its arguments,
+    so the string returned is exactly what ``exec python -m whisper_ui.worker
+    worker ...`` would have launched.
+    """
+    stub = tmp_path / "python"
+    stub.write_text(f'#!/bin/sh\necho "{_STUB_PREFIX} $*"\n')
+    stub.chmod(0o755)
+
+    env = {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}", **env_overrides}
+    result = subprocess.run(
+        ["bash", str(_ENTRYPOINT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+
+    for line in result.stdout.splitlines():
+        if line.startswith(_STUB_PREFIX):
+            return line
+    raise AssertionError(f"entrypoint did not exec the stub python; stdout:\n{result.stdout}")
+
+
+def test_rocm_worker_gets_simpleworker_and_idle_flag(tmp_path: Path) -> None:
+    argv = _run_entrypoint(tmp_path, {"DEVICE": "rocm", "WORKER_MAX_IDLE_TIME": "300"})
+
+    assert "--worker-class rq.SimpleWorker" in argv
+    assert "--max-idle-time 300" in argv
+
+
+def test_cuda_worker_without_idle_time_omits_idle_flag(tmp_path: Path) -> None:
+    argv = _run_entrypoint(tmp_path, {"DEVICE": "cuda"})
+
+    assert "--worker-class rq.SimpleWorker" in argv
+    assert "--max-idle-time" not in argv
+
+
+def test_idle_time_zero_is_treated_as_disabled(tmp_path: Path) -> None:
+    argv = _run_entrypoint(tmp_path, {"DEVICE": "cuda", "WORKER_MAX_IDLE_TIME": "0"})
+
+    assert "--max-idle-time" not in argv
+
+
+@pytest.mark.parametrize("device", ["cpu", "auto"])
+def test_idle_flag_is_device_agnostic_but_simpleworker_is_gpu_only(tmp_path: Path, device: str) -> None:
+    # The idle-release mechanism is a generic rq flag (the entrypoint adds it
+    # whenever WORKER_MAX_IDLE_TIME is set); only the SimpleWorker class is
+    # gated to GPU devices. Compose only defaults the var on for GPU workers.
+    argv = _run_entrypoint(tmp_path, {"DEVICE": device, "WORKER_MAX_IDLE_TIME": "120"})
+
+    assert "--max-idle-time 120" in argv
+    assert "--worker-class rq.SimpleWorker" not in argv

--- a/tests/unit/test_entrypoint_worker.py
+++ b/tests/unit/test_entrypoint_worker.py
@@ -30,7 +30,7 @@ def _run_entrypoint(tmp_path: Path, env_overrides: dict[str, str]) -> subprocess
     stub.write_text(f'#!/bin/sh\necho "{_STUB_PREFIX} $*"\n')
     stub.chmod(0o755)
 
-    env = {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}", **env_overrides}
+    env = {**os.environ, "PATH": f"{tmp_path}:{os.environ.get('PATH', '')}", **env_overrides}
     return subprocess.run(
         ["bash", str(_ENTRYPOINT)],
         env=env,

--- a/tests/unit/test_entrypoint_worker.py
+++ b/tests/unit/test_entrypoint_worker.py
@@ -1,7 +1,7 @@
 """Behavioural tests for ``docker/entrypoint-worker.sh`` argument assembly.
 
 The entrypoint builds the RQ worker invocation from environment variables
-(``DEVICE`` selects ``SimpleWorker``; ``WORKER_MAX_IDLE_TIME`` adds
+(``DEVICE`` selects ``SimpleWorker``; ``WORKER_MAX_IDLE_TIME`` adds a validated
 ``--max-idle-time``). These tests run the real script with a stub ``python`` on
 ``PATH`` that prints the argv it was ``exec``'d with, so we assert on the exact
 flags the worker would receive without launching RQ or a container.
@@ -19,19 +19,19 @@ _ENTRYPOINT = Path(__file__).resolve().parents[2] / "docker" / "entrypoint-worke
 _STUB_PREFIX = "STUB_PYTHON_ARGS:"
 
 
-def _run_entrypoint(tmp_path: Path, env_overrides: dict[str, str]) -> str:
-    """Run the entrypoint with a stub ``python`` and return the exec'd argv line.
+def _run_entrypoint(tmp_path: Path, env_overrides: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    """Run the entrypoint with a stub ``python`` and return the completed process.
 
     The stub shadows the real interpreter via ``PATH`` and echoes its arguments,
-    so the string returned is exactly what ``exec python -m whisper_ui.worker
-    worker ...`` would have launched.
+    so ``result.stdout`` carries exactly what ``exec python -m whisper_ui.worker
+    worker ...`` would have launched, and ``result.stderr`` carries any WARNING.
     """
     stub = tmp_path / "python"
     stub.write_text(f'#!/bin/sh\necho "{_STUB_PREFIX} $*"\n')
     stub.chmod(0o755)
 
     env = {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}", **env_overrides}
-    result = subprocess.run(
+    return subprocess.run(
         ["bash", str(_ENTRYPOINT)],
         env=env,
         capture_output=True,
@@ -40,6 +40,9 @@ def _run_entrypoint(tmp_path: Path, env_overrides: dict[str, str]) -> str:
         check=True,
     )
 
+
+def _argv_line(result: subprocess.CompletedProcess[str]) -> str:
+    """Extract the rq argv line the stub python printed."""
     for line in result.stdout.splitlines():
         if line.startswith(_STUB_PREFIX):
             return line
@@ -47,31 +50,69 @@ def _run_entrypoint(tmp_path: Path, env_overrides: dict[str, str]) -> str:
 
 
 def test_rocm_worker_gets_simpleworker_and_idle_flag(tmp_path: Path) -> None:
-    argv = _run_entrypoint(tmp_path, {"DEVICE": "rocm", "WORKER_MAX_IDLE_TIME": "300"})
+    argv = _argv_line(_run_entrypoint(tmp_path, {"DEVICE": "rocm", "WORKER_MAX_IDLE_TIME": "300"}))
 
     assert "--worker-class rq.SimpleWorker" in argv
     assert "--max-idle-time 300" in argv
 
 
 def test_cuda_worker_without_idle_time_omits_idle_flag(tmp_path: Path) -> None:
-    argv = _run_entrypoint(tmp_path, {"DEVICE": "cuda"})
+    argv = _argv_line(_run_entrypoint(tmp_path, {"DEVICE": "cuda"}))
 
     assert "--worker-class rq.SimpleWorker" in argv
     assert "--max-idle-time" not in argv
 
 
 def test_idle_time_zero_is_treated_as_disabled(tmp_path: Path) -> None:
-    argv = _run_entrypoint(tmp_path, {"DEVICE": "cuda", "WORKER_MAX_IDLE_TIME": "0"})
+    argv = _argv_line(_run_entrypoint(tmp_path, {"DEVICE": "cuda", "WORKER_MAX_IDLE_TIME": "0"}))
 
     assert "--max-idle-time" not in argv
+
+
+def test_zero_padded_value_is_disabled(tmp_path: Path) -> None:
+    # "00" must not slip past as a non-empty string and reach rq as 0 (which rq
+    # rejects). It normalizes to 0 → disabled.
+    argv = _argv_line(_run_entrypoint(tmp_path, {"DEVICE": "cuda", "WORKER_MAX_IDLE_TIME": "00"}))
+
+    assert "--max-idle-time" not in argv
+
+
+def test_leading_zeros_are_normalized(tmp_path: Path) -> None:
+    argv = _argv_line(_run_entrypoint(tmp_path, {"DEVICE": "rocm", "WORKER_MAX_IDLE_TIME": "0300"}))
+
+    assert "--max-idle-time 300" in argv
 
 
 @pytest.mark.parametrize("device", ["cpu", "auto"])
 def test_idle_flag_is_device_agnostic_but_simpleworker_is_gpu_only(tmp_path: Path, device: str) -> None:
     # The idle-release mechanism is a generic rq flag (the entrypoint adds it
-    # whenever WORKER_MAX_IDLE_TIME is set); only the SimpleWorker class is
-    # gated to GPU devices. Compose only defaults the var on for GPU workers.
-    argv = _run_entrypoint(tmp_path, {"DEVICE": device, "WORKER_MAX_IDLE_TIME": "120"})
+    # whenever WORKER_MAX_IDLE_TIME is a positive integer); only the SimpleWorker
+    # class is gated to GPU devices. Compose only defaults the var on for GPU workers.
+    argv = _argv_line(_run_entrypoint(tmp_path, {"DEVICE": device, "WORKER_MAX_IDLE_TIME": "120"}))
 
     assert "--max-idle-time 120" in argv
     assert "--worker-class rq.SimpleWorker" not in argv
+
+
+@pytest.mark.parametrize("bad", ["abc", "-5", "+5", "1e3", "0x10", "300 foo", "  "])
+def test_invalid_idle_time_is_ignored_with_warning(tmp_path: Path, bad: str) -> None:
+    result = _run_entrypoint(tmp_path, {"DEVICE": "rocm", "WORKER_MAX_IDLE_TIME": bad})
+    argv = _argv_line(result)
+
+    # Invalid values never reach rq (no crash-loop, no instant-exit), and the
+    # worker still starts. The misconfiguration is surfaced on stderr.
+    assert "--max-idle-time" not in argv
+    assert "--worker-class rq.SimpleWorker" in argv
+    assert "WORKER_MAX_IDLE_TIME" in result.stderr
+
+
+def test_whitespace_value_does_not_inject_extra_queue(tmp_path: Path) -> None:
+    # A value like "300 foo" must not word-split into the command and add a bogus
+    # queue ("foo") or a bare "300" token.
+    argv = _argv_line(
+        _run_entrypoint(tmp_path, {"DEVICE": "rocm", "WORKER_MAX_IDLE_TIME": "300 foo", "WORKER_QUEUES": "whisper:gpu"})
+    )
+
+    assert "--max-idle-time" not in argv
+    assert "foo" not in argv
+    assert argv.rstrip().endswith("whisper:gpu")


### PR DESCRIPTION
## Why

After a transcription job finishes, GPU/ROCm workers keep holding GPU VRAM and
host RSS while idle — they do not "release the environment" the way they used
to. Root cause: GPU workers (`cuda` / `rocm`) run RQ's non-forking
`SimpleWorker` in one long-lived process (a CUDA/HIP context cannot be
re-initialised after `fork()`, so the forking `Worker` is not usable on GPU —
introduced for CUDA in v2.9.0 and for ROCm in v2.12.1). Each stage already
cleans up (`del` + `gc.collect()` + `torch.cuda.empty_cache()`), but
`empty_cache()` returns only model weights to the driver's free pool — it
cannot destroy the process's CUDA/HIP context or the mapped GPU runtime
libraries. Those stay resident until the **process** exits. The forking CPU
worker never showed this because its per-job work-horse exits and the OS
reclaims everything. This affects **both** NVIDIA and AMD (AMD actually holds
less, since transcription shells out to whisper.cpp).

## How

Add `WORKER_MAX_IDLE_TIME` (seconds): when > 0 the entrypoint appends rq's
`--max-idle-time` so the worker self-exits after a spell with no job, and the
existing `restart: unless-stopped` respawns a fresh process — handing the GPU
context + RSS back to the OS. It triggers only while idle, so a running job is
never interrupted and back-to-back jobs stay warm.

- `docker/entrypoint-worker.sh` — append `--max-idle-time` when the env is set (generic mechanism, like `WORKER_QUEUES`).
- `compose.yml` — new `x-gpu-lifecycle-env` anchor, defaulted to `300` **only** on `worker-gpu` / `worker-rocm`. CPU/io/llm workers fork per job and already release, so they are untouched.
- `tests/unit/test_entrypoint_worker.py` — runs the entrypoint with a stub `python` on `PATH` and asserts the assembled rq argv across rocm/cuda/cpu × idle-time combinations.
- README, `.env.example`, CHANGELOG (`[Unreleased]`) — document the knob, the SimpleWorker-vs-forking lifecycle, and an `OLLAMA_KEEP_ALIVE` VRAM trade-off note.

## Behavior change / tuning

GPU/ROCm workers now recycle the worker process after `WORKER_MAX_IDLE_TIME`
seconds idle instead of staying resident for the container's lifetime. Tune via
`.env`: lower (e.g. `60`) = release sooner / reload on next job; higher = stay
warm longer; `WORKER_MAX_IDLE_TIME=0` restores the previous always-resident
behavior. No version bump here — release/version bump follows the usual separate
release commit.

## Verification

Local: full unit suite **1076 passed**; new entrypoint test 5/5; pre-commit
(shellcheck/shfmt/yamlfmt/ruff/prettier/markdownlint) green; `docker compose
config` confirms only `worker-gpu`/`worker-rocm` get `WORKER_MAX_IDLE_TIME=300`.

Live on an AMD gfx1151 box with the real `whisper-ui-worker-rocm:2.14.0` image:

| State | Host VRAM | In-process |
| --- | --- | --- |
| Baseline (no GPU process) | 171 MB | — |
| Idle, **after** `del`+`gc`+`empty_cache()` | **484 MB** (+313 MB) | RSS 931 MB, gpu_alloc 80 MB, reserved 80 MB |
| After process **exited** | 171 MB (baseline) | — |

So the per-stage cleanup does **not** return the process to baseline; only
process exit does (a real diarize+align job holds more than this synthetic
matmul, so +313 MB is a conservative lower bound). A worker started with
`--max-idle-time 15` on an empty queue exited cleanly (code 0) after ~16 s,
confirming the self-exit → restart → reclaim path end to end.

## Scope / follow-ups (intentionally not in this PR)

- `libtorchcodec` / `libavutil.so.60` warning on the ROCm worker (pyannote audio-decode fallback; would require touching torch/torchcodec/ffmpeg versions).
- align stage re-fetching wav2vec2 HF metadata per job (startup/caching optimisation).
- `OLLAMA_KEEP_ALIVE` default left at `30m` (documented trade-off only); it's a deployment-side `.env` choice.

## Notes for reviewers

`WORKER_MAX_IDLE_TIME` is now described in three same-source places — the
`compose.yml` `x-gpu-lifecycle-env` comment, the `docker/entrypoint-worker.sh`
comment, and the README section — keep them in sync if the behavior changes.
(The repo's `CLAUDE.md` was also updated locally with a matching bullet, but
`CLAUDE.md` is gitignored here, so it is not part of this PR.)
