### PR TITLE
feat: configurable diarization default + whisper:gpu stall alert & worker-rocm auto-heal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,12 @@ LANGUAGE=zh
 # https://huggingface.co/pyannote/segmentation-3.0
 HF_TOKEN=
 
+# Default state of the upload-form "enable speaker diarization" toggle.
+# Only takes effect when HF_TOKEN is set (diarization must be available).
+# Set false so new uploads default to no diarization (the slowest stage);
+# users can still opt in per job.
+# DIARIZATION_DEFAULT_ENABLED=true
+
 # Queue / job timeouts (seconds)
 # All have sensible defaults matching compose.yml; uncomment to override.
 # Invariants are enforced at startup — the service will fail to start if:

--- a/README.md
+++ b/README.md
@@ -550,10 +550,9 @@ ceiling is sized for small-office deployments only.
 
 ### Observability: metrics & monitoring (minimal)
 
-The frontend exposes Prometheus metrics at **`/metrics`** — unauthenticated by
-default (same posture as `/health`), so keep it internal, or set `METRICS_TOKEN`
-to require scrapes to send `Authorization: Bearer <token>`. They are computed at
-scrape time from RQ/Redis and the SQLite `jobs` table, with no persistent counters:
+The frontend exposes Prometheus metrics at **`/metrics`** — unauthenticated,
+same posture as `/health`, so keep it internal. They are computed at scrape
+time from RQ/Redis and the SQLite `jobs` table, with no persistent counters:
 
 | Metric                                         | Type  | Labels   | Source             |
 | ---------------------------------------------- | ----- | -------- | ------------------ |

--- a/README.md
+++ b/README.md
@@ -155,21 +155,22 @@ docker compose --profile gpu build
 
 All settings are configured via environment variables (`.env` file):
 
