### PR TITLE
chore: release v2.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.21.0] - 2026-07-20
+
+Deployment-wiring and GPU-worker reliability follow-ups to 2.20.0.
+
+### Added
+
+- `DIARIZATION_DEFAULT_ENABLED` sets the upload form's diarization toggle
+  default (clamped by `HF_TOKEN` availability). Diarization is the slowest
+  stage, so deployments that rarely need speaker labels can default it off
+  while users still opt in per job.
+- Prometheus alert rules (`monitoring/alerts.yml`): `WhisperGpuQueueStalled`
+  (a `whisper:gpu` backlog with nothing in-flight — the signature of a dead
+  GPU worker) and `WhisperNoRqWorkers`.
+- `docker/whisper-rocm-heal.sh`, a host systemd-timer script that recovers
+  `worker-rocm` after the boot-time GPU-device race that Docker's restart
+  policy gives up on — the cause of a silent multi-day `whisper:gpu` outage.
+
+### Fixed
+
+- Wire deployer-facing settings into the Compose `environment:` so a `.env`
+  value actually reaches the container (Compose has no `env_file`):
+  `TRUSTED_PROXY_COUNT`, `MAX_REGISTER_ATTEMPTS_PER_IP`, and the
+  `REDIS_SOCKET_TIMEOUT` / `REDIS_SOCKET_CONNECT_TIMEOUT` /
+  `REDIS_HEALTH_CHECK_INTERVAL` timeouts — all added in 2.20.0 but never wired.
+
 ## [2.20.0] - 2026-07-08
 
 Pre-release hardening pass: resilience, security, and correctness fixes with
@@ -1010,7 +1035,8 @@ Error` JSON body while logging the full traceback, so an
   classification, missing-job handling) are now covered by unit tests
   in `test_pipeline_dispatcher.py` and `test_stage_tasks.py`.
 
-[Unreleased]: https://github.com/fdff87554/whisper-ui/compare/v2.18.0...HEAD
+[Unreleased]: https://github.com/fdff87554/whisper-ui/compare/v2.21.0...HEAD
+[2.21.0]: https://github.com/fdff87554/whisper-ui/releases/tag/v2.21.0
 [2.18.0]: https://github.com/fdff87554/whisper-ui/releases/tag/v2.18.0
 [2.17.0]: https://github.com/fdff87554/whisper-ui/releases/tag/v2.17.0
 [2.16.0]: https://github.com/fdff87554/whisper-ui/releases/tag/v2.16.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisper-ui"
-version = "2.20.0"
+version = "2.21.0"
 description = "Speech-to-text system using OpenAI Whisper with speaker diarization and Docker GPU support"
 license = "MIT"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3955,7 +3955,7 @@ wheels = [
 
 [[package]]
 name = "whisper-ui"
-version = "2.20.0"
+version = "2.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Release v2.21.0

Cuts the release for the changes merged in #156 — version bump + CHANGELOG only; the feature code is already on `main`.

### Included (from #156)

- **Added** `DIARIZATION_DEFAULT_ENABLED` (configurable upload-form diarization default).
- **Added** Prometheus alert rules (`WhisperGpuQueueStalled`, `WhisperNoRqWorkers`) and `docker/whisper-rocm-heal.sh` (worker-rocm boot-race auto-heal).
- **Fixed** deployer-facing settings (`TRUSTED_PROXY_COUNT`, `MAX_REGISTER_ATTEMPTS_PER_IP`, the three `REDIS_SOCKET_*` timeouts) now wired into the Compose environment — added in 2.20.0 but never reachable in a Compose deploy.

### Release steps

- `pyproject.toml` + `uv.lock` bumped to `2.21.0`; CHANGELOG `[2.21.0]` section added.
- On merge, tag `v2.21.0` → `docker-publish` builds pinned `2.21.0` images for all services (incl. `worker-rocm`, which only builds on `v*` tags).
