### PR TITLE
release/v2.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.18.0] - 2026-07-06
+
+Inline media playback on the viewer page, synchronized with the transcript.
+
+### Added
+
+- HTML5 audio/video player on the viewer page: uploaded MP4, MP3 and other
+  supported formats play directly in the browser without downloading.
+- Transcript sync: clicking a segment timestamp seeks the player to that point;
+  during playback the active segment highlights and auto-scrolls.
+- Keyboard shortcuts for media playback: `Space` (play/pause), `J` (rewind 5s),
+  `L` (forward 5s).
+- The media endpoint now serves direct file uploads (not just URL-sourced jobs),
+  so the "Download Media" button and inline player work for all job types.
+- Added missing MIME types: `.mp3`, `.aac`, `.flac`, `.wma`.
+
 ## [2.17.0] - 2026-06-17
 
 UI alignment with the Whisper UI design system (non-destructive presentation
@@ -933,7 +949,8 @@ Error` JSON body while logging the full traceback, so an
   classification, missing-job handling) are now covered by unit tests
   in `test_pipeline_dispatcher.py` and `test_stage_tasks.py`.
 
-[Unreleased]: https://github.com/fdff87554/Whisper-UI/compare/v2.17.0...HEAD
+[Unreleased]: https://github.com/fdff87554/Whisper-UI/compare/v2.18.0...HEAD
+[2.18.0]: https://github.com/fdff87554/Whisper-UI/releases/tag/v2.18.0
 [2.17.0]: https://github.com/fdff87554/Whisper-UI/releases/tag/v2.17.0
 [2.16.0]: https://github.com/fdff87554/Whisper-UI/releases/tag/v2.16.0
 [2.15.0]: https://github.com/fdff87554/Whisper-UI/releases/tag/v2.15.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
   "pydantic>=2.0,<3",
-  "pydantic-settings>=2.0,<3",
+  "pydantic-settings>=2.14.2,<3",
   "redis>=8.0.0,<9",
   "rq>=2.9.1,<3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.17.0"
+version = "2.18.0"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"

--- a/src/whisper_ui/web/routes/viewer.py
+++ b/src/whisper_ui/web/routes/viewer.py
@@ -86,9 +86,7 @@ async def viewer_page(request: Request, db: DbDep, filestore: FileStoreDep, user
     # while the transcript stays — checking here keeps the template free
     # of file-system access and avoids the 404 dead-click the button
     # would otherwise produce.
-    media_path = (
-        filestore.get_any_media_path(job_id, job.filepath if job else None) if job is not None else None
-    )
+    media_path = filestore.get_any_media_path(job_id, job.filepath if job else None) if job is not None else None
     media_available = media_path is not None
     media_is_video = media_available and media_path.suffix.lower() in _VIDEO_EXTENSIONS
 

--- a/uv.lock
+++ b/uv.lock
@@ -645,7 +645,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
@@ -1971,7 +1971,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -1982,7 +1982,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2009,9 +2009,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2022,7 +2022,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -2763,16 +2763,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]
@@ -3955,7 +3955,7 @@ wheels = [
 
 [[package]]
 name = "whisper-ui"
-version = "2.16.0"
+version = "2.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
@@ -4022,7 +4022,7 @@ requires-dist = [
     { name = "prometheus-client", marker = "extra == 'frontend'", specifier = ">=0.21,<1" },
     { name = "pyannote-audio", marker = "extra == 'worker'", specifier = ">=4.0.0" },
     { name = "pydantic", specifier = ">=2.0,<3" },
-    { name = "pydantic-settings", specifier = ">=2.0,<3" },
+    { name = "pydantic-settings", specifier = ">=2.14.2,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.1.0,<10" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0,<8" },
     { name = "pytest-playwright", marker = "extra == 'dev'", specifier = ">=0.5,<1" },


### PR DESCRIPTION
## Summary
- Bump version to 2.18.0
- Update CHANGELOG with inline media player feature

### What's in this release
- **Inline media player** on the viewer page with HTML5 `<audio>`/`<video>` — uploaded MP4/MP3 files play directly in the browser
- **Transcript sync** — click a timestamp to seek; active segment highlights and auto-scrolls during playback
- **Keyboard shortcuts** — `Space` (play/pause), `J`/`L` (seek -5s/+5s)
- **Media endpoint extended** to serve direct file uploads (not just URL-sourced jobs)
- **Missing MIME types** added: `.mp3`, `.aac`, `.flac`, `.wma`

🤖 Generated with [Claude Code](https://claude.com/claude-code)