### PR TITLE
fix: clipboard fallback for share link on non-HTTPS

### DIFF
--- a/src/whisper_ui/web/templates/viewer.html
+++ b/src/whisper_ui/web/templates/viewer.html
@@ -203,7 +203,7 @@
       <div class="flex items-center gap-1" x-data="{ linkCopied: false }">
         <button class="btn btn-sm btn-ghost gap-1"
                 @click="
-                  navigator.clipboard.writeText(window.location.origin + '/shared/{{ job.share_token }}')
+                  window.whisperCopy(window.location.origin + '/shared/{{ job.share_token }}')
                     .then(() => { linkCopied = true; setTimeout(() => linkCopied = false, 2000) });
                 ">
           <template x-if="!linkCopied">
@@ -370,6 +370,20 @@
     } catch (_) {
       return escapeHtml(text);
     }
+  };
+  window.whisperCopy = function(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text);
+    }
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'fixed';
+    ta.style.left = '-9999px';
+    document.body.appendChild(ta);
+    ta.select();
+    document.execCommand('copy');
+    document.body.removeChild(ta);
+    return Promise.resolve();
   };
 })();
 </script>


### PR DESCRIPTION
## Summary

- `navigator.clipboard` is unavailable over plain HTTP (non-secure context)
- Added `window.whisperCopy()` helper that falls back to `execCommand('copy')` via a hidden textarea
- Share link "複製連結" button now works on HTTP deployments

## Test plan

- [ ] Open viewer over HTTP, click "複製連結" → URL copied without error
- [ ] Same flow over HTTPS/localhost → still works via Clipboard API

🤖 Generated with [Claude Code](https://claude.com/claude-code)