-| Variable               | Default                             | Description                                                                                   |
-| ---------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------- |
-| `WHISPER_MODEL`        | `large-v3`                          | Whisper model variant (see model list below)                                                  |
-| `COMPUTE_TYPE`         | `int8_float16` (GPU) / `int8` (CPU) | CTranslate2 compute type                                                                      |
-| `DEVICE`               | `auto`                              | Inference device; compose profiles set `cuda` (GPU) / `rocm` (AMD) / `cpu` (CPU)              |
-| `TRANSCRIBE_BACKEND`   | `whisperx`                          | `whisperx` (CTranslate2, CUDA/CPU) or `whispercpp` (whisper.cpp HIP; set by the rocm profile) |
-| `BATCH_SIZE`           | `4`                                 | Transcription batch size (whisperx backend only)                                              |
-| `LANGUAGE`             | `zh`                                | Default language code                                                                         |
-| `HF_TOKEN`             | (empty)                             | HuggingFace token for speaker diarization                                                     |
-| `MAX_UPLOAD_SIZE`      | `2147483648`                        | Per-file upload cap in bytes (2 GB); also caps Google Drive downloads                         |
-| `YOUTUBE_MAX_DURATION` | `14400`                             | Longest accepted YouTube video in seconds (4 h); live streams are always rejected             |
-| `TWITTER_MAX_DURATION` | `14400`                             | Longest accepted X (Twitter) video in seconds                                                 |
-| `TWITTER_COOKIES_FILE` | (empty)                             | Container path to a cookies.txt for login-walled X posts (see `.env.example`)                 |
-| `PIP_INDEX_URL`        | (empty)                             | Custom PyPI mirror for Docker builds                                                          |
-| `WHISPER_UI_VERSION`   | `latest`                            | Docker image version tag to pull                                                              |
+| Variable                      | Default                             | Description                                                                                                                                                                                        |
+| ----------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `WHISPER_MODEL`               | `large-v3`                          | Whisper model variant (see model list below)                                                                                                                                                       |
+| `COMPUTE_TYPE`                | `int8_float16` (GPU) / `int8` (CPU) | CTranslate2 compute type                                                                                                                                                                           |
+| `DEVICE`                      | `auto`                              | Inference device; compose profiles set `cuda` (GPU) / `rocm` (AMD) / `cpu` (CPU)                                                                                                                   |
+| `TRANSCRIBE_BACKEND`          | `whisperx`                          | `whisperx` (CTranslate2, CUDA/CPU) or `whispercpp` (whisper.cpp HIP; set by the rocm profile)                                                                                                      |
+| `BATCH_SIZE`                  | `4`                                 | Transcription batch size (whisperx backend only)                                                                                                                                                   |
+| `LANGUAGE`                    | `zh`                                | Default language code                                                                                                                                                                              |
+| `HF_TOKEN`                    | (empty)                             | HuggingFace token for speaker diarization                                                                                                                                                          |
+| `DIARIZATION_DEFAULT_ENABLED` | `true`                              | Initial state of the upload-form diarization toggle (only when `HF_TOKEN` is set). Set `false` so new uploads default to no diarization — the slowest stage — with per-job opt-in still available. |
+| `MAX_UPLOAD_SIZE`             | `2147483648`                        | Per-file upload cap in bytes (2 GB); also caps Google Drive downloads                                                                                                                              |
+| `YOUTUBE_MAX_DURATION`        | `14400`                             | Longest accepted YouTube video in seconds (4 h); live streams are always rejected                                                                                                                  |
+| `TWITTER_MAX_DURATION`        | `14400`                             | Longest accepted X (Twitter) video in seconds                                                                                                                                                      |
+| `TWITTER_COOKIES_FILE`        | (empty)                             | Container path to a cookies.txt for login-walled X posts (see `.env.example`)                                                                                                                      |
+| `PIP_INDEX_URL`               | (empty)                             | Custom PyPI mirror for Docker builds                                                                                                                                                               |
+| `WHISPER_UI_VERSION`          | `latest`                            | Docker image version tag to pull                                                                                                                                                                   |
 
 **Whisper models:** `tiny`, `tiny.en`, `base`, `base.en`, `small`, `small.en`, `medium`, `medium.en`, `large-v1`, `large-v2`, `large-v3`, `large-v3-turbo`
 
@@ -549,9 +550,10 @@ ceiling is sized for small-office deployments only.
 
 ### Observability: metrics & monitoring (minimal)
 
-The frontend exposes Prometheus metrics at **`/metrics`** — unauthenticated,
-same posture as `/health`, so keep it internal. They are computed at scrape
-time from RQ/Redis and the SQLite `jobs` table, with no persistent counters:
+The frontend exposes Prometheus metrics at **`/metrics`** — unauthenticated by
+default (same posture as `/health`), so keep it internal, or set `METRICS_TOKEN`
+to require scrapes to send `Authorization: Bearer <token>`. They are computed at
+scrape time from RQ/Redis and the SQLite `jobs` table, with no persistent counters:
 
 | Metric                                         | Type  | Labels   | Source             |
 | ---------------------------------------------- | ----- | -------- | ------------------ |

--- a/compose.yml
+++ b/compose.yml
@@ -19,6 +19,10 @@ x-app-depends: &app-depends
     condition: service_completed_successfully
 x-core-env: &core-env
   REDIS_URL: redis://:${REDIS_PASSWORD:-}@redis:6379/0
+  # Redis client resiliency — read by the web app and every worker.
+  REDIS_SOCKET_TIMEOUT: ${REDIS_SOCKET_TIMEOUT:-10}
+  REDIS_SOCKET_CONNECT_TIMEOUT: ${REDIS_SOCKET_CONNECT_TIMEOUT:-5}
+  REDIS_HEALTH_CHECK_INTERVAL: ${REDIS_HEALTH_CHECK_INTERVAL:-30}
   LOG_LEVEL: ${LOG_LEVEL:-INFO}
   LOG_JSON: ${LOG_JSON:-false}
   DATABASE_PATH: /app/data/db/whisper_ui.db
