### PR TITLE
docs: correct CHANGELOG index name to idx_jobs_owner_created_at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [2.20.0] - 2026-07-08
 
 Pre-release hardening pass: resilience, security, and correctness fixes with
-no user-facing feature changes. One additive migration (`idx_jobs_created_at`).
+no user-facing feature changes. One additive migration (`idx_jobs_owner_created_at`).
 
 ### Security
 
@@ -50,7 +50,7 @@ no user-facing feature changes. One additive migration (`idx_jobs_created_at`).
 - Logging level/format (`LOG_LEVEL`/`LOG_JSON`) now honoured from `.env` via
   Settings (were silently ignored there before).
 - Blocking work (single-file export, argon2 verify, upload writes) moved off
-  the async event loop; added `idx_jobs_created_at` for the polled job list.
+  the async event loop; added `idx_jobs_owner_created_at` for the polled job list.
 - Pinned whisperx / CPU torch / compose sidecar image versions; deduplicated
   upload-option validation, the enqueue-failure tail, and the FileStore
   upload-dir idiom.


### PR DESCRIPTION
## Why

The v2.20.0 CHANGELOG entry names the additive migration `idx_jobs_created_at`, but the migration that actually shipped (`src/whisper_ui/storage/migrations.py:103`, introduced by commit 9d44331) creates the composite index **`idx_jobs_owner_created_at`** on `jobs(owner_id, created_at)`. The single-column name was a leftover from an earlier draft that was superseded during the merge with `main`; the deployed databases correctly carry `idx_jobs_owner_created_at` (verified on both production hosts).

## How

Corrects both occurrences in `CHANGELOG.md` (the [2.20.0] summary line and the Changed entry). Documentation only — no code or schema change.