### PR TITLE
chore: release v2.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.20.0] - 2026-07-08
+
 Pre-release hardening pass: resilience, security, and correctness fixes with
 no user-facing feature changes. One additive migration (`idx_jobs_created_at`).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.19.0"
+version = "2.20.0"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3955,7 +3955,7 @@ wheels = [
 
 [[package]]
 name = "whisper-ui"
-version = "2.19.0"
+version = "2.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Release v2.20.0

Cuts the `2.20.0` release: promotes the pre-release hardening pass (merged in #148) from `[Unreleased]` to a dated `[2.20.0]` section and bumps the version.

### Why MINOR (not PATCH)
Predominantly security/correctness fixes, but it also adds backward-compatible **functionality** — new config options (`REDIS_SOCKET_TIMEOUT` family, `TRUSTED_PROXY_COUNT`, `METRICS_TOKEN`, Settings-driven `LOG_LEVEL`/`LOG_JSON`), a Content-Security-Policy, QUEUED-job recovery, and an additive `idx_jobs_created_at` migration — so semver puts it at a minor bump.

### Changes in this PR
- `pyproject.toml`: `2.19.0` → `2.20.0`
- `uv.lock`: project version synced (keeps `uv sync --frozen` green in CI)
- `CHANGELOG.md`: `[Unreleased]` hardening entry → `[2.20.0] - 2026-07-08`, fresh empty `[Unreleased]`

No code changes. On merge, the `v2.20.0` tag will be pushed, which triggers `docker-publish` to build/push the frontend + worker (and, on the tag, ROCm) images to GHCR.