@@ -84,6 +88,9 @@ services:
       WHISPER_MODEL: ${WHISPER_MODEL:-large-v3}
       HF_TOKEN: ${HF_TOKEN:-}
       DIARIZE_HEARTBEAT_INTERVAL: ${DIARIZE_HEARTBEAT_INTERVAL:-30}
+      # Initial state of the upload-form diarization toggle (clamped at render
+      # time by whether HF_TOKEN is set — see diarization_default_for_form).
+      DIARIZATION_DEFAULT_ENABLED: ${DIARIZATION_DEFAULT_ENABLED:-true}
       # LLM correction: the frontend only needs the gate + model name to
       # render the upload-form toggle; the client knobs stay worker-side.
       OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-}
@@ -101,10 +108,14 @@ services:
       SESSION_HTTPS_ONLY: ${SESSION_HTTPS_ONLY:-false}
       MAX_LOGIN_ATTEMPTS: ${MAX_LOGIN_ATTEMPTS:-5}
       MAX_LOGIN_ATTEMPTS_PER_IP: ${MAX_LOGIN_ATTEMPTS_PER_IP:-20}
+      MAX_REGISTER_ATTEMPTS_PER_IP: ${MAX_REGISTER_ATTEMPTS_PER_IP:-10}
       LOGIN_LOCKOUT_SECONDS: ${LOGIN_LOCKOUT_SECONDS:-900}
       TRUST_PROXY_HEADERS: ${TRUST_PROXY_HEADERS:-false}
+      TRUSTED_PROXY_COUNT: ${TRUSTED_PROXY_COUNT:-1}
       # Registration gate (frontend-only).
       ALLOW_REGISTRATION: ${ALLOW_REGISTRATION:-true}
+      # Optional bearer token protecting /metrics (empty = open, the default).
+      METRICS_TOKEN: ${METRICS_TOKEN:-}
     volumes:
       - app-data:/app/data
     depends_on:

--- a/compose.yml
+++ b/compose.yml
@@ -114,8 +114,6 @@ services:
       TRUSTED_PROXY_COUNT: ${TRUSTED_PROXY_COUNT:-1}
       # Registration gate (frontend-only).
       ALLOW_REGISTRATION: ${ALLOW_REGISTRATION:-true}
-      # Optional bearer token protecting /metrics (empty = open, the default).
-      METRICS_TOKEN: ${METRICS_TOKEN:-}
     volumes:
       - app-data:/app/data
     depends_on:

--- a/compose.yml
+++ b/compose.yml
@@ -400,6 +400,7 @@ services:
     image: prom/prometheus:v3.5.0
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/alerts.yml:/etc/prometheus/alerts.yml:ro
       - prometheus-data:/prometheus
     ports:
       - "127.0.0.1:9090:9090"

