### PR TITLE
fix: review remediation — path traversal guard, scroll visibility, cleanup

### DIFF
--- a/src/whisper_ui/storage/filestore.py
+++ b/src/whisper_ui/storage/filestore.py
@@ -103,8 +103,8 @@ class FileStore:
         if path is not None:
             return path
         if filepath:
-            p = Path(filepath)
-            if p.is_file():
+            p = Path(filepath).resolve()
+            if p.is_file() and self._upload_dir.resolve() in p.parents:
                 return p
         return None
 

--- a/src/whisper_ui/web/templates/viewer.html
+++ b/src/whisper_ui/web/templates/viewer.html
@@ -75,7 +75,6 @@
   activeIndex: 0,
   shortcutsOpen: false,
   currentSegIdx: -1,
-  playerReady: false,
   _segments: [],
   _lastScrollTime: 0,
   get matchCount() {
@@ -115,7 +114,6 @@
       start: parseFloat(el.dataset.start),
       end: parseFloat(el.dataset.end)
     }));
-    player.addEventListener('canplay', () => { this.playerReady = true; });
     player.addEventListener('timeupdate', () => { this._onTimeUpdate(player.currentTime); });
   },
   _onTimeUpdate(t) {
@@ -134,8 +132,8 @@
     const now = Date.now();
     if (now - this._lastScrollTime < 1000) return;
     this._lastScrollTime = now;
-    const el = document.querySelector('[data-seg-idx=\"' + idx + '\"]');
-    if (el) el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    const el = document.querySelector('[data-seg-idx="' + idx + '"]');
+    if (el && el.offsetParent !== null) el.scrollIntoView({ block: 'center', behavior: 'smooth' });
   },
   seekTo(time) {
     const player = document.getElementById('media-player');


### PR DESCRIPTION
## Summary
Cherry-pick of review fixes that landed on `release/v2.18.0` after the PR was merged.

- **Path traversal guard**: `get_any_media_path` now resolves `filepath` and verifies it resides within `_upload_dir` to prevent LFI
- **Skip hidden segments on scroll**: checks `el.offsetParent !== null` before `scrollIntoView` so auto-scroll skips filtered-out segments during search
- **Remove unused `playerReady`**: removed dead state and `canplay` listener

## Test plan
- [ ] Existing tests pass (`test_filestore.py`, `test_web_routes.py`)
- [ ] Viewer auto-scroll does not jump to hidden segments during search + playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)