### PR TITLE
chore: release v2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.16.0] - 2026-06-16
+
 Pre-release review remediation.
 
 ### Added
@@ -895,7 +897,8 @@ Error` JSON body while logging the full traceback, so an
   classification, missing-job handling) are now covered by unit tests
   in `test_pipeline_dispatcher.py` and `test_stage_tasks.py`.
 
-[Unreleased]: https://github.com/fdff87554/Whisper-UI/compare/v2.15.0...HEAD
+[Unreleased]: https://github.com/fdff87554/Whisper-UI/compare/v2.16.0...HEAD
+[2.16.0]: https://github.com/fdff87554/Whisper-UI/releases/tag/v2.16.0
 [2.15.0]: https://github.com/fdff87554/Whisper-UI/releases/tag/v2.15.0
 [2.14.0]: https://github.com/fdff87554/Whisper-UI/releases/tag/v2.14.0
 [2.13.1]: https://github.com/fdff87554/Whisper-UI/releases/tag/v2.13.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.15.0"
+version = "2.16.0"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3955,7 +3955,7 @@ wheels = [
 
 [[package]]
 name = "whisper-ui"
-version = "2.15.0"
+version = "2.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Release v2.16.0 — pre-release review remediation (PR #132 content).

Cuts the version after PR #132 merged to main: bumps `pyproject.toml` / `uv.lock` to 2.16.0 and finalizes the CHANGELOG `[Unreleased]` section as `[2.16.0] - 2026-06-16`.

Highlights (full list in the CHANGELOG):
- **Added**: `MAX_REGISTER_ATTEMPTS_PER_IP` per-IP registration throttle.
- **Security**: Redis password redaction in startup log; username masking in failed-auth logs.
- **Fixed**: corrupt/non-object `result.json` degrades gracefully; login open-redirect backslash; negative SRT/VTT timestamps; ZIP entry path-separator stripping.
- **Changed/Perf**: `url_validation` moved to `core`; batched/offloaded progress reads and delete cleanup; new hot-path DB indexes.

Tagging `v2.16.0` after merge will publish all images (incl. the ROCm worker) to GHCR.