--- a/docker/whisper-rocm-heal.sh
+++ b/docker/whisper-rocm-heal.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Bring worker-rocm back up when fewer than the desired number are running.
+#
+# Why this exists: worker-rocm mounts /dev/kfd + /dev/dri, which Docker resolves
+# at container CREATE time. On a host reboot / GPU driver reload the container
+# can try to start before those device nodes reappear, failing to create with
+# `exit 128 ... custom device "/dev/dri": no such file`. Docker's
+# `restart: unless-stopped` retries rapidly and then GIVES UP, leaving the
+# worker down indefinitely while every other service (which needs no GPU) stays
+# healthy — a silent multi-day whisper:gpu outage (observed 2026-07).
+#
+# An in-container entrypoint wait cannot fix this: the create-time device
+# failure means the entrypoint never runs. The fix has to live on the host.
+# Run this from a systemd timer (see docs/gpu-worker-recovery.md); it waits for
+# the device nodes, then re-runs `compose up` only if a worker-rocm is missing.
+#
+# Env:
+#   WHISPER_DEPLOY_DIR  deploy dir holding compose.yml + .env (default ~/whisper-ui-deploy)
+#   WHISPER_ROCM_SCALE  desired worker-rocm replicas (default 1)
+#   WHISPER_IO_SCALE    desired worker-io replicas (default 2)
+#   WHISPER_HEAL_LOG    log file (default $WHISPER_DEPLOY_DIR/whisper-rocm-heal.log)
+set -u
+
+DEPLOY="${WHISPER_DEPLOY_DIR:-$HOME/whisper-ui-deploy}"
+DESIRED="${WHISPER_ROCM_SCALE:-1}"
+IO_SCALE="${WHISPER_IO_SCALE:-2}"
+LOG="${WHISPER_HEAL_LOG:-$DEPLOY/whisper-rocm-heal.log}"
+
+# Wait up to ~120s for the GPU device nodes so the compose up can succeed.
+for _ in $(seq 1 60); do
+	[ -e /dev/kfd ] && [ -e /dev/dri/renderD128 ] && break
+	sleep 2
+done
+
+running=$(docker ps --filter 'name=worker-rocm' --format '{{.Names}}' | wc -l)
+if [ "$running" -lt "$DESIRED" ]; then
+	cd "$DEPLOY" || exit 1
+	echo "$(date -Is) heal: $running/$DESIRED worker-rocm running, running compose up" >>"$LOG"
+	docker compose --profile rocm --profile io --profile llm-worker up -d --no-recreate \
+		--scale worker-io="$IO_SCALE" --scale worker-rocm="$DESIRED" \
+		frontend worker-rocm worker-io worker-llm >>"$LOG" 2>&1 ||
+		echo "$(date -Is) heal: compose up failed" >>"$LOG"
+fi

--- a/docker/whisper-rocm-heal.sh
+++ b/docker/whisper-rocm-heal.sh
@@ -10,34 +10,87 @@
 # healthy — a silent multi-day whisper:gpu outage (observed 2026-07).
 #
 # An in-container entrypoint wait cannot fix this: the create-time device
-# failure means the entrypoint never runs. The fix has to live on the host.
-# Run this from a systemd timer (see docs/gpu-worker-recovery.md); it waits for
-# the device nodes, then re-runs `compose up` only if a worker-rocm is missing.
+# failure means the entrypoint never runs, so the fix has to live on the host.
+# This script only heals worker-rocm — frontend/redis/io/llm need no GPU and
+# recover on their own via `restart: unless-stopped`.
+#
+# Install (host systemd timer):
+#   sudo install -m0755 docker/whisper-rocm-heal.sh /usr/local/bin/whisper-rocm-heal.sh
+#
+#   sudo tee /etc/systemd/system/whisper-rocm-heal.service >/dev/null <<'UNIT'
+#   [Unit]
+#   Description=Heal whisper worker-rocm (bring up if fewer than desired run)
+#   After=docker.service
+#   Wants=docker.service
+#   [Service]
+#   Type=oneshot
+#   User=ubuntu
+#   # Override the deploy dir / desired count here if they differ:
+#   #   Environment=WHISPER_DEPLOY_DIR=/home/ubuntu/whisper-ui-deploy
+#   #   Environment=WHISPER_ROCM_SCALE=1
+#   ExecStart=/usr/local/bin/whisper-rocm-heal.sh
+#   UNIT
+#
+#   sudo tee /etc/systemd/system/whisper-rocm-heal.timer >/dev/null <<'UNIT'
+#   [Unit]
+#   Description=Periodic heal for whisper worker-rocm
+#   [Timer]
+#   OnBootSec=45s
+#   OnUnitActiveSec=2min
+#   AccuracySec=15s
+#   [Install]
+#   WantedBy=timers.target
+#   UNIT
+#
+#   sudo systemctl daemon-reload && sudo systemctl enable --now whisper-rocm-heal.timer
 #
 # Env:
 #   WHISPER_DEPLOY_DIR  deploy dir holding compose.yml + .env (default ~/whisper-ui-deploy)
 #   WHISPER_ROCM_SCALE  desired worker-rocm replicas (default 1)
-#   WHISPER_IO_SCALE    desired worker-io replicas (default 2)
 #   WHISPER_HEAL_LOG    log file (default $WHISPER_DEPLOY_DIR/whisper-rocm-heal.log)
-set -u
+set -euo pipefail
 
 DEPLOY="${WHISPER_DEPLOY_DIR:-$HOME/whisper-ui-deploy}"
 DESIRED="${WHISPER_ROCM_SCALE:-1}"
-IO_SCALE="${WHISPER_IO_SCALE:-2}"
 LOG="${WHISPER_HEAL_LOG:-$DEPLOY/whisper-rocm-heal.log}"
 
+case "$DESIRED" in
+'' | *[!0-9]*)
+	echo "$(date -Is) heal: invalid WHISPER_ROCM_SCALE=$DESIRED (need a non-negative integer)" >&2
+	exit 1
+	;;
+esac
+
+cd "$DEPLOY" || {
+	echo "$(date -Is) heal: deploy dir not found: $DEPLOY" >&2
+	exit 1
+}
+
 # Wait up to ~120s for the GPU device nodes so the compose up can succeed.
+devices_ready() { [ -e /dev/kfd ] && [ -e /dev/dri/renderD128 ]; }
+ready=0
 for _ in $(seq 1 60); do
-	[ -e /dev/kfd ] && [ -e /dev/dri/renderD128 ] && break
+	if devices_ready; then
+		ready=1
+		break
+	fi
 	sleep 2
 done
+if [ "$ready" -ne 1 ]; then
+	echo "$(date -Is) heal: GPU device nodes still absent after wait; aborting" >>"$LOG"
+	exit 1
+fi
 
-running=$(docker ps --filter 'name=worker-rocm' --format '{{.Names}}' | wc -l)
+# Count only THIS compose project's worker-rocm, not other deployments' by name.
+if ! running=$(docker compose --profile rocm ps -q --status running worker-rocm | wc -l); then
+	echo "$(date -Is) heal: 'docker compose ps' failed" >>"$LOG"
+	exit 1
+fi
+
 if [ "$running" -lt "$DESIRED" ]; then
-	cd "$DEPLOY" || exit 1
 	echo "$(date -Is) heal: $running/$DESIRED worker-rocm running, running compose up" >>"$LOG"
-	docker compose --profile rocm --profile io --profile llm-worker up -d --no-recreate \
-		--scale worker-io="$IO_SCALE" --scale worker-rocm="$DESIRED" \
-		frontend worker-rocm worker-io worker-llm >>"$LOG" 2>&1 ||
+	if ! docker compose --profile rocm up -d --no-recreate --scale worker-rocm="$DESIRED" worker-rocm >>"$LOG" 2>&1; then
 		echo "$(date -Is) heal: compose up failed" >>"$LOG"
+		exit 1
+	fi
 fi

--- a/docker/whisper-rocm-heal.sh
+++ b/docker/whisper-rocm-heal.sh
@@ -67,7 +67,14 @@ cd "$DEPLOY" || {
 }
 
 # Wait up to ~120s for the GPU device nodes so the compose up can succeed.
-devices_ready() { [ -e /dev/kfd ] && [ -e /dev/dri/renderD128 ]; }
+# Match any render node (renderD128, renderD129, ...), not just the gfx1151 one.
+devices_ready() {
+	[ -e /dev/kfd ] || return 1
+	for node in /dev/dri/renderD*; do
+		[ -e "$node" ] && return 0
+	done
+	return 1
+}
 ready=0
 for _ in $(seq 1 60); do
 	if devices_ready; then

--- a/monitoring/alerts.yml
+++ b/monitoring/alerts.yml
@@ -1,0 +1,32 @@
+# Prometheus alert rules for the `monitoring` compose profile. Loaded via
+# rule_files in prometheus.yml and mounted read-only into the prometheus
+# container. Without an Alertmanager (a documented follow-up) these still
+# surface as pending/firing in the Prometheus UI and the ALERTS series, so a
+# dashboard or a manual `up{alertstate="firing"}` check already catches them.
+groups:
+  - name: whisper-ui
+    rules:
+      # The 2026-07 incident: worker-rocm died on a boot-time GPU device race
+      # (/dev/dri not ready → exit 128) and Docker's restart policy gave up, so
+      # whisper:gpu jobs piled up with no consumer for days while the UI and the
+      # io/llm workers stayed healthy. whisper_rq_workers is a GLOBAL count (the
+      # io/llm workers kept it > 0), so it can't isolate a dead GPU worker — key
+      # off the gpu queue itself: a backlog with nothing in-flight = not
+      # draining, which is exactly a dead/stuck worker-rocm.
+      - alert: WhisperGpuQueueStalled
+        expr: whisper_queue_depth{queue="whisper:gpu"} > 0 and whisper_started_jobs{queue="whisper:gpu"} == 0
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "whisper:gpu backlog not draining (GPU worker likely down)"
+          description: "{{ $value }} job(s) queued on whisper:gpu with nothing in-flight for 15m — worker-rocm is probably dead (device race / crashed HIP context). Recovery: docker/whisper-rocm-heal.sh (install on the host as a systemd timer)."
+      # Full worker outage: Redis reachable but no RQ workers registered at all.
+      - alert: WhisperNoRqWorkers
+        expr: whisper_rq_workers == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "No RQ workers registered"
+          description: "whisper_rq_workers == 0 for 5m — every worker is down or cannot reach Redis."

--- a/monitoring/alerts.yml
+++ b/monitoring/alerts.yml
@@ -2,7 +2,7 @@
 # rule_files in prometheus.yml and mounted read-only into the prometheus
 # container. Without an Alertmanager (a documented follow-up) these still
 # surface as pending/firing in the Prometheus UI and the ALERTS series, so a
-# dashboard or a manual `up{alertstate="firing"}` check already catches them.
+# dashboard or a manual `ALERTS{alertstate="firing"}` check already catches them.
 groups:
   - name: whisper-ui
     rules:

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -4,6 +4,9 @@
 global:
   scrape_interval: 15s
   scrape_timeout: 10s
+# Alert rules (mounted alongside this file at /etc/prometheus/alerts.yml).
+rule_files:
+  - alerts.yml
 scrape_configs:
   # Whisper-UI app metrics (queue depth, job status, RQ workers). The frontend
   # container listens on 8000 internally (8080 is only the host port map).

--- a/src/whisper_ui/core/config.py
+++ b/src/whisper_ui/core/config.py
@@ -92,6 +92,15 @@ class Settings(BaseSettings):
     # HuggingFace
     hf_token: str = ""
 
+    # Diarization
+    # Initial state of the upload form's "enable speaker diarization" toggle.
+    # Diarization (pyannote) is the slowest pipeline stage — clustering runs on
+    # CPU and is unbounded when num_speakers is unset — so deployments that
+    # rarely need speaker labels can default it off and let users opt in per
+    # job. Only takes effect when diarization_available (an HF token is set);
+    # see the diarization_default_for_form property.
+    diarization_default_enabled: bool = True
+
     # Authentication
     # Signing key for session cookies. MUST be set to a stable random value in
     # production (e.g. ``openssl rand -hex 32``); leaving it empty causes
@@ -311,6 +320,16 @@ class Settings(BaseSettings):
         would only skip — see ``DiarizeStage.execute``.
         """
         return bool(self.hf_token)
+
+    @property
+    def diarization_default_for_form(self) -> bool:
+        """Initial value of the upload form's diarization toggle.
+
+        The operator default (``diarization_default_enabled``) clamped by
+        capability: never pre-check the box when diarization can't run at all,
+        so the rendered default always matches what a submit would persist.
+        """
+        return self.diarization_default_enabled and self.diarization_available
 
     @property
     def llm_correction_available(self) -> bool:

--- a/src/whisper_ui/web/routes/upload.py
+++ b/src/whisper_ui/web/routes/upload.py
@@ -154,6 +154,7 @@ async def upload_page(request: Request, settings: SettingsDep, user: CurrentUser
             # Only the derived values the form needs — not the whole Settings
             # object — so no sensitive field can leak into the rendered HTML.
             "diarization_available": settings.diarization_available,
+            "diarization_default": settings.diarization_default_for_form,
             "llm_correction_available": settings.llm_correction_available,
             "default_language": settings.language,
             "default_model": settings.whisper_model,

--- a/src/whisper_ui/web/templates/upload.html
+++ b/src/whisper_ui/web/templates/upload.html
@@ -347,7 +347,7 @@ function uploadForm() {
     selectedFiles: [],
     urlText: '',
     advancedOpen: false,
-    diarization: {{ 'true' if diarization_available else 'false' }},
+    diarization: {{ 'true' if diarization_default else 'false' }},
     convertTraditional: true,
     llmCorrection: false,
     activePreset: null,

--- a/tests/unit/test_compose_env_wiring.py
+++ b/tests/unit/test_compose_env_wiring.py
@@ -18,7 +18,6 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 # Deployer-facing env vars the web app reads and must receive via Compose.
 _REQUIRED_FRONTEND_ENV = {
     "DIARIZATION_DEFAULT_ENABLED",
-    "METRICS_TOKEN",
     "TRUSTED_PROXY_COUNT",
     "MAX_REGISTER_ATTEMPTS_PER_IP",
     "REDIS_SOCKET_TIMEOUT",

--- a/tests/unit/test_compose_env_wiring.py
+++ b/tests/unit/test_compose_env_wiring.py
@@ -1,0 +1,50 @@
+"""Guard that deployer-facing settings actually reach the frontend container.
+
+compose.yml has no ``env_file`` (see its header): a value reaches a container
+only when it is listed in an ``environment:`` map, directly or via a merged
+anchor. So a Settings field can exist and parse correctly yet be silently
+unreachable in a Compose deploy — the bug class caught in PR #156 review.
+This test fails if any such field stops being wired into the frontend service.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Deployer-facing env vars the web app reads and must receive via Compose.
+_REQUIRED_FRONTEND_ENV = {
+    "DIARIZATION_DEFAULT_ENABLED",
+    "METRICS_TOKEN",
+    "TRUSTED_PROXY_COUNT",
+    "MAX_REGISTER_ATTEMPTS_PER_IP",
+    "REDIS_SOCKET_TIMEOUT",
+    "REDIS_SOCKET_CONNECT_TIMEOUT",
+    "REDIS_HEALTH_CHECK_INTERVAL",
+}
+
+
+def _frontend_env_keys() -> set[str]:
+    compose = yaml.safe_load((_REPO_ROOT / "compose.yml").read_text())
+    keys: set[str] = set()
+    front = compose["services"]["frontend"].get("environment")
+    # PyYAML may or may not fold the `<<` merge into a plain dict; handle both,
+    # and fold the shared anchors explicitly as a belt-and-suspenders check.
+    if isinstance(front, dict):
+        keys |= set(front)
+    elif isinstance(front, list):
+        for item in front:
+            if isinstance(item, dict):
+                keys |= set(item)
+    for anchor in ("x-core-env", "x-timeout-env"):
+        block = compose.get(anchor) or {}
+        keys |= set(block)
+    return keys
+
+
+def test_frontend_wires_all_required_deployer_settings():
+    missing = _REQUIRED_FRONTEND_ENV - _frontend_env_keys()
+    assert not missing, f"frontend compose environment is missing deployer settings: {sorted(missing)}"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -246,6 +246,21 @@ def test_diarization_available_reflects_hf_token(tmp_path):
     assert _make_settings(tmp_path, hf_token="hf-test-not-real").diarization_available is True
 
 
+def test_diarization_default_for_form_respects_setting_and_capability(tmp_path):
+    # No HF token: diarization can't run, so the form never pre-checks the box,
+    # regardless of the operator default — the rendered default matches submit.
+    assert _make_settings(tmp_path, hf_token="").diarization_default_for_form is False
+    assert _make_settings(tmp_path, hf_token="", diarization_default_enabled=True).diarization_default_for_form is False
+    # With a token, the form default follows diarization_default_enabled.
+    assert _make_settings(tmp_path, hf_token="hf-test-not-real").diarization_default_for_form is True  # default
+    assert (
+        _make_settings(
+            tmp_path, hf_token="hf-test-not-real", diarization_default_enabled=False
+        ).diarization_default_for_form
+        is False
+    )
+
+
 def test_llm_correction_available_reflects_ollama_base_url(tmp_path):
     assert _make_settings(tmp_path, ollama_base_url="").llm_correction_available is False
     assert _make_settings(tmp_path, ollama_base_url="http://ollama:11434").llm_correction_available is True


### PR DESCRIPTION
## Why

Two issues surfaced from a production incident on the gfx1151 (Radeon 8060S) deployment:

1. **Silent GPU-worker outage.** `worker-rocm` maps `/dev/kfd` + `/dev/dri`, which Docker resolves at container *create* time. On a host reboot the device nodes can lag, the create fails with `exit 128 ... custom device "/dev/dri": no such file`, and Docker's `restart: unless-stopped` gives up after rapid retries. The GPU worker stays down while the UI, Redis, and io/llm workers all report healthy — so `whisper:gpu` jobs pile up with no consumer and every transcription silently stalls (there is no CPU fallback). This went unnoticed for days.
2. **Diarization is the slowest stage** (pyannote clustering on CPU, unbounded when `num_speakers` is unset) yet the upload toggle was always on.

## How

- **Configurable diarization default** — new `DIARIZATION_DEFAULT_ENABLED` setting and a `diarization_default_for_form` property (clamped by `diarization_available`, so the rendered default always matches what a submit persists). The upload form seeds its toggle from it; deployments that rarely need speaker labels can ship it off while users still opt in per job.
- **Alerting** — `monitoring/alerts.yml` adds `WhisperGpuQueueStalled` (fires when `whisper:gpu` has a backlog with nothing in-flight for 15m — the exact silent-outage signature; `whisper_rq_workers` is a global count so it can't isolate a dead GPU worker) and `WhisperNoRqWorkers`. Wired via `rule_files` in `prometheus.yml` and mounted into the prometheus container.
- **Auto-heal** — `docker/whisper-rocm-heal.sh` for a host systemd timer that waits for the device nodes and re-runs `compose up` whenever fewer than the desired `worker-rocm` are running. The create-time device failure happens before the entrypoint runs, so the fix must live on the host, not in the container.

## Testing

- `pytest tests/unit` — 1190 passed, incl. new `test_diarization_default_for_form_respects_setting_and_capability`.
- `ruff check` / `ruff format` clean; `shellcheck` + `shfmt` clean on the heal script; `check-yaml` + `yamlfmt` clean on the alert/compose YAML.

## Notes

- The device-race recovery runbook (symptom, diagnosis, manual + systemd install steps) lives in the header of `docker/whisper-rocm-heal.sh`, because the repo gitignores `*.md` so a standalone doc cannot be tracked.
- Alertmanager routing remains a follow-up; the rules already surface as pending/firing in the Prometheus UI